### PR TITLE
Mark skip action as handling input

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -53,6 +53,8 @@ func _process(delta: float) -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	if self.is_typing and visible_ratio < 1 and event.is_action_pressed(skip_action):
+		get_viewport().set_input_as_handled()
+
 		# Run any inline mutations that haven't been run yet
 		for i in range(visible_characters, get_total_character_count()):
 			mutate_inline_mutations(i)


### PR DESCRIPTION
This marks the `skip_action` input as being handled. That should remove any double input handling if the `skip_action` value is set to the same as the one for advancing to the next line (eg. `ui_accept`).