### PR TITLE
Make goto lines randomisable

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -267,7 +267,7 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 				cummulative_weight += sibling.weight
 
 	# Check condtiions
-	elif data.type == DialogueConstants.TYPE_CONDITION:
+	if data.type == DialogueConstants.TYPE_CONDITION:
 		# "else" will have no actual condition
 		if await check_condition(data, extra_game_states):
 			return await get_line(resource, data.next_id + id_trail, extra_game_states)

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -120,6 +120,15 @@ import "res://snippets.dialogue" as snippets
 
 And then you can jump to titles by prefixing them with `snippets/`. For example, say there was a "talk_to_nathan" title in the snippets file then in the current file I could use `=> snippets/talk_to_nathan`.
 
+The `%` syntax also applies to jumps. So to jump to one of a random set of titles you might have something like this:
+
+```
+Nathan: Let's go somewhere random.
+% => first
+% => second
+% => third
+```
+
 ## Responses
 
 To give the player branching options you can start a line with "- " and then a prompt. Like dialogue, prompts can also contain variables wrapped in `{{}}`.


### PR DESCRIPTION
This adds support for using the `%` syntax for goto lines.

To go to one randomly of a set of titles you might have something like:

```
Nathan: Let's go to a random title.
% => first_title
% => second_title
% => third_title
```

Closes #314 