### PR TITLE
Fix settings bug with include_all_responses

### DIFF
--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -12,6 +12,7 @@ const DEFAULT_SETTINGS = {
 	"missing_translations_are_errors" = false,
 	"wrap_lines" = false,
 	"new_with_template" = true,
+	"include_all_responses" = false,
 	"custom_test_scene_path" = "res://addons/dialogue_manager/test_scene.tscn"
 }
 
@@ -23,6 +24,7 @@ static func prepare() -> void:
 		"missing_translations_are_errors", 
 		"wrap_lines", 
 		"new_with_template", 
+		"include_all_responses", 
 		"custom_test_scene_path"
 	]:
 		if ProjectSettings.has_setting("dialogue_manager/%s" % key):


### PR DESCRIPTION
The parameter `include_all_responses` isn't in the settings dictionary, causing an error when it's toggled.

Tested using 4.0.2 stable.

<img width="860" alt="Screenshot 2023-04-18 at 5 58 10 PM" src="https://user-images.githubusercontent.com/21185262/232938951-c2e6077e-8728-46af-ba8d-eed54f74ee80.png">
