### PR TITLE
Fix running test scene when there is no active title

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -224,10 +224,10 @@ func check_active_title() -> void:
 	# Look at each line above this one to find the next title line
 	for i in range(line_number, -1, -1):
 		if lines[i].begins_with("~ "):
-			emit_signal("active_title_change", lines[i].replace("~ ", ""))
+			active_title_change.emit(lines[i].replace("~ ", ""))
 			return
 
-	emit_signal("active_title_change", "0")
+	active_title_change.emit("")
 
 
 # Move the caret line to match a given title
@@ -309,7 +309,7 @@ func toggle_comment() -> void:
 			set_line(line, line_text.substr(comment_delimiter.length()) if is_line_commented else comment_delimiter + line_text)
 			caret_offsets[line] += (-1 if is_line_commented else 1) * comment_delimiter.length()
 
-		emit_signal("lines_edited_from", from, to)
+		lines_edited_from.emit(from, to)
 
 	# Readjust carets and selection positions after all carets effect have been calculated
 	# Tried making it in the above loop, but that causes a weird behaviour if two carets are on the same line (first caret will move, but not the second one)
@@ -323,8 +323,8 @@ func toggle_comment() -> void:
 
 	end_complex_operation()
 
-	emit_signal("text_set")
-	emit_signal("text_changed")
+	text_set.emit()
+	text_changed.emit()
 
 
 # Move the selected lines up or down
@@ -359,7 +359,7 @@ func move_line(offset: int) -> void:
 	if reselect:
 		select(from, 0, to, get_line_width(to))
 	set_cursor(cursor)
-	emit_signal("text_changed")
+	text_changed.emit()
 
 
 ### Signals
@@ -379,7 +379,7 @@ func _on_code_edit_symbol_validate(symbol: String) -> void:
 
 func _on_code_edit_symbol_lookup(symbol: String, line: int, column: int) -> void:
 	if symbol.begins_with("res://") and symbol.ends_with(".dialogue"):
-		emit_signal("external_file_requested", symbol, "")
+		external_file_requested.emit(symbol, "")
 	else:
 		go_to_title(symbol)
 
@@ -400,4 +400,4 @@ func _on_code_edit_caret_changed() -> void:
 func _on_code_edit_gutter_clicked(line: int, gutter: int) -> void:
 	var line_errors = errors.filter(func(error): return error.line_number == line)
 	if line_errors.size() > 0:
-		emit_signal("error_clicked", line)
+		error_clicked.emit(line)

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -196,7 +196,7 @@ func create_resource_from_text(text: String) -> Resource:
 
 
 ## Show the example balloon
-func show_example_dialogue_balloon(resource: DialogueResource, title: String = "0", extra_game_states: Array = []) -> void:
+func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> void:
 	var ExampleBalloonScene = load("res://addons/dialogue_manager/example_balloon/example_balloon.tscn")
 	var SmallExampleBalloonScene = load("res://addons/dialogue_manager/example_balloon/small_example_balloon.tscn")
 
@@ -229,6 +229,10 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 	key = stack.pop_front()
 	var id_trail: String = "" if stack.size() == 0 else "|" + "|".join(stack)
 
+	# Key is blank so just use the first title
+	if key == null or key == "":
+		key = resource.first_title
+
 	# See if we just ended the conversation
 	if key in [DialogueConstants.ID_END, DialogueConstants.ID_NULL, null]:
 		if stack.size() > 0:
@@ -246,10 +250,6 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 
 	if key in resource.titles.values():
 		passed_title.emit(resource.titles.find_key(key))
-
-	# Key is blank so just use the first title
-	if key == null or key == "":
-		key = resource.first_title
 
 	assert(resource.lines.has(key), DialogueConstants.translate("errors.key_not_found").format({ key = key }))
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -6,7 +6,7 @@
 - `Treat missing translations as errors` can be enabled if you are using static translation keys and are adding them manually (there is an automatic static key button but you might be writing specific keys).
 - `Export character names in translation files` can be enabled to include character names when using translations.
 - `Wrap long lines` turns on word wrapping.
-- `Custom Test Scene` can be used to override the default test scene that gets run when you click "Test Scene" in the dialogue editor.
+- `Custom Test Scene` can be used to override the default test scene that gets run when you click the "Test dialogue" button in the dialogue editor.
 - `Default CSV locale` can be modified to set the default locale heading when generating CSVs for translation.
 
 ## Runtime

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -2,12 +2,17 @@
 
 ## Editor
 
+- `New dialogue files will start with template text` can be enabled to start new dialogue files with example dialogue.
 - `Treat missing translations as errors` can be enabled if you are using static translation keys and are adding them manually (there is an automatic static key button but you might be writing specific keys).
+- `Export character names in translation files` can be enabled to include character names when using translations.
 - `Wrap long lines` turns on word wrapping.
+- `Custom Test Scene` can be used to override the default test scene that gets run when you click "Test Scene" in the dialogue editor.
+- `Default CSV locale` can be modified to set the default locale heading when generating CSVs for translation.
 
 ## Runtime
 
 - `Include responses with failed conditions` will include responses that failed their condition check in the list of responses attached to a given line.
+- `Skip over missing state value errors` will let you run dialogue and ignore any errors that occur when you reference state values that don't exist.
 
 ### Globals shortcuts
 

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -251,7 +251,7 @@ If any are found they will be highlighted and must be fixed before you can run y
 
 For dialogue that doesn't rely too heavily on game state conditions you can do a quick test of it by clicking the "Run the test scene" button in the main toolbar.
 
-This will boot up a test scene and run the currently active node. Use `ui_up`, `ui_down`, and `ui_accept` to navigate the dialogue and responses.
+This will boot up a test scene and run from the nearest title marker above the cursor position. Use your mouse and/or `ui_up`, `ui_down`, and `ui_accept` to navigate the dialogue and responses.
 
 Once the conversation is over the scene will close.
 
@@ -259,7 +259,7 @@ Once the conversation is over the scene will close.
 
 You can override which scene is run when clicking the test button in settings.
 
-Your custom test scene must extend `BaseDialogueTestScene` which will provide you with a `resource` property which is the `DialogueResource` currently open and a `title` property which is the nearest title to the cursor position.
+Your custom test scene must extend `BaseDialogueTestScene` which will provide you with a `resource` property (which is the `DialogueResource` currently open) and the `title` to start from.
 
 The simplest example custom test scene is something like this (which is pretty much the same as the actual test scene):
 


### PR DESCRIPTION
This adds a fallback for when the "Test dialogue" button is pressed but there is no active title to start from.

Closes #296 