### PR TITLE
Add a skipped_typing signal

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -10,6 +10,9 @@ signal spoke(letter: String, letter_index: int, speed: float)
 ## Emitted when typing paused for a `[wait]`
 signal paused_typing(duration: float)
 
+## Emitted when the player skips the typing of dialogue.
+signal skipped_typing()
+
 ## Emitted when typing finishes.
 signal finished_typing()
 
@@ -93,6 +96,7 @@ func skip_typing() -> void:
 	_mutation_remaining_mutations()
 	visible_characters = get_total_character_count()
 	self.is_typing = false
+	skipped_typing.emit()
 
 
 # Type out the next character(s)

--- a/docs/API.md
+++ b/docs/API.md
@@ -58,8 +58,9 @@ It will close once dialogue runs out.
 ### Signals
 
 - `spoke(letter: String, letter_index: int, speed: float)` - emitted each step while typing out.
-- `paused_typing(duration: float)` - emitted when the label pauses typing
-- `finished_typing()` - emitted when the label finishes typing
+- `paused_typing(duration: float)` - emitted when the label pauses typing.
+- `skipped_typing()` - emitted when the player skips the label typing out.
+- `finished_typing()` - emitted when the label finishes typing.
 
 ### Methods
 


### PR DESCRIPTION
This adds a `skipped_typing` signal for when the `DialogueLabel` skips typing.

Closes #318 