### PR TITLE
Fixed skip_typing() triggered by mouse release in example balloon

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -199,7 +199,7 @@ func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 
 func _on_balloon_gui_input(event: InputEvent) -> void:
 	# If the user clicks on the balloon while it's typing then skip typing
-	if dialogue_label.is_typing and event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+	if dialogue_label.is_typing and event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed():
 		get_viewport().set_input_as_handled()
 		dialogue_label.skip_typing()
 		return


### PR DESCRIPTION
When the dialogue is advanced in the example baloon by clicking with the mouse, the subsequent release of the mouse button causes the next line to be always skipped.

By adding a check if the button is pressed before skipping, this can be avoided.