### PR TITLE
Bump compiler version

### DIFF
--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -6,7 +6,7 @@ signal compiled_resource(resource: Resource)
 
 
 const DialogueResource = preload("res://addons/dialogue_manager/dialogue_resource.gd")
-const compiler_version = 8
+const compiler_version = 9
 
 
 var editor_plugin


### PR DESCRIPTION
This bumps the internal compiler version to ensure that compiled resources have line IDs.