### PR TITLE
Fixes issue with calling erase on arrays

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -968,6 +968,7 @@ func resolve_array_method(array: Array, method_name: String, args: Array):
 			return null
 		"erase":
 			array.erase(args[0])
+			return null
 		"has":
 			return array.has(args[0])
 		"insert":


### PR DESCRIPTION
Calling `erase` on an array wasn't returning before hitting the catchall fail assertion. This change adds a null return after erasing.