### PR TITLE
Add IDs to lines and responses

### DIFF
--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -5,6 +5,9 @@ class_name DialogueLine extends RefCounted
 const _DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
 
 
+## The ID of this line
+var id: String
+
 ## The internal type of this dialogue object. One of [code]TYPE_DIALOGUE[/code] or [code]TYPE_MUTATION[/code]
 var type: String = _DialogueConstants.TYPE_DIALOGUE
 
@@ -53,6 +56,7 @@ var conditions: Dictionary = {}
 
 func _init(data: Dictionary = {}) -> void:
 	if data.size() > 0:
+		id = data.id
 		next_id = data.next_id
 		type = data.type
 		extra_game_states = data.extra_game_states

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -349,6 +349,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 		DialogueConstants.TYPE_DIALOGUE:
 			var resolved_data: ResolvedLineData = await get_resolved_line_data(data, extra_game_states)
 			return DialogueLine.new({
+				id = data.id,
 				type = DialogueConstants.TYPE_DIALOGUE,
 				next_id = data.next_id,
 				character = await get_resolved_character(data, extra_game_states),
@@ -366,6 +367,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 
 		DialogueConstants.TYPE_RESPONSE:
 			return DialogueLine.new({
+				id = data.id,
 				type = DialogueConstants.TYPE_RESPONSE,
 				next_id = data.next_id,
 				extra_game_states = extra_game_states
@@ -373,6 +375,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 
 		DialogueConstants.TYPE_MUTATION:
 			return DialogueLine.new({
+				id = data.id,
 				type = DialogueConstants.TYPE_MUTATION,
 				next_id = data.next_id,
 				mutation = data.mutation,
@@ -386,6 +389,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 func create_response(data: Dictionary, extra_game_states: Array) -> DialogueResponse:
 	var resolved_data: ResolvedLineData = await get_resolved_line_data(data, extra_game_states)
 	return DialogueResponse.new({
+		id = data.id,
 		type = DialogueConstants.TYPE_RESPONSE,
 		next_id = data.next_id,
 		is_allowed = await check_condition(data, extra_game_states),

--- a/addons/dialogue_manager/dialogue_response.gd
+++ b/addons/dialogue_manager/dialogue_response.gd
@@ -4,6 +4,10 @@ class_name DialogueResponse extends RefCounted
 
 const _DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
 
+
+## The ID of this response
+var id: String
+
 ## The internal type of this dialogue object, always set to [code]TYPE_RESPONSE[/code].
 var type: String = _DialogueConstants.TYPE_RESPONSE
 
@@ -25,6 +29,7 @@ var translation_key: String = ""
 
 func _init(data: Dictionary = {}) -> void:
 	if data.size() > 0:
+		id = data.id
 		type = data.type
 		next_id = data.next_id
 		is_allowed = data.is_allowed

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,11 +19,13 @@ Given a resource and title/ID, it will find the next printable line of dialogue 
 
 Returns a `DialogueLine` that looks something like this:
 
+- `id: String` - the ID of the line.
 - `next_id: String` - the ID of the next line of dialogue after this one.
 - `character: String` - the name of the character speaking (or `""`).
 - `text: String` - the text that the character is saying.
 - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the line)
 - `responses: Array[DialogueResponse]` - the list of responses to this line (or `[]` if none are available).
+  - `id: String` - the ID of the response.
   - `next_id: String` - the ID of the next line if this response is chosen.
   - `is_allowed: bool` - whether this line passed its condition check (useful if you have "include all responses" enabled)
   - `text: String` - the text for this response.


### PR DESCRIPTION
This adds an `id` property to `DialogueLine` and `DialogueResponse` objects.

Related to #273 