### PR TITLE
Add "Input" tab to settings screen

### DIFF
--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -15,6 +15,8 @@ func _ready() -> void:
 		config.set_value("editor", "missing_translations_are_errors", false)
 	if not config.has_section("runtime"):
 		config.set_value("runtime", "states", [])
+	if not config.has_section("input"):
+		config.set_value("input", "skip_typing", "ui_cancel")
 
 
 func reset_config() -> void:
@@ -46,3 +48,16 @@ func set_runtime_value(key: String, value) -> void:
 
 func get_runtime_value(key: String, default = null):
 	return config.get_value("runtime", key, default)
+
+
+func has_input_value(key: String) -> bool:
+	return config.has_section_key("input", key)
+
+
+func set_input_value(key: String, value) -> void:
+	config.set_value("input", key, value)
+	config.save(Constants.CONFIG_PATH)
+
+
+func get_input_value(key: String, default = null):
+	return config.get_value("input", key, default)

--- a/addons/dialogue_manager/views/settings_dialog.gd
+++ b/addons/dialogue_manager/views/settings_dialog.gd
@@ -14,19 +14,19 @@ onready var settings: Settings = get_node(_settings)
 onready var errors_button := $Margin/VBox/Tabs/Editor/VBox/CheckForErrorsButton
 onready var missing_translations_button := $Margin/VBox/Tabs/Editor/VBox/MissingTranslationsButton
 onready var globals_list := $Margin/VBox/Tabs/Runtime/VBox/GlobalsList
+onready 	var skip_typing_option_button := $Margin/VBox/Tabs/Input/GridContainer/SkipTypingOptionButton
 
 var dialogue_manager_config := ConfigFile.new()
 var all_globals: Dictionary = {}
 var enabled_globals: Array = []
 
 
-### Signals
-
-
-func _on_SettingsDialog_about_to_show():
+func _initialize_editor_tab():
 	errors_button.pressed = settings.get_editor_value("check_for_errors", true)
 	missing_translations_button.pressed = settings.get_editor_value("missing_translations_are_errors", false)
 
+
+func _initialize_globals_tab():
 	var project = ConfigFile.new()
 	var err = project.load("res://project.godot")
 	assert(err == OK, "Could not find the project file")
@@ -58,6 +58,24 @@ func _on_SettingsDialog_about_to_show():
 	globals_list.set_column_title(2, "Path")
 
 
+func _initialize_input_tab():
+	var actions: Array = InputMap.get_actions()
+	for index in actions.size():
+		var action: String = actions[index]
+		skip_typing_option_button.add_item(action)
+		skip_typing_option_button.set_item_metadata(index, action)
+		if action == settings.get_input_value("skip_typing", "ui_cancel"):
+			skip_typing_option_button.selected = index
+
+
+### Signals
+
+
+func _on_SettingsDialog_about_to_show():
+	_initialize_editor_tab()
+	_initialize_globals_tab()
+	_initialize_input_tab()
+
 
 func _on_GlobalsList_item_selected():
 	var item = globals_list.get_selected()
@@ -87,3 +105,8 @@ func _on_DoneButton_pressed():
 func _on_GlobalsList_button_pressed(item, column, id):
 	hide()
 	emit_signal("script_button_pressed", item.get_text(2))
+
+
+func _on_SkipTypingOptionButton_item_selected(index: int) -> void:
+	var action: String = skip_typing_option_button.get_item_metadata(index)
+	settings.set_input_value("skip_typing", action)

--- a/addons/dialogue_manager/views/settings_dialog.tscn
+++ b/addons/dialogue_manager/views/settings_dialog.tscn
@@ -29,8 +29,8 @@ __meta__ = {
 [node name="VBox" type="VBoxContainer" parent="Margin"]
 margin_left = 10.0
 margin_top = 10.0
-margin_right = 950.0
-margin_bottom = 530.0
+margin_right = 590.0
+margin_bottom = 490.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 10
@@ -39,8 +39,8 @@ __meta__ = {
 }
 
 [node name="Tabs" type="TabContainer" parent="Margin/VBox"]
-margin_right = 940.0
-margin_bottom = 490.0
+margin_right = 580.0
+margin_bottom = 450.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tab_align = 0
@@ -68,47 +68,47 @@ __meta__ = {
 [node name="VBox" type="VBoxContainer" parent="Margin/VBox/Tabs/Editor"]
 margin_left = 4.0
 margin_top = 4.0
-margin_right = 928.0
-margin_bottom = 450.0
+margin_right = 568.0
+margin_bottom = 410.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="ErrorsTitle" type="Label" parent="Margin/VBox/Tabs/Editor/VBox"]
-margin_right = 924.0
+margin_right = 564.0
 margin_bottom = 14.0
 text = "Errors"
 
 [node name="CheckForErrorsButton" type="CheckButton" parent="Margin/VBox/Tabs/Editor/VBox"]
 margin_top = 18.0
-margin_right = 924.0
+margin_right = 564.0
 margin_bottom = 58.0
 text = "Check for errors while you type"
 
 [node name="MissingTranslationsButton" type="CheckButton" parent="Margin/VBox/Tabs/Editor/VBox"]
 margin_top = 62.0
-margin_right = 924.0
+margin_right = 564.0
 margin_bottom = 102.0
 text = "Treat missing static translation keys as errors"
 
 [node name="Margin" type="MarginContainer" parent="Margin/VBox/Tabs/Editor/VBox"]
 modulate = Color( 1, 1, 1, 0.470588 )
 margin_top = 106.0
-margin_right = 924.0
-margin_bottom = 120.0
+margin_right = 564.0
+margin_bottom = 137.0
 custom_constants/margin_right = 80
 custom_constants/margin_left = 20
 
 [node name="TranslationHelp" type="Label" parent="Margin/VBox/Tabs/Editor/VBox/Margin"]
 margin_left = 20.0
-margin_right = 844.0
-margin_bottom = 14.0
+margin_right = 484.0
+margin_bottom = 31.0
 text = "If you are using static translation keys then having this enabled will help you find any lines that you haven't added a key to yet."
 autowrap = true
 
 [node name="Spacer" type="Control" parent="Margin/VBox/Tabs/Editor/VBox"]
-margin_top = 124.0
-margin_right = 924.0
-margin_bottom = 446.0
+margin_top = 141.0
+margin_right = 564.0
+margin_bottom = 406.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -133,22 +133,22 @@ __meta__ = {
 [node name="VBox" type="VBoxContainer" parent="Margin/VBox/Tabs/Runtime"]
 margin_left = 4.0
 margin_top = 4.0
-margin_right = 928.0
-margin_bottom = 450.0
+margin_right = 568.0
+margin_bottom = 410.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 10
 
 [node name="Message" type="Label" parent="Margin/VBox/Tabs/Runtime/VBox"]
-margin_right = 924.0
+margin_right = 564.0
 margin_bottom = 14.0
 text = "Choose which globals contain game state or methods that your dialogue needs."
 autowrap = true
 
 [node name="GlobalsList" type="Tree" parent="Margin/VBox/Tabs/Runtime/VBox"]
 margin_top = 24.0
-margin_right = 924.0
-margin_bottom = 446.0
+margin_right = 564.0
+margin_bottom = 406.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 3
@@ -156,17 +156,53 @@ hide_folding = true
 hide_root = true
 select_mode = 1
 
+[node name="Input" type="MarginContainer" parent="Margin/VBox/Tabs"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/margin_right = 4
+custom_constants/margin_top = 4
+custom_constants/margin_left = 4
+custom_constants/margin_bottom = 4
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="GridContainer" type="GridContainer" parent="Margin/VBox/Tabs/Input"]
+margin_left = 4.0
+margin_top = 4.0
+margin_right = 568.0
+margin_bottom = 410.0
+columns = 2
+
+[node name="SkipTypingLabel" type="Label" parent="Margin/VBox/Tabs/Input/GridContainer"]
+margin_top = 3.0
+margin_right = 71.0
+margin_bottom = 17.0
+text = "Skip Typing"
+
+[node name="SkipTypingOptionButton" type="OptionButton" parent="Margin/VBox/Tabs/Input/GridContainer"]
+margin_left = 75.0
+margin_right = 104.0
+margin_bottom = 20.0
+
 [node name="Actions" type="CenterContainer" parent="Margin/VBox"]
-margin_top = 500.0
-margin_right = 940.0
-margin_bottom = 520.0
+margin_top = 460.0
+margin_right = 580.0
+margin_bottom = 480.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="DoneButton" type="Button" parent="Margin/VBox/Actions"]
-margin_left = 447.0
-margin_right = 493.0
+margin_left = 267.0
+margin_right = 313.0
 margin_bottom = 20.0
 text = "Done"
 
@@ -175,4 +211,5 @@ text = "Done"
 [connection signal="toggled" from="Margin/VBox/Tabs/Editor/VBox/MissingTranslationsButton" to="." method="_on_MissingTranslationsButton_toggled"]
 [connection signal="button_pressed" from="Margin/VBox/Tabs/Runtime/VBox/GlobalsList" to="." method="_on_GlobalsList_button_pressed"]
 [connection signal="item_selected" from="Margin/VBox/Tabs/Runtime/VBox/GlobalsList" to="." method="_on_GlobalsList_item_selected"]
+[connection signal="item_selected" from="Margin/VBox/Tabs/Input/GridContainer/SkipTypingOptionButton" to="." method="_on_SkipTypingOptionButton_item_selected"]
 [connection signal="pressed" from="Margin/VBox/Actions/DoneButton" to="." method="_on_DoneButton_pressed"]


### PR DESCRIPTION
Hi Nathan! First of all, thanks so much for this awesome addon! Second of all, I hope you don't mind this unsolicited pull request. I was trying to figure out how to allow the player to skip the typing animation by pressing `ui_accept` instead of `ui_cancel`. I noticed the input action is hardcoded into `addons/dialogue_manager/dialogue_label.gd`:

https://github.com/nathanhoad/godot_dialogue_manager/blob/01cf5fd3e194d34bfe938e104c45c8a4c454f61a/addons/dialogue_manager/dialogue_label.gd#L28-L31

I started working on this PR that would allow a user of Dialogue Manager to choose which input action should be used to skip the typing animation. Here's a screenshot of the new tab I added:

![Screen Shot 2022-02-18 at 2 50 11 PM](https://user-images.githubusercontent.com/99618049/154753237-76c04b5c-ba12-44b3-acf5-c0c1e632d298.png)

It's just a quick mockup because I didn't want to spend too much time on this if you had a better way of accomplishing this. Feel free to push commits to this branch if you think this code is a good start, otherwise I'd love to help work on any other solution you can suggest.

Thanks again!