### PR TITLE
Made title panel resizeable

### DIFF
--- a/addons/dialogue_manager/views/main_view.tscn
+++ b/addons/dialogue_manager/views/main_view.tscn
@@ -58,7 +58,7 @@ theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 metadata/_edit_layout_mode = 1
 
-[node name="Content" type="HBoxContainer" parent="Margin"]
+[node name="Content" type="HSplitContainer" parent="Margin"]
 layout_mode = 2
 offset_left = 5.0
 offset_right = 1147.0
@@ -66,9 +66,9 @@ offset_bottom = 643.0
 size_flags_vertical = 3
 
 [node name="TitlesPanel" type="VBoxContainer" parent="Margin/Content"]
-custom_minimum_size = Vector2i(300, 0)
+custom_minimum_size = Vector2i(150, 0)
 layout_mode = 2
-offset_right = 300.0
+offset_right = 222.0
 offset_bottom = 643.0
 size_flags_horizontal = 3
 


### PR DESCRIPTION
Literally just changed the solid HBoxContainer to HSplitContainer so i can resize my title list. I didn't like how i couldn't so here we are. You can do what you want with this i just thought i'd share

![image](https://user-images.githubusercontent.com/28844450/193982744-87736b35-f57a-4799-8c0a-c4529f0fa564.png)

Thanks for the great addon :)