### PR TITLE
Fix enum referencing in dictionaries

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1236,6 +1236,7 @@ func build_token_tree(tokens: Array[Dictionary], line_type: String, expected_clo
 					type = DialogueConstants.TOKEN_DICTIONARY,
 					value = tokens_to_dictionary(sub_tree[0])
 				})
+
 				tokens = sub_tree[1]
 
 			DialogueConstants.TOKEN_BRACKET_OPEN:
@@ -1508,7 +1509,10 @@ func tokens_to_dictionary(tokens: Array[Dictionary]) -> Dictionary:
 	var dictionary = {}
 	for i in range(0, tokens.size()):
 		if tokens[i].type == DialogueConstants.TOKEN_COLON:
-			dictionary[tokens[i-1]] = tokens[i+1]
+			if tokens.size() == i + 2:
+				dictionary[tokens[i-1]] = tokens[i+1]
+			else:
+				dictionary[tokens[i-1]] = { type = DialogueConstants.TOKEN_GROUP, value = tokens.slice(i+1) }
 
 	return dictionary
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -707,7 +707,10 @@ func resolve(tokens: Array, extra_game_states: Array):
 			var dictionary = {}
 			for key in token.value.keys():
 				var resolved_key = await resolve([key], extra_game_states)
-				var resolved_value = await resolve([token.value.get(key)], extra_game_states)
+				var preresolved_value = token.value.get(key)
+				if typeof(preresolved_value) != TYPE_ARRAY:
+					preresolved_value = [preresolved_value]
+				var resolved_value = await resolve(preresolved_value, extra_game_states)
 				dictionary[resolved_key] = resolved_value
 			token["value"] = dictionary
 


### PR DESCRIPTION
This fixes using deep references when using dictionary literals (eg `do some_function({ "some_key": SomeAutoload.SomeEnum.SomeValue })`.

Fixes #252 