### PR TITLE
Fix: empty non-indented lines mess up parent stack

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -103,7 +103,7 @@ func parse(text: String, path: String) -> Error:
 		# Work out if we are inside a conditional or option or if we just
 		# indented back out of one
 		var indent_size: int = get_indent(raw_line)
-		if indent_size < parent_stack.size():
+		if indent_size < parent_stack.size() and not is_line_empty(raw_line):
 			for _tab in range(0, parent_stack.size() - indent_size):
 				parent_stack.pop_back()
 


### PR DESCRIPTION
When using blocks that incur a new indent level, using empty but non-indented lines messed up the parent assignment process, thus resulting in unwanted behavior most of the time.

For example:
```
~ start

Nathan: Hi, I'm Nathan and this is Coco.
Coco: Meow.
Nathan: Here are some response options.
- First one

	Nathan: You picked the first one.
- Second one
	Nathan: You picked the second one.
- Start again => start
- End the conversation => END
Nathan: I hope this example is helpful.
Coco: Meow.

=> END
```

Just adding this one simple empty line to the default example made the `next()` call on line 8 to go to a premature end.

The fix is simply not to pop the parent stack when encountering an empty line. One other fix I considered was to move up the `is_line_empty(raw_line)` check so that it is the first thing done, and make it continue the loop, but I did not know what other effects it could have.