### PR TITLE
Fix issue with generated lines missing IDs

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -280,6 +280,10 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 			id_trail = "|" + data.next_id_after + id_trail
 		return await get_line(resource, data.next_id + id_trail, extra_game_states)
 
+	elif data.type == DialogueConstants.TYPE_DIALOGUE:
+		if not data.has("id"):
+			data.id = key
+
 	# Set up a line object
 	var line: DialogueLine = await create_dialogue_line(data, extra_game_states)
 


### PR DESCRIPTION
The lines that are automatically generated from responses have no id, which causes crash in `get_next_dialogue_line()`

Example:
```gdscript
NPC: line
- Player: response
   NPC: answer

# line 1: id 1, text line, next_id 2
# line 2: id 2, text response, next_id 2.1
# line 2.1: id --, text response, next_id 3
# line 3: id 3, text answer, next_id 4
```