### PR TITLE
Improvement on docs / fixing parser.queue_free()

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -99,7 +99,7 @@ func create_resource_from_text(text: String) -> Resource:
 	parser.parse(text)
 	var results: Dictionary = parser.get_data()
 	var errors: Array[Dictionary] = parser.get_errors()
-	parser.queue_free()
+	parser.free()
 	
 	if errors.size() > 0:
 		printerr("You have errors in your dialogue text.")

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -24,7 +24,7 @@ Nathan: Here are some options.
 And then in your game:
 
 ```gdscript
-var resource = load("res://some_dialogue.dialogue)
+var resource = load("res://some_dialogue.dialogue")
 var dialogue_line = await DialogueManager.get_next_dialogue_line(resource, "start")
 ```
 
@@ -54,10 +54,10 @@ The label will emit a `paused_typing` signal (along with the duration of the pau
 
 ## Generating Dialogue Resources at runtime
 
-If you need to construct a dialogue resource at runtime you can use `get_resource_from_text(string)`:
+If you need to construct a dialogue resource at runtime you can use `create_resource_from_text(string)`:
 
 ```gdscript
-var resource = DialogueManager.get_resource_from_text("~ title\nCharacter: Hello!)
+var resource = DialogueManager.create_resource_from_text("~ title\nCharacter: Hello!")
 ```
 
 This will run the given text through the parser.


### PR DESCRIPTION
- fixed the lack of a closing quotation mark in some example codes in Using_Dialogue.md
- changed `get_resource_from_text` to `create_resource_from_text` in the docs page since `get_resource_from_text` no longer exists in the latest version
- changed `parser.queue_free()` to `parser.free()` in dialogue_manager.gd since `queue_free()` does not exist in `parser` as it is not a node, although I am unsure if simply changing it to `free()` is the best solution.