### PR TITLE
Fix text box 'blink' (#16)

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -3,6 +3,7 @@ extends Node
 
 signal dialogue_started
 signal dialogue_finished
+signal balloon_visible
 
 
 const DialogueResource = preload("res://addons/dialogue_manager/dialogue_resource.gd")
@@ -87,6 +88,7 @@ func get_next_dialogue_line(key: String, override_resource: DialogueResource = n
 			return get_next_dialogue_line(dialogue.next_id, local_resource)
 	else:
 		return dialogue
+	
 
 
 func replace_values(line_or_response) -> String:
@@ -106,9 +108,10 @@ func show_example_dialogue_balloon(title: String, resource: DialogueResource = n
 	if dialogue != null:
 		var balloon = preload("res://addons/dialogue_manager/example_balloon/example_balloon.tscn").instance()
 		balloon.dialogue = dialogue
-		get_tree().current_scene.add_child(balloon)
+		
+		get_tree().current_scene.call_deferred("add_child", balloon)
+		
 		show_example_dialogue_balloon(yield(balloon, "actioned"), resource)
-	
 
 ### Helpers
 

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -71,6 +71,7 @@ func _ready() -> void:
 	
 	# Show our box
 	balloon.visible = true
+	DialogueManager.emit_signal("balloon_visible")
 	
 	dialogue_label.type_out()
 	yield(dialogue_label, "finished")
@@ -91,5 +92,6 @@ func _ready() -> void:
 			yield(get_tree(), "idle_frame")
 	
 	# Send back input
-	emit_signal("actioned", next_id)
+	call_deferred("emit_signal", "actioned", next_id)
+	yield(DialogueManager, "balloon_visible")
 	queue_free()


### PR DESCRIPTION
Created a signal 'balloon_visible' in dialogue_manager.gd

example_balloon.gd now emits 'balloon_visible' and waits for this signal before freeing the previous balloon.