### PR TITLE
Add asset-lib gitattribute recommendations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Small issue I noticed while downloading the project from the asset lib.

This changes will make the godot downloader only add the `/addons` folder by default (users can still add docs and other folders from the dialogue)

Recommended in the [godot docs](https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html)
![image](https://user-images.githubusercontent.com/14203988/183288610-f5e5f6a3-d1bf-488f-8fd2-7076d8b615ff.png)
