### PR TITLE
Add support for indented newlines

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -99,9 +99,6 @@ func parse(text: String, path: String) -> Error:
 			next_id = DialogueConstants.ID_NULL
 		}
 
-		# Ignore empty lines and comments
-#		if is_line_empty(raw_line): continue
-
 		# Work out if we are inside a conditional or option or if we just
 		# indented back out of one
 		var indent_size: int = get_indent(raw_line)

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -37,7 +37,7 @@ Nathan: The value of some_variable is {{SomeGlobal.some_property}}.
 To break a single line into multiple lines for display, you can either use a newline (`\n`) or indent each line below the first line. For example, these two snippets would be equivalent:
 
 ```
-Nathan: This is the first line.
+Coco: This is the first line.
 	This line would show up below it in the same balloon.
 	And even this line.
 ```
@@ -45,7 +45,7 @@ Nathan: This is the first line.
 and
 
 ```
-Nathan: This is the first line.\nThis line would show up below it in the same balloon.\nAnd even this line.
+Coco: This is the first line.\nThis line would show up below it in the same balloon.\nAnd even this line.
 ```
 
 _Note: When using indented line breaks and [line IDs for translations](./Translations.md) you can only specify a line ID on the first (unindented) line of each group._

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -20,7 +20,6 @@ Titles can also be thought of as markers within the dialogue.
 
 Dialogue will run until it hits an `=> END`, `=> END!`, or the end of the file.
 
-
 ## Dialogue
 
 A dialogue line is either just text or in the form of "Character: What they say".
@@ -34,6 +33,22 @@ This is a line said by nobody.
 Nathan: I am saying this line.
 Nathan: The value of some_variable is {{SomeGlobal.some_property}}.
 ```
+
+To break a single line into multiple lines for display, you can either use a newline (`\n`) or indent each line below the first line. For example, these two snippets would be equivalent:
+
+```
+Nathan: This is the first line.
+	This line would show up below it in the same balloon.
+	And even this line.
+```
+
+and
+
+```
+Nathan: This is the first line.\nThis line would show up below it in the same balloon.\nAnd even this line.
+```
+
+_Note: When using indented line breaks and [line IDs for translations](./Translations.md) you can only specify a line ID on the first (unindented) line of each group._
 
 Dialogue lines can also contain **bb_code** for RichTextEffects (if you end up using a `RichTextLabel` or the `DialogueLabel` provided by this addon).
 


### PR DESCRIPTION
This adds support for indented newlines in dialogue lines. For example, these two snippets would be equivalent:

```
Coco: This is the first line.
	This line would show up below it in the same balloon.
	And even this line.
```
and
```
Coco: This is the first line.\nThis line would show up below it in the same balloon.\nAnd even this line.
```