### PR TITLE
Ignore multiple pause characters together

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -151,4 +151,8 @@ func _should_auto_pause() -> bool:
 		if str(float(possible_number)) == possible_number:
 			return false
 
+	# Ignore two non-"." characters next to each other
+	if visible_characters > 1 and parsed_text[visible_characters - 1] in pause_at_characters.replace(".", "").split():
+		return false
+
 	return parsed_text[visible_characters - 1] in pause_at_characters.split()

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -45,7 +45,7 @@
      id="layer1">
     <g
        id="g4265"
-       transform="matrix(0.12123513,0,0,0.12123513,4.67048,0.94397532)"
+       transform="matrix(0.13118578,0,0,0.13118578,0.50179297,-1.0547604)"
        style="clip-rule:evenodd;fill-rule:evenodd;stroke-width:0.9717;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:40">
       <path
          id="path5"


### PR DESCRIPTION
This will stop double-ups on pauses when multiple pause characters are next to each other (with the exception of ".").