### PR TITLE
Fix Node inheritance warning

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -43,7 +43,7 @@ var translation_source: TranslationSource = TranslationSource.Guess
 var _node_properties: Array = []
 
 
-func _init() -> void:
+func _ready() -> void:
 	# Make the dialogue manager available as a singleton
 	Engine.register_singleton("DialogueManager", self)
 
@@ -54,8 +54,6 @@ func _init() -> void:
 		_node_properties.append(property.name)
 	temp_node.free()
 
-
-func _ready() -> void:
 	# Add any autoloads to a generic state so we can refer to them by name
 	var autoloads: Dictionary = {}
 	for child in get_tree().root.get_children():

--- a/examples/test_scenes/test_scene.gd
+++ b/examples/test_scenes/test_scene.gd
@@ -9,14 +9,14 @@ extends Node2D
 
 func _ready():
 	DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
-	
+
 	await get_tree().create_timer(0.4).timeout
 	show_dialogue(title)
 
 
 func show_dialogue(key: String) -> void:
 	assert(dialogue_resource != null, "\"dialogue_resource\" property needs a to point to a DialogueResource.")
-	
+
 	var is_small_window: bool = ProjectSettings.get_setting("display/window/size/viewport_width") < 400
 	var balloon: Node = (SmallBalloon if is_small_window else Balloon).instantiate()
 	add_child(balloon)


### PR DESCRIPTION
This moves the Singleton registration back into `_ready()` to get rid of the `Script does not inherit from Node` warning.