### PR TITLE
Make deliberately missing key throw an error

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -73,7 +73,7 @@ func _ready() -> void:
 
 
 ## Step through lines and run any mutations until we either hit some dialogue or the end of the conversation
-func get_next_dialogue_line(resource: DialogueResource, key: String = "0", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine:
+func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine:
 	# You have to provide a valid dialogue resource
 	assert(resource != null, DialogueConstants.translate("runtime.no_resource"))
 	assert(resource.lines.size() > 0, DialogueConstants.translate("runtime.no_content").format({ file_path = resource.resource_path }))
@@ -247,9 +247,11 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 	if key in resource.titles.values():
 		passed_title.emit(resource.titles.find_key(key))
 
-	# Key not found, just use the first title
-	if not resource.lines.has(key):
+	# Key is blank so just use the first title
+	if key == null or key == "":
 		key = resource.first_title
+
+	assert(resource.lines.has(key), DialogueConstants.translate("errors.key_not_found").format({ key = key }))
 
 	var data: Dictionary = resource.lines.get(key)
 

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -201,6 +201,9 @@ msgstr "Filter files"
 msgid "titles_list.filter"
 msgstr "Filter titles"
 
+msgid "errors.key_not_found"
+msgstr "Key \"{key}\" not found."
+
 msgid "errors.line_and_message"
 msgstr "Error at {line}, {column}: {message}"
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -191,6 +191,9 @@ msgstr ""
 msgid "titles_list.filter"
 msgstr ""
 
+msgid "errors.key_not_found"
+msgstr ""
+
 msgid "errors.line_and_message"
 msgstr ""
 


### PR DESCRIPTION
This makes the runtime throw an error when a deliberate title is given that doesn't exist.

Fixes #235 