### PR TITLE
Reset DialogueLabel visibility ratio on type_out

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -65,6 +65,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func type_out() -> void:
 	text = dialogue_line.text
 	visible_characters = 0
+	visible_ratio = 0
 	self.is_typing = true
 	waiting_seconds = 0
 

--- a/examples/visual_novel_balloon/balloon.gd
+++ b/examples/visual_novel_balloon/balloon.gd
@@ -80,8 +80,6 @@ var dialogue_line: DialogueLine:
 
 func _ready() -> void:
 	response_template.hide()
-#	hide()
-
 	Engine.get_singleton("DialogueManager").mutated.connect(_on_mutated)
 
 


### PR DESCRIPTION
This resets the `visibility_ratio` when starting a `type_out` on the `DialogueLabel`.