### PR TITLE
Fix two typos in CSharp docs

### DIFF
--- a/docs/CSharp.md
+++ b/docs/CSharp.md
@@ -40,7 +40,7 @@ public async Task AskForName()
 }
 ```
 
-And you would need to declar that `PlayerName` property like so (make sure to inclue the `[Export]` decorator or the Dialogue Manager won't be able to see it):
+And you would need to declare that `PlayerName` property like so (make sure to include the `[Export]` decorator or the Dialogue Manager won't be able to see it):
 
 ```csharp
 [Export]


### PR DESCRIPTION
Just two small typo fixes to the CSharp docs