### PR TITLE
Fix parsing multiple types of codes

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -623,6 +623,7 @@ func extract_markers(line: String) -> Dictionary:
 	
 	var found = MARKER_CODE_REGEX.search(text)
 	var limit = 0
+	var prev_codes_len = 0
 	while found and limit < 1000:
 		limit += 1
 		var index = text.find(found.strings[0])
@@ -655,9 +656,18 @@ func extract_markers(line: String) -> Dictionary:
 		
 		var length = found.strings[0].length()
 		
+		var start = found.get_start()
+		# Account for lengths of codes before this one
+		start += prev_codes_len
+		prev_codes_len += length
+		# Account for lengths of BB codes that are before this
+		for bb_code in bb_codes:
+			if bb_code[0] < start:
+				start += bb_code[1].length()
+				
 		# Find any BB codes that are after this index and remove the length from their start
 		for bb_code in bb_codes:
-			if bb_code[0] > length:
+			if bb_code[0] > start:
 				bb_code[0] -= length
 		
 		text.erase(index, length)


### PR DESCRIPTION
This fixes an issue where the `extract_markers` function in `parser.gd` sometimes places BBCode tags in the wrong location due to not correctly interpreting the locations of the other codes (wait, speed, etc.).

Here is what the following line looks like in the test scene before and after this change.
`Test: Waiting for [b]boldness[/b]...[wait=3] Waiting for [i]italics[/i]...[wait=4] Done [color=blue]blue[/color] waiting! `

Before fix:
![Before](https://user-images.githubusercontent.com/15860303/158084196-c49bfb54-d319-4aa7-b7bf-d7a747cbefc5.PNG)
After fix:
![After](https://user-images.githubusercontent.com/15860303/158084201-a7a85e6e-84ca-4bd9-bb27-1c06740576f2.PNG)

