### PR TITLE
Add a singleton helper for C#

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -6,6 +6,33 @@ namespace DialogueManagerRuntime
 {
   public partial class DialogueManager : Node
   {
+    private static GodotObject singleton;
+
+    public static async Task<GodotObject> GetSingleton()
+    {
+      if (singleton != null) return singleton;
+
+      var tree = Engine.GetMainLoop();
+      int x = 0;
+
+      // Try and find the singleton for a few seconds
+      while (!Engine.HasSingleton("DialogueManager") && x < 300)
+      {
+        await tree.ToSignal(tree, "process_frame");
+        x++;
+      }
+
+      // If it times out something is wrong
+      if (x >= 300)
+      {
+        throw new System.Exception("The DialogueManager singleton is missing.");
+      }
+
+      singleton = Engine.GetSingleton("DialogueManager");
+      return singleton;
+    }
+
+
     public static async Task<DialogueLine> GetNextDialogueLine(Resource dialogueResource, string key = "0", Array<Variant> extraGameStates = null)
     {
       var dialogueManager = Engine.GetSingleton("DialogueManager");

--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -20,18 +20,18 @@ const DEFAULT_SETTINGS = {
 static func prepare() -> void:
 	# Migrate previous keys
 	for key in [
-		"states", 
-		"missing_translations_are_errors", 
-		"wrap_lines", 
-		"new_with_template", 
-		"include_all_responses", 
+		"states",
+		"missing_translations_are_errors",
+		"wrap_lines",
+		"new_with_template",
+		"include_all_responses",
 		"custom_test_scene_path"
 	]:
 		if ProjectSettings.has_setting("dialogue_manager/%s" % key):
 			var value = ProjectSettings.get_setting("dialogue_manager/%s" % key)
 			ProjectSettings.set_setting("dialogue_manager/%s" % key, null)
 			set_setting(key, value)
-	
+
 	# Set up defaults
 	for setting in DEFAULT_SETTINGS:
 		if ProjectSettings.has_setting("dialogue_manager/general/%s" % setting):
@@ -64,11 +64,11 @@ static func get_user_config() -> Dictionary:
 		run_resource_path = "",
 		is_running_test_scene = false
 	}
-	
+
 	if FileAccess.file_exists(DialogueConstants.USER_CONFIG_PATH):
 		var file: FileAccess = FileAccess.open(DialogueConstants.USER_CONFIG_PATH, FileAccess.READ)
 		user_config.merge(JSON.parse_string(file.get_as_text()), true)
-	
+
 	return user_config
 
 
@@ -121,8 +121,8 @@ static func clear_recent_files() -> void:
 
 static func set_caret(path: String, cursor: Vector2) -> void:
 	var carets: Dictionary = get_user_value("carets", {})
-	carets[path] = { 
-		x = cursor.x, 
+	carets[path] = {
+		x = cursor.x,
 		y = cursor.y
 	}
 	set_user_value("carets", carets)

--- a/examples/test_scenes/TestScene.cs
+++ b/examples/test_scenes/TestScene.cs
@@ -1,4 +1,5 @@
 using Godot;
+using DialogueManagerRuntime;
 
 public partial class TestScene : Node2D
 {
@@ -17,7 +18,9 @@ public partial class TestScene : Node2D
 
   public async override void _Ready()
   {
-    Engine.GetSingleton("DialogueManager").Connect("dialogue_ended", new Callable(this, "OnDialogueEnded"));
+    var dialogueManager = await DialogueManager.GetSingleton();
+
+    dialogueManager.Connect("dialogue_ended", new Callable(this, "OnDialogueEnded"));
 
     await ToSignal(GetTree().CreateTimer(0.4), "timeout");
 


### PR DESCRIPTION
This adds an async `GetSingleton()` method to the C# wrapper in cases where `Engine.GetSingleton("DialogueManager")` seems to be occasionally null. It works by continually trying to find the singleton until it either loads or fails completely.

Related to #210 