### PR TITLE
Add line tags

### DIFF
--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -14,8 +14,8 @@ var regex_condition: RegEx = RegEx.create_from_string("^\\s*(if|elif|while|else 
 var regex_wcondition: RegEx = RegEx.create_from_string("\\[if (?<condition>((?:[^\\[\\]]*)|(?:\\[(?1)\\]))*?)\\]")
 var regex_wendif: RegEx = RegEx.create_from_string("\\[\\/(if)\\]")
 var regex_rgroup: RegEx = RegEx.create_from_string("\\[\\[(?<options>.*?)\\]\\]")
-var regex_endconditions: RegEx = RegEx.create_from_string("^\\s*(endif|else)\\s*$")
-var regex_tags: RegEx = RegEx.create_from_string("\\[(?<tag>(?!(?:ID:.*)|if)[a-zA-Z_][a-zA-Z0-9_]*)(?:[= ](?<val>[^\\[\\]]+))?\\](?:(?<text>(?!\\[\\/\\k<tag>\\]).*?)?(?<end>\\[\\/\\k<tag>\\]))?")
+var regex_endconditions: RegEx = RegEx.create_from_string("^\\s*(endif|else):?\\s*$")
+var regex_tags: RegEx = RegEx.create_from_string("\\[(?<tag>(?!(?:ID:.*)|if|)[a-zA-Z_][a-zA-Z0-9_]*)(?:[= ](?<val>[^\\[\\]]+))?\\](?:(?<text>(?!\\[\\/\\k<tag>\\]).*?)?(?<end>\\[\\/\\k<tag>\\]))?")
 var regex_dialogue: RegEx = RegEx.create_from_string("^\\s*(?:(?<random>\\%\\d* )|(?<response>- ))?(?:(?<character>[^#:]*): )?(?<dialogue>.*)$")
 var regex_goto: RegEx = RegEx.create_from_string("=><? (?:(?<file>[^\\/]+)\\/)?(?<title>[^\\/]*)")
 var regex_string: RegEx = RegEx.create_from_string("^(?<delimiter>[\"'])(?<content>(?:\\\\{2})*|(?:.*?[^\\\\](?:\\\\{2})*))\\1$")
@@ -112,6 +112,7 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 	var endcondition_matches: Array[RegExMatch] = regex_endconditions.search_all(text)
 	for endcondition_match in endcondition_matches:
 		colors[endcondition_match.get_start(1)] = {"color": text_edit.theme_overrides.conditions_color}
+		colors[endcondition_match.get_end(1)] = {"color": text_edit.theme_overrides.symbols_color}
 
 	# Mutations.
 	var mutation_matches: Array[RegExMatch] = regex_mutation.search_all(text)
@@ -134,6 +135,12 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 func _get_dialogue_syntax_highlighting(start_index: int, text: String) -> Dictionary:
 	var text_edit: TextEdit = get_text_edit()
 	var colors: Dictionary = {}
+
+	# #tag style tags
+	var hashtag_matches: Array[RegExMatch] = dialogue_manager_parser.TAGS_REGEX.search_all(text)
+	for hashtag_match in hashtag_matches:
+		colors[start_index + hashtag_match.get_start(0)] = { "color": text_edit.theme_overrides.comments_color }
+		colors[start_index + hashtag_match.get_end(0)] = { "color": text_edit.theme_overrides.text_color }
 
 	# Global tags, like bbcode.
 	var tag_matches: Array[RegExMatch] = regex_tags.search_all(text)

--- a/addons/dialogue_manager/components/resolved_tag_data.gd
+++ b/addons/dialogue_manager/components/resolved_tag_data.gd
@@ -1,0 +1,10 @@
+class_name ResolvedTagData extends RefCounted
+
+
+var tags: PackedStringArray = []
+var line_without_tags: String = ""
+
+
+func _init(data: Dictionary) -> void:
+	tags = data.tags
+	line_without_tags = data.line_without_tags

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -47,6 +47,9 @@ var extra_game_states: Array = []
 ## How long to show this line before advancing to the next. Either a float (of seconds), [code]"auto"[/code], or [code]null[/code].
 var time = null
 
+## Any #tags that were included in the line
+var tags: PackedStringArray = []
+
 ## The mutation details if this is a mutation line (where [code]type == TYPE_MUTATION[/code]).
 var mutation: Dictionary = {}
 
@@ -73,6 +76,7 @@ func _init(data: Dictionary = {}) -> void:
 				inline_mutations = data.inline_mutations
 				conditions = data.conditions
 				time = data.time
+				tags = data.tags
 
 			_DialogueConstants.TYPE_MUTATION:
 				mutation = data.mutation

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -366,6 +366,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 				inline_mutations = resolved_data.mutations,
 				conditions = resolved_data.conditions,
 				time = resolved_data.time,
+				tags = data.tags,
 				extra_game_states = extra_game_states
 			})
 
@@ -374,6 +375,7 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 				id = data.id,
 				type = DialogueConstants.TYPE_RESPONSE,
 				next_id = data.next_id,
+				tags = data.tags,
 				extra_game_states = extra_game_states
 			})
 
@@ -399,6 +401,7 @@ func create_response(data: Dictionary, extra_game_states: Array) -> DialogueResp
 		is_allowed = await check_condition(data, extra_game_states),
 		text = resolved_data.text,
 		text_replacements = data.text_replacements,
+		tags = data.tags,
 		translation_key = data.translation_key
 	})
 

--- a/addons/dialogue_manager/dialogue_response.gd
+++ b/addons/dialogue_manager/dialogue_response.gd
@@ -23,6 +23,9 @@ var text: String = ""
 ## A dictionary of variable replaces for the text. Generally for internal use only.
 var text_replacements: Array[Dictionary] = []
 
+## Any #tags
+var tags: PackedStringArray = []
+
 ## The key to use for translating the text.
 var translation_key: String = ""
 
@@ -35,6 +38,7 @@ func _init(data: Dictionary = {}) -> void:
 		is_allowed = data.is_allowed
 		text = data.text
 		text_replacements = data.text_replacements
+		tags = data.tags
 		translation_key = data.translation_key
 
 

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -6,7 +6,7 @@ signal compiled_resource(resource: Resource)
 
 
 const DialogueResource = preload("res://addons/dialogue_manager/dialogue_resource.gd")
-const compiler_version = 9
+const compiler_version = 10
 
 
 var editor_plugin

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,12 +23,14 @@ Returns a `DialogueLine` that looks something like this:
 - `next_id: String` - the ID of the next line of dialogue after this one.
 - `character: String` - the name of the character speaking (or `""`).
 - `text: String` - the text that the character is saying.
+- `tags: PackedStringArray` - a list of tags.
 - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the line)
 - `responses: Array[DialogueResponse]` - the list of responses to this line (or `[]` if none are available).
   - `id: String` - the ID of the response.
   - `next_id: String` - the ID of the next line if this response is chosen.
   - `is_allowed: bool` - whether this line passed its condition check (useful if you have "include all responses" enabled)
   - `text: String` - the text for this response.
+  - `tags: PackedStringArray` - a list of tags.
   - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the response)
 
 If there is no next line of dialogue found then it will return an empty dictionary (`{}`).

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -56,6 +56,14 @@ If you use the `DialogueLabel` node then you can also make use of the `[wait=N]`
 
 There is also a `[next]` code that you can use to signify that a line should be auto advanced. If given no arguments it will auto advance immediately after the text has typed out. If given something like `[next=0.5]` it will wait for 0.5s after typing has finished before moving to the next line. If given `[next=auto]` it will wait for an automatic amount of time based on the length of the line.
 
+### Tags
+
+If you need to annotate your lines with tags then you can wrap them in `[#` and `]`, separated by commas. So to specify "happy" and "surprised" tags for a line you would do something like:
+
+```
+Nathan: [#happy, #surprised] Oh, Hello!
+```
+
 ### Randomising lines of dialogue
 
 If you want to pick one from a few lines of dialogue you can mark the line with a `%` at the start like this:

--- a/examples/dialogue.dialogue.import
+++ b/examples/dialogue.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_9"
+importer="dialogue_manager_compiler_10"
 type="Resource"
 uid="uid://c7xhr8kec0j4l"
 path="res://.godot/imported/dialogue.dialogue-7261ed8f1fc7558828110057cd7de1cd.tres"

--- a/examples/dialogue_for_csharp.dialogue.import
+++ b/examples/dialogue_for_csharp.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_9"
+importer="dialogue_manager_compiler_10"
 type="Resource"
 uid="uid://crw6v7sw0tx34"
 path="res://.godot/imported/dialogue_for_csharp.dialogue-9c843d92323bc3ce3a6860c848251c23.tres"

--- a/examples/dialogue_for_point_n_click.dialogue.import
+++ b/examples/dialogue_for_point_n_click.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_9"
+importer="dialogue_manager_compiler_10"
 type="Resource"
 uid="uid://c21ogqvaf7u0p"
 path="res://.godot/imported/dialogue_for_point_n_click.dialogue-3f5e4d7e9b600a1465fdfd8417d06976.tres"

--- a/examples/dialogue_for_visual_novel.dialogue.import
+++ b/examples/dialogue_for_visual_novel.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_9"
+importer="dialogue_manager_compiler_10"
 type="Resource"
 uid="uid://dd5gx2wq6xojd"
 path="res://.godot/imported/dialogue_for_visual_novel.dialogue-68b4d7220d88c358e1312ba2f42ceb11.tres"

--- a/examples/dialogue_with_input.dialogue.import
+++ b/examples/dialogue_with_input.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_9"
+importer="dialogue_manager_compiler_10"
 type="Resource"
 uid="uid://bnya3clsjvb71"
 path="res://.godot/imported/dialogue_with_input.dialogue-c39aeeef4356c037cffb9524fd896bb5.tres"


### PR DESCRIPTION
This adds support for line/response tags. They get processed at compile time (as opposed to BBCode and RichTextEffects that get processed at run time). 

To define tags, specify something like `[#tag1, #tag2]` on a dialogue line or response and they will be available as `.tags` (a `PackedStringArray`) on the line or response.

Related to #272