### PR TITLE
Prevent `Division By Zero in operator '/'.` error when responses don't come immediately after a dialogue line

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -75,5 +75,9 @@ func type_out() -> void:
 	waiting_seconds = 0
 	# Text isn't calculated until the next frame
 	yield(get_tree(), "idle_frame")
+	if not get_total_character_count():
+		emit_signal("finished")
+		queue_free()
+		return
 	percent_per_index = 100.0 / float(get_total_character_count()) / 100.0
 	is_typing = true


### PR DESCRIPTION
### The problem
If you have dialogue that has responses immediately after a mutation:

```
~ test
Welcome!
set has_been_welcomed = true
- hi
- bye
```

Or if the dialogue _begins_ with responses:
```
~ test
- hi
- bye
```

You'll get a `Division By Zero in operator '/'.` error:

![image](https://user-images.githubusercontent.com/99618049/154850696-4d5505ec-33dd-4415-8b3a-133dbb7f25ce.png)

This PR fixes that by returning from `type_out()` early if `get_total_character_count()` is `0`.

![image](https://user-images.githubusercontent.com/99618049/154851254-bf97a0b8-92a5-4004-8efd-093085ad56ea.png)

