### PR TITLE
Fixed duplicate-use enum designation

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -61,7 +61,7 @@ func _process(delta: float) -> void:
 func reset_height() -> void:
 	# For some reason, RichTextLabels within containers don't resize properly when their content 
 	# changes so we make a clone that isn't bound by a VBox
-	var size_check_label = duplicate(DUPLICATE_USE_INSTANCING)
+	var size_check_label = duplicate(DUPLICATE_USE_INSTANTIATION)
 	size_check_label.modulate.a = 0
 	get_tree().current_scene.add_child(size_check_label)
 	size_check_label.size = Vector2(size.x, 0)


### PR DESCRIPTION
Godot 4 Beta 6 renamed `DUPLICATE_USE_INSTANCING `to `DUPLICATE_USE_INSTANTIATION `in the `DuplicateFlags` enum in `Node`. This therefore had to be changed in dialogue_label.gd as well.