### PR TITLE
Fixed random weight issues

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -694,7 +694,7 @@ func apply_weighted_random(id: int, raw_line: String, indent_size: int, line: Di
 		if not raw_lines[i].strip_edges().begins_with("%") or get_indent(raw_lines[i]) != indent_size:
 			break
 		# Make sure we group random dialogue and ranom lines separately
-		elif WEIGHTED_RANDOM_SIBLINGS_REGEX.sub(raw_line.strip_edges(), "").begins_with("=") and not WEIGHTED_RANDOM_SIBLINGS_REGEX.sub(raw_lines[i].strip_edges(), "").begins_with("="):
+		elif WEIGHTED_RANDOM_SIBLINGS_REGEX.sub(raw_line.strip_edges(), "").begins_with("=") != WEIGHTED_RANDOM_SIBLINGS_REGEX.sub(raw_lines[i].strip_edges(), "").begins_with("="):
 			break
 		# Otherwise we've found the origin
 		elif parsed_lines.has(str(i)) and parsed_lines[str(i)].has("siblings"):
@@ -708,6 +708,9 @@ func apply_weighted_random(id: int, raw_line: String, indent_size: int, line: Di
 			# Update the next line for all siblings (not goto lines, though, they manager their
 			# own next ID)
 			original_random_line["next_id"] = get_line_after_line(id, indent_size, line)
+			for sibling in original_random_line["siblings"]:
+				if sibling.id in parsed_lines:
+					parsed_lines[sibling.id]["next_id"] = original_random_line["next_id"]
 		line["next_id"] = original_random_line.next_id
 	# Or set up this line as the original
 	else:


### PR DESCRIPTION
There are currently two issues with the new random weight:

-----

> Separation between dialogues and goto types didn't work properly:
> ```
> ~ start
> 
> % Random 1
> % =>< something
> % Random 2
> % Random 3
> 
> => END
> 
> ~ something
> 
> => END
> ```
> 
> 1 was on its own, the goto didn't match with the 1, however 2 and 3 matched with the goto because of the lazy `and` evaluation.

-----

> Siblings `next_id` was not set properly for middle-of-the-pack siblings:
> ```
> ~ start
> 
> % Random 1
> % Random 2
> % Random 3
> % Random 4
> 
> => END
> ```
> 
> 1 being the original, its `next_id` was properly set, as well as 4 because of it being the last.
> However 2's `next_id` was still 3, and 3's was 4. So you could have several dialogues being displayed one after the other.

-----

Both have been fixed with this PR.