### PR TITLE
Rework dialogue cache

### DIFF
--- a/addons/dialogue_manager/components/dialogue_cache.gd
+++ b/addons/dialogue_manager/components/dialogue_cache.gd
@@ -1,0 +1,115 @@
+extends Node
+
+
+const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+
+
+# Keeps track of errors and dependencies.
+# {
+# 	<dialogue file path> = {
+# 		path = <dialogue file path>,
+# 		dependencies = [<dialogue file path>, <dialogue file path>],
+# 		errors = [<error>, <error>]
+# 	}
+# }
+var _cache: Dictionary = {}
+
+
+func _init() -> void:
+	_build_cache()
+
+
+## Add a dialogue file to the cache.
+func add_file(path: String, parse_results: DialogueManagerParseResult = null) -> void:
+	var dependencies: PackedStringArray = []
+
+	if parse_results != null:
+		dependencies = Array(parse_results.imported_paths).filter(func(d): return d != path)
+
+	_cache[path] = {
+		path = path,
+		dependencies = dependencies,
+		errors = []
+	}
+
+	# If this is a fresh cache entry then we need to check for dependencies
+	if parse_results == null:
+		WorkerThreadPool.add_task(_update_dependencies.bind(path))
+
+
+## Get the file paths in the cache.
+func get_files() -> PackedStringArray:
+	return _cache.keys()
+
+
+## Remember any errors in a dialogue file.
+func add_errors_to_file(path: String, errors: Array[Dictionary]) -> void:
+	if _cache.has(path):
+		_cache[path].errors = errors
+	else:
+		_cache[path] = {
+			path = path,
+			resource_path = "",
+			dependencies = [],
+			errors = errors
+		}
+
+
+## Get a list of files that have errors in them.
+func get_files_with_errors() -> Array[Dictionary]:
+	var files_with_errors: Array[Dictionary] = []
+	for dialogue_file in _cache.values():
+		if dialogue_file and dialogue_file.errors.size() > 0:
+			files_with_errors.append(dialogue_file)
+	return files_with_errors
+
+
+## Update any references to a file path that has moved
+func move_file_path(from_path: String, to_path: String) -> void:
+	if _cache.has(from_path):
+		_cache[to_path] = _cache[from_path].duplicate()
+		_cache.erase(from_path)
+
+
+## Get any dialogue files that import a given path.
+func get_files_with_dependency(imported_path: String) -> Array:
+	return _cache.values().filter(func(d): return imported_path in d.dependencies)
+
+
+# Build the initial cache for dialogue files.
+func _build_cache() -> void:
+	var current_files: PackedStringArray = _get_dialogue_files_in_filesystem()
+	for file in current_files:
+		add_file(file)
+
+
+# Recursively find any dialogue files in a directory
+func _get_dialogue_files_in_filesystem(path: String = "res://") -> PackedStringArray:
+	var files: PackedStringArray = []
+
+	if DirAccess.dir_exists_absolute(path):
+		var dir = DirAccess.open(path)
+		dir.list_dir_begin()
+		var file_name = dir.get_next()
+		while file_name != "":
+			var file_path: String = (path + "/" + file_name).simplify_path()
+			if dir.current_is_dir():
+				if not file_name in [".godot", ".tmp"]:
+					files.append_array(_get_dialogue_files_in_filesystem(file_path))
+			elif file_name.get_extension() == "dialogue":
+				files.append(file_path)
+			file_name = dir.get_next()
+
+	return files
+
+
+# Check for dependencies of a path
+func _update_dependencies(path: String) -> void:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	var import_regex: RegEx = RegEx.create_from_string("import \"(?<path>.*?)\"")
+	var found_imports = import_regex.search_all(file.get_as_text())
+	var dependencies: PackedStringArray = []
+	for found in found_imports:
+		dependencies.append(found.strings[found.names.path])
+	_cache[path].dependencies = dependencies

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -63,26 +63,22 @@ func _get_option_visibility(path: String, option_name: StringName, options: Dict
 
 
 func _import(source_file: String, save_path: String, options: Dictionary, platform_variants: Array[String], gen_files: Array[String]) -> Error:
-	return compile_file(source_file, "%s.%s" % [save_path, _get_save_extension()])
-
-
-func compile_file(path: String, resource_path: String, will_cascade_cache_data: bool = true) -> Error:
 	# Get the raw file contents
-	if not FileAccess.file_exists(path): return ERR_FILE_NOT_FOUND
+	if not FileAccess.file_exists(source_file): return ERR_FILE_NOT_FOUND
 
-	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	var file: FileAccess = FileAccess.open(source_file, FileAccess.READ)
 	var raw_text: String = file.get_as_text()
 
 	# Parse the text
 	var parser: DialogueManagerParser = DialogueManagerParser.new()
-	var err: Error = parser.parse(raw_text, path)
+	var err: Error = parser.parse(raw_text, source_file)
 	var data: DialogueManagerParseResult = parser.get_data()
 	var errors: Array[Dictionary] = parser.get_errors()
 	parser.free()
 
 	if err != OK:
-		printerr("%d errors found in %s" % [errors.size(), path])
-		editor_plugin.add_errors_to_dialogue_file_cache(path, errors)
+		printerr("%d errors found in %s" % [errors.size(), source_file])
+		editor_plugin.add_errors_to_cache(source_file, errors)
 		return err
 
 	# Get the current addon version
@@ -99,10 +95,10 @@ func compile_file(path: String, resource_path: String, will_cascade_cache_data: 
 	resource.character_names = data.character_names
 	resource.lines = data.lines
 
-	if will_cascade_cache_data:
-		editor_plugin.add_to_dialogue_file_cache(path, resource_path, data)
+	# Clear errors and possibly trigger any cascade recompiles
+	editor_plugin.add_file_to_cache(source_file, data)
 
-	err = ResourceSaver.save(resource, resource_path)
+	err = ResourceSaver.save(resource, "%s.%s" % [save_path, _get_save_extension()])
 
 	compiled_resource.emit(resource)
 

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -6,14 +6,17 @@ const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
 const DialogueImportPlugin = preload("res://addons/dialogue_manager/import_plugin.gd")
 const DialogueTranslationParserPlugin = preload("res://addons/dialogue_manager/editor_translation_parser_plugin.gd")
 const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueCache = preload("res://addons/dialogue_manager/components/dialogue_cache.gd")
 const MainView = preload("res://addons/dialogue_manager/views/main_view.tscn")
 
 
 var import_plugin: DialogueImportPlugin
 var translation_parser_plugin: DialogueTranslationParserPlugin
 var main_view
+var dialogue_cache: DialogueCache
 
-var dialogue_file_cache: Dictionary = {}
+var _recompile_timer: Timer = Timer.new()
+var _recompile_paths: PackedStringArray
 
 
 func _enter_tree() -> void:
@@ -35,8 +38,12 @@ func _enter_tree() -> void:
 		get_editor_interface().get_editor_main_screen().add_child(main_view)
 		_make_visible(false)
 
-		update_dialogue_file_cache()
-		get_editor_interface().get_resource_filesystem().filesystem_changed.connect(_on_filesystem_changed)
+		main_view.add_child(_recompile_timer)
+		_recompile_timer.timeout.connect(_on_recompile_timer_timeout)
+
+		dialogue_cache = DialogueCache.new()
+		_update_localization()
+
 		get_editor_interface().get_file_system_dock().files_moved.connect(_on_files_moved)
 		get_editor_interface().get_file_system_dock().file_removed.connect(_on_file_removed)
 
@@ -56,8 +63,8 @@ func _exit_tree() -> void:
 	if is_instance_valid(main_view):
 		main_view.queue_free()
 
-	get_editor_interface().get_resource_filesystem().filesystem_changed.disconnect(_on_filesystem_changed)
 	get_editor_interface().get_file_system_dock().files_moved.disconnect(_on_files_moved)
+	get_editor_interface().get_file_system_dock().file_removed.disconnect(_on_file_removed)
 
 	remove_tool_menu_item("Create copy of dialogue example balloon...")
 
@@ -91,59 +98,39 @@ func _edit(object) -> void:
 func _apply_changes() -> void:
 	if is_instance_valid(main_view):
 		main_view.apply_changes()
+		_update_localization()
 
 
 func _build() -> bool:
 	# Ignore errors in other files if we are just running the test scene
 	if DialogueSettings.get_user_value("is_running_test_scene", true): return true
 
-	var can_build: bool = true
-	var is_first_file: bool = true
-	for dialogue_file in dialogue_file_cache.values():
-		if dialogue_file and dialogue_file.errors.size() > 0:
-			# Open the first file
-			if is_first_file:
-				get_editor_interface().edit_resource(load(dialogue_file.path))
-				main_view.show_build_error_dialog()
-				is_first_file = false
+	var files_with_errors = dialogue_cache.get_files_with_errors()
+	if files_with_errors.size() > 0:
+		for dialogue_file in files_with_errors:
 			push_error("You have %d error(s) in %s" % [dialogue_file.errors.size(), dialogue_file.path])
-			can_build = false
-	return can_build
+		get_editor_interface().edit_resource(load(files_with_errors[0].path))
+		main_view.show_build_error_dialog()
+		return false
+
+	return true
 
 
 ## Keep track of known files and their dependencies
-func add_to_dialogue_file_cache(path: String, resource_path: String, parse_results: DialogueManagerParseResult) -> void:
-	dialogue_file_cache[path] = {
-		path = path,
-		resource_path = resource_path,
-		dependencies = Array(parse_results.imported_paths).filter(func(d): return d != path),
-		errors = []
-	}
-
-	save_dialogue_cache()
-	recompile_dependent_files(path)
+func add_file_to_cache(path: String, parse_results: DialogueManagerParseResult) -> void:
+	dialogue_cache.add_file(path, parse_results)
+	queue_recompile_of_dependencies(path)
 
 
 ## Keep track of compile errors
-func add_errors_to_dialogue_file_cache(path: String, errors: Array[Dictionary]) -> void:
-	if dialogue_file_cache.has(path):
-		dialogue_file_cache[path]["errors"] = errors
-	else:
-		dialogue_file_cache[path] = {
-			path = path,
-			errors = errors
-		}
-
-	save_dialogue_cache()
-	recompile_dependent_files(path)
+func add_errors_to_cache(path: String, errors: Array[Dictionary]) -> void:
+	dialogue_cache.add_errors_to_file(path, errors)
+	queue_recompile_of_dependencies(path)
 
 
 ## Update references to a moved file
 func update_import_paths(from_path: String, to_path: String) -> void:
-	# Update its own reference in the cache
-	if dialogue_file_cache.has(from_path):
-		dialogue_file_cache[to_path] = dialogue_file_cache[from_path].duplicate()
-		dialogue_file_cache.erase(from_path)
+	dialogue_cache.move_file_path(from_path, to_path)
 
 	# Reopen the file if it's already open
 	if main_view.current_file_path == from_path:
@@ -151,7 +138,7 @@ func update_import_paths(from_path: String, to_path: String) -> void:
 		main_view.open_file(to_path)
 
 	# Update any other files that import the moved file
-	var dependents = dialogue_file_cache.values().filter(func(d): return from_path in d.dependencies)
+	var dependents = dialogue_cache.get_files_with_dependency(from_path)
 	for dependent in dependents:
 		dependent.dependencies.erase(from_path)
 		dependent.dependencies.append(to_path)
@@ -168,81 +155,36 @@ func update_import_paths(from_path: String, to_path: String) -> void:
 		file = FileAccess.open(dependent.path, FileAccess.WRITE)
 		file.store_string(text)
 
-	save_dialogue_cache()
+
+func queue_recompile_of_dependencies(of_path: String) -> void:
+	_recompile_timer.stop()
+	if not _recompile_paths.has(of_path):
+		_recompile_paths.append(of_path)
+	_recompile_timer.start(0.5)
 
 
-## Rebuild any files that depend on this path
-func recompile_dependent_files(path: String) -> void:
-	# Rebuild any files that depend on this one
-	var dependents = dialogue_file_cache.values().filter(func(d): return path in d.dependencies)
-	for dependent in dependents:
-		if dependent.has("path") and dependent.has("resource_path"):
-			import_plugin.compile_file(dependent.path, dependent.resource_path, false)
+func _update_localization() -> void:
+	var dialogue_files = dialogue_cache.get_files()
 
-
-## Make sure the cache points to real files
-func update_dialogue_file_cache() -> void:
-	var cache: Dictionary = {}
-
-	# Open our cache file if it exists
-	if FileAccess.file_exists(DialogueConstants.CACHE_PATH):
-		var file: FileAccess = FileAccess.open(DialogueConstants.CACHE_PATH, FileAccess.READ)
-		cache = JSON.parse_string(file.get_as_text())
-
-	# Scan for dialogue files
-	var current_files: PackedStringArray = _get_dialogue_files_in_filesystem()
-
-	# Add any files to POT generation
+	# Add any new files to POT generation
 	var files_for_pot: PackedStringArray = ProjectSettings.get_setting("internationalization/locale/translations_pot_files", [])
 	var files_for_pot_changed: bool = false
-	for path in current_files:
+	for path in dialogue_files:
 		if not files_for_pot.has(path):
 			files_for_pot.append(path)
 			files_for_pot_changed = true
 
-	# Remove any files that don't exist any more
-	for path in cache.keys():
-		if path == null or not path in current_files:
-			cache.erase(path)
-			DialogueSettings.remove_recent_file(path)
-
-			# Remove missing files from POT generation
-			if files_for_pot.has(path):
-				files_for_pot.remove_at(files_for_pot.find(path))
-				files_for_pot_changed = true
+	# Remove any POT references that don't exist any more
+	for i in range(files_for_pot.size() - 1, -1, -1):
+		var file_for_pot: String = files_for_pot[i]
+		if file_for_pot.get_extension() == "dialogue" and not dialogue_files.has(file_for_pot):
+			files_for_pot.remove_at(i)
+			files_for_pot_changed = true
 
 	# Update project settings if POT changed
 	if files_for_pot_changed:
 		ProjectSettings.set_setting("internationalization/locale/translations_pot_files", files_for_pot)
 		ProjectSettings.save()
-
-	dialogue_file_cache = cache
-
-
-## Persist the cache
-func save_dialogue_cache() -> void:
-	var file: FileAccess = FileAccess.open(DialogueConstants.CACHE_PATH, FileAccess.WRITE)
-	file.store_string(JSON.stringify(dialogue_file_cache))
-
-
-## Recursively find any dialogue files in a directory
-func _get_dialogue_files_in_filesystem(path: String = "res://") -> PackedStringArray:
-	var files: PackedStringArray = []
-
-	if DirAccess.dir_exists_absolute(path):
-		var dir = DirAccess.open(path)
-		dir.list_dir_begin()
-		var file_name = dir.get_next()
-		while file_name != "":
-			var file_path: String = (path + "/" + file_name).simplify_path()
-			if dir.current_is_dir():
-				if not file_name in [".godot", ".tmp"]:
-					files.append_array(_get_dialogue_files_in_filesystem(file_path))
-			elif file_name.get_extension() == "dialogue":
-				files.append(file_path)
-			file_name = dir.get_next()
-
-	return files
 
 
 ### Callbacks
@@ -287,8 +229,19 @@ func _copy_dialogue_balloon() -> void:
 ### Signals
 
 
-func _on_filesystem_changed() -> void:
-	update_dialogue_file_cache()
+func _on_recompile_timer_timeout() -> void:
+	_recompile_timer.stop()
+	if _recompile_paths.size() > 0:
+		var files_to_reimport: PackedStringArray = []
+		for path in _recompile_paths:
+			var dependencies = dialogue_cache.get_files_with_dependency(path).map(func(file): return file.path)
+			for dependency in dependencies:
+				if not files_to_reimport.has(dependency):
+					files_to_reimport.append(dependency)
+
+		if files_to_reimport.size() > 0:
+			get_editor_interface().get_resource_filesystem().reimport_files(files_to_reimport)
+			_recompile_paths = []
 
 
 func _on_files_moved(old_file: String, new_file: String) -> void:
@@ -297,6 +250,6 @@ func _on_files_moved(old_file: String, new_file: String) -> void:
 
 
 func _on_file_removed(file: String) -> void:
-	recompile_dependent_files(file)
+	queue_recompile_of_dependencies(file)
 	if is_instance_valid(main_view):
 		main_view.close_file(file)

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -84,6 +84,7 @@ var current_file_path: String = "":
 			files_list.hide()
 			title_list.hide()
 			code_edit.hide()
+			errors_panel.hide()
 		else:
 			test_button.disabled = false
 			search_button.disabled = false
@@ -428,7 +429,8 @@ func build_open_menu() -> void:
 		menu.set_item_disabled(2, true)
 	else:
 		for path in recent_files:
-			menu.add_icon_item(get_theme_icon("File", "EditorIcons"), path)
+			if FileAccess.file_exists(path):
+				menu.add_icon_item(get_theme_icon("File", "EditorIcons"), path)
 
 	menu.add_separator()
 	menu.add_item(DialogueConstants.translate("open.clear_recent_files"), OPEN_CLEAR)


### PR DESCRIPTION
This changes how the dialogue file cache is built and maintained. It no longer writes to the file system and no longer does a total rebuild at any time after the initial boot. Dependency detection and recompiling is now deferred and batched which will hopefully speed things up in large projects.

Related to #265 