### PR TITLE
Fix a bug in script in Using_Dialogue.md

### DIFF
--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -78,5 +78,5 @@ If there were syntax errors the method will fail.
 If there were no errors then you can use this ephemeral resource like normal:
 
 ```gdscript
-var dialogue_line = await DialogueManager.get_next_dialogue_line("title", resource)
+var dialogue_line = await DialogueManager.get_next_dialogue_line(resource, "title")
 ```


### PR DESCRIPTION
The title must be the 2nd argument of the DialogueManager.get_next_dialogue_line function. I fixed the bug in the end of the [Using_Dialogue.md](docs/Using_Dialogue.md).