### PR TITLE
Use relative paths for internal referencing

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -7,7 +7,7 @@ signal error_clicked(line_number: int)
 signal external_file_requested(path: String, title: String)
 
 
-const DialogueSyntaxHighlighter = preload("res://addons/dialogue_manager/components/code_edit_syntax_highlighter.gd")
+const DialogueSyntaxHighlighter = preload("./code_edit_syntax_highlighter.gd")
 
 
 # A link back to the owner MainView

--- a/addons/dialogue_manager/components/dialogue_cache.gd
+++ b/addons/dialogue_manager/components/dialogue_cache.gd
@@ -1,8 +1,8 @@
 extends Node
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueConstants = preload("../constants.gd")
+const DialogueSettings = preload("./settings.gd")
 
 
 # Keeps track of errors and dependencies.

--- a/addons/dialogue_manager/components/download_update_panel.gd
+++ b/addons/dialogue_manager/components/download_update_panel.gd
@@ -6,7 +6,7 @@ signal failed()
 signal updated(updated_to_version: String)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 const TEMP_FILE_NAME = "user://temp.zip"
 

--- a/addons/dialogue_manager/components/errors_panel.gd
+++ b/addons/dialogue_manager/components/errors_panel.gd
@@ -5,7 +5,7 @@ extends HBoxContainer
 signal error_pressed(line_number)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 
 @onready var error_button: Button = $ErrorButton

--- a/addons/dialogue_manager/components/files_list.gd
+++ b/addons/dialogue_manager/components/files_list.gd
@@ -7,7 +7,7 @@ signal file_popup_menu_requested(at_position: Vector2)
 signal file_double_clicked(file_path: String)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 const MODIFIED_SUFFIX = "(*)"
 

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -3,8 +3,8 @@
 class_name DialogueManagerParser extends Object
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueConstants = preload("../constants.gd")
+const DialogueSettings = preload("./settings.gd")
 
 
 var IMPORT_REGEX: RegEx = RegEx.create_from_string("import \"(?<path>[^\"]+)\" as (?<prefix>[^\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\-\\=\\+\\{\\}\\[\\]\\;\\:\\\"\\'\\,\\.\\<\\>\\?\\/\\s]+)")

--- a/addons/dialogue_manager/components/search_and_replace.gd
+++ b/addons/dialogue_manager/components/search_and_replace.gd
@@ -6,7 +6,7 @@ signal open_requested()
 signal close_requested()
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 
 @onready var input: LineEdit = $Search/Input

--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -2,7 +2,7 @@
 extends Node
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 
 ### Editor config
@@ -15,7 +15,7 @@ const DEFAULT_SETTINGS = {
 	new_with_template = true,
 	include_all_responses = false,
 	ignore_missing_state_values = false,
-	custom_test_scene_path = "res://addons/dialogue_manager/test_scene.tscn",
+	custom_test_scene_path = preload("../test_scene.tscn").resource_path,
 	default_csv_locale = "en"
 }
 

--- a/addons/dialogue_manager/components/title_list.gd
+++ b/addons/dialogue_manager/components/title_list.gd
@@ -4,7 +4,7 @@ extends VBoxContainer
 signal title_selected(title: String)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 
 @onready var filter_edit: LineEdit = $FilterEdit
@@ -27,7 +27,7 @@ var filter: String:
 
 func _ready() -> void:
 	apply_theme()
-	
+
 	filter_edit.placeholder_text = DialogueConstants.translate("titles_list.filter")
 
 

--- a/addons/dialogue_manager/components/update_button.gd
+++ b/addons/dialogue_manager/components/update_button.gd
@@ -1,10 +1,9 @@
 @tool
 extends Button
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const DialogueConstants = preload("../constants.gd")
 
 const REMOTE_RELEASES_URL = "https://api.github.com/repos/nathanhoad/godot_dialogue_manager/releases"
-const LOCAL_CONFIG_PATH = "res://addons/dialogue_manager/plugin.cfg"
 
 
 @onready var http_request: HTTPRequest = $HTTPRequest
@@ -32,13 +31,6 @@ func _ready() -> void:
 
 	# Check again every few hours
 	timer.start(60 * 60 * 12)
-
-
-# Get the current version
-func get_version() -> String:
-	var config: ConfigFile = ConfigFile.new()
-	config.load(LOCAL_CONFIG_PATH)
-	return config.get_value("plugin", "version")
 
 
 # Convert a version number to an actually comparable number
@@ -72,7 +64,7 @@ func check_for_update() -> void:
 func _on_http_request_request_completed(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray) -> void:
 	if result != HTTPRequest.RESULT_SUCCESS: return
 
-	var current_version: String = get_version()
+	var current_version: String = editor_plugin.get_version()
 
 	# Work out the next version from the releases information on GitHub
 	var response = JSON.parse_string(body.get_string_from_utf8())

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -2,7 +2,7 @@
 class_name DialogueLine extends RefCounted
 
 
-const _DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const _DialogueConstants = preload("./constants.gd")
 
 
 ## The ID of this line

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -8,10 +8,10 @@ signal dialogue_ended(resource)
 signal bridge_get_next_dialogue_line_completed(line)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
-const DialogueLine = preload("res://addons/dialogue_manager/dialogue_line.gd")
-const DialogueResponse = preload("res://addons/dialogue_manager/dialogue_response.gd")
+const DialogueConstants = preload("./constants.gd")
+const DialogueSettings = preload("./components/settings.gd")
+const DialogueLine = preload("./dialogue_line.gd")
+const DialogueResponse = preload("./dialogue_response.gd")
 
 
 enum MutationBehaviour {

--- a/addons/dialogue_manager/dialogue_resource.gd
+++ b/addons/dialogue_manager/dialogue_resource.gd
@@ -4,7 +4,7 @@
 class_name DialogueResource extends Resource
 
 
-const _DialogueManager = preload("res://addons/dialogue_manager/dialogue_manager.gd")
+const _DialogueManager = preload("./dialogue_manager.gd")
 
 
 ## A map of titles and the lines they point to.

--- a/addons/dialogue_manager/dialogue_response.gd
+++ b/addons/dialogue_manager/dialogue_response.gd
@@ -2,7 +2,7 @@
 class_name DialogueResponse extends RefCounted
 
 
-const _DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+const _DialogueConstants = preload("./constants.gd")
 
 
 ## The ID of this response

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -1,8 +1,8 @@
 extends EditorTranslationParserPlugin
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueConstants = preload("./constants.gd")
+const DialogueSettings = preload("./components/settings.gd")
 
 
 func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> void:

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -5,7 +5,7 @@ extends EditorImportPlugin
 signal compiled_resource(resource: Resource)
 
 
-const DialogueResource = preload("res://addons/dialogue_manager/dialogue_resource.gd")
+const DialogueResource = preload("./dialogue_resource.gd")
 const compiler_version = 10
 
 

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -2,12 +2,12 @@
 extends EditorPlugin
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueImportPlugin = preload("res://addons/dialogue_manager/import_plugin.gd")
-const DialogueTranslationParserPlugin = preload("res://addons/dialogue_manager/editor_translation_parser_plugin.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
-const DialogueCache = preload("res://addons/dialogue_manager/components/dialogue_cache.gd")
-const MainView = preload("res://addons/dialogue_manager/views/main_view.tscn")
+const DialogueConstants = preload("./constants.gd")
+const DialogueImportPlugin = preload("./import_plugin.gd")
+const DialogueTranslationParserPlugin = preload("./editor_translation_parser_plugin.gd")
+const DialogueSettings = preload("./components/settings.gd")
+const DialogueCache = preload("./components/dialogue_cache.gd")
+const MainView = preload("./views/main_view.tscn")
 
 
 var import_plugin: DialogueImportPlugin
@@ -20,7 +20,7 @@ var _recompile_paths: PackedStringArray
 
 
 func _enter_tree() -> void:
-	add_autoload_singleton("DialogueManager", "res://addons/dialogue_manager/dialogue_manager.gd")
+	add_autoload_singleton("DialogueManager", "./dialogue_manager.gd")
 
 	if Engine.is_editor_hint():
 		DialogueSettings.prepare()
@@ -81,7 +81,7 @@ func _get_plugin_name() -> String:
 
 
 func _get_plugin_icon() -> Texture2D:
-	return load("res://addons/dialogue_manager/assets/icon.svg")
+	return load(get_script().resource_path.get_base_dir() + "/assets/icon.svg")
 
 
 func _handles(object) -> bool:
@@ -112,6 +112,18 @@ func _build() -> bool:
 		return false
 
 	return true
+
+
+## Get the current version
+func get_version() -> String:
+	var config: ConfigFile = ConfigFile.new()
+	config.load(get_plugin_path() + "/plugin.cfg")
+	return config.get_value("plugin", "version")
+
+
+## Get the current path of the plugin
+func get_plugin_path() -> String:
+	return get_script().resource_path.get_base_dir()
 
 
 ## Keep track of known files and their dependencies
@@ -197,19 +209,19 @@ func _copy_dialogue_balloon() -> void:
 	directory_dialog.file_mode = FileDialog.FILE_MODE_OPEN_DIR
 	directory_dialog.min_size = Vector2(600, 500) * scale
 	directory_dialog.dir_selected.connect(func(path):
-		var file: FileAccess = FileAccess.open("res://addons/dialogue_manager/example_balloon/example_balloon.tscn", FileAccess.READ)
-		var file_contents: String = file.get_as_text().replace("res://addons/dialogue_manager/example_balloon/example_balloon.gd", path + "/balloon.gd")
+		var file: FileAccess = FileAccess.open("./example_balloon/example_balloon.tscn", FileAccess.READ)
+		var file_contents: String = file.get_as_text().replace("./example_balloon/example_balloon.gd", path + "/balloon.gd")
 		file = FileAccess.open(path + "/balloon.tscn", FileAccess.WRITE)
 		file.store_string(file_contents)
 		file.close()
 
-		file = FileAccess.open("res://addons/dialogue_manager/example_balloon/small_example_balloon.tscn", FileAccess.READ)
-		file_contents = file.get_as_text().replace("res://addons/dialogue_manager/example_balloon/example_balloon.gd", path + "/balloon.gd")
+		file = FileAccess.open("./example_balloon/small_example_balloon.tscn", FileAccess.READ)
+		file_contents = file.get_as_text().replace("./example_balloon/example_balloon.gd", path + "/balloon.gd")
 		file = FileAccess.open(path + "/small_balloon.tscn", FileAccess.WRITE)
 		file.store_string(file_contents)
 		file.close()
 
-		file = FileAccess.open("res://addons/dialogue_manager/example_balloon/example_balloon.gd", FileAccess.READ)
+		file = FileAccess.open("./example_balloon/example_balloon.gd", FileAccess.READ)
 		file_contents = file.get_as_text()
 		file = FileAccess.open(path + "/balloon.gd", FileAccess.WRITE)
 		file.store_string(file_contents)

--- a/addons/dialogue_manager/test_scene.gd
+++ b/addons/dialogue_manager/test_scene.gd
@@ -1,7 +1,7 @@
 class_name BaseDialogueTestScene extends Node2D
 
 
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueSettings = preload("./components/settings.gd")
 
 
 @onready var title: String = DialogueSettings.get_user_value("run_title")

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -2,8 +2,8 @@
 extends Control
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
+const DialogueConstants = preload("../constants.gd")
+const DialogueSettings = preload("../components/settings.gd")
 
 const OPEN_OPEN = 100
 const OPEN_CLEAR = 101
@@ -122,7 +122,7 @@ func _ready() -> void:
 	self.current_file_path = ""
 
 	# Set up the update checker
-	version_label.text = "v%s" % update_button.get_version()
+	version_label.text = "v%s" % editor_plugin.get_version()
 	update_button.editor_plugin = editor_plugin
 	update_button.on_before_refresh = func on_before_refresh():
 		# Save everything

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -5,11 +5,8 @@ extends TabContainer
 signal script_button_pressed(path: String)
 
 
-const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
-const DialogueSettings = preload("res://addons/dialogue_manager/components/settings.gd")
-
-
-const DEFAULT_TEST_SCENE_PATH = "res://addons/dialogue_manager/test_scene.tscn"
+const DialogueConstants = preload("../constants.gd")
+const DialogueSettings = preload("../components/settings.gd")
 
 
 # Editor
@@ -32,6 +29,7 @@ const DEFAULT_TEST_SCENE_PATH = "res://addons/dialogue_manager/test_scene.tscn"
 var editor_plugin: EditorPlugin
 var all_globals: Dictionary = {}
 var enabled_globals: Array = []
+var _default_test_scene_path: String = preload("../test_scene.tscn").resource_path
 
 
 func _ready() -> void:
@@ -51,8 +49,8 @@ func _ready() -> void:
 
 
 func prepare() -> void:
-	test_scene_path_input.placeholder_text = DialogueSettings.get_setting("custom_test_scene_path", DEFAULT_TEST_SCENE_PATH)
-	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != DEFAULT_TEST_SCENE_PATH
+	test_scene_path_input.placeholder_text = DialogueSettings.get_setting("custom_test_scene_path", _default_test_scene_path)
+	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != _default_test_scene_path
 	revert_test_scene_button.icon = get_theme_icon("RotateLeft", "EditorIcons")
 	revert_test_scene_button.tooltip_text = DialogueConstants.translate("settings.revert_to_default_test_scene")
 	load_test_scene_button.icon = get_theme_icon("Load", "EditorIcons")
@@ -146,9 +144,9 @@ func _on_sample_template_toggled(button_pressed):
 
 
 func _on_revert_test_scene_pressed() -> void:
-	DialogueSettings.set_setting("custom_test_scene_path", DEFAULT_TEST_SCENE_PATH)
-	test_scene_path_input.placeholder_text = DEFAULT_TEST_SCENE_PATH
-	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != DEFAULT_TEST_SCENE_PATH
+	DialogueSettings.set_setting("custom_test_scene_path", _default_test_scene_path)
+	test_scene_path_input.placeholder_text = _default_test_scene_path
+	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != _default_test_scene_path
 
 
 func _on_load_test_scene_pressed() -> void:
@@ -158,7 +156,7 @@ func _on_load_test_scene_pressed() -> void:
 func _on_custom_test_scene_file_dialog_file_selected(path: String) -> void:
 	DialogueSettings.set_setting("custom_test_scene_path", path)
 	test_scene_path_input.placeholder_text = path
-	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != DEFAULT_TEST_SCENE_PATH
+	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != _default_test_scene_path
 
 
 func _on_ignore_missing_state_values_toggled(button_pressed: bool) -> void:


### PR DESCRIPTION
This converts all paths used for the addon inner-workings to be relative.