### PR TITLE
Allow for specifying a response template

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -86,14 +86,14 @@ func type_out() -> void:
 	if get_total_character_count() == 0:
 		self.is_typing = false
 	elif seconds_per_step == 0:
-		_mutation_remaining_mutations()
+		_mutate_remaining_mutations()
 		visible_characters = get_total_character_count()
 		self.is_typing = false
 
 
 ## Stop typing out the text and jump right to the end
 func skip_typing() -> void:
-	_mutation_remaining_mutations()
+	_mutate_remaining_mutations()
 	visible_characters = get_total_character_count()
 	self.is_typing = false
 	skipped_typing.emit()
@@ -147,7 +147,7 @@ func _get_speed(at_index: int) -> float:
 
 
 # Run any inline mutations that haven't been run yet
-func _mutation_remaining_mutations() -> void:
+func _mutate_remaining_mutations() -> void:
 	for i in range(visible_characters, get_total_character_count() + 1):
 		_mutate_inline_mutations(i)
 

--- a/addons/dialogue_manager/dialogue_reponses_menu.gd
+++ b/addons/dialogue_manager/dialogue_reponses_menu.gd
@@ -8,6 +8,9 @@ class_name DialogueResponsesMenu extends VBoxContainer
 signal response_selected(response: DialogueResponse)
 
 
+## Optionally specify a control to duplicate for each response
+@export var response_template: Control
+
 # The list of dialogue responses.
 var _responses: Array = []
 
@@ -17,6 +20,9 @@ func _ready() -> void:
 		if visible and get_menu_items().size() > 0:
 			get_menu_items()[0].grab_focus()
 	)
+
+	if is_instance_valid(response_template):
+		response_template.get_parent().remove_child(response_template)
 
 
 ## Set the list of responses to show.
@@ -31,7 +37,11 @@ func set_responses(next_responses: Array) -> void:
 	# Add new items
 	if _responses.size() > 0:
 		for response in _responses:
-			var item: Button = Button.new()
+			var item: Control
+			if is_instance_valid(response_template):
+				item = response_template.duplicate()
+			else:
+				item = Button.new()
 			item.name = "Response%d" % get_child_count()
 			if not response.is_allowed:
 				item.name = String(item.name) + "Disallowed"

--- a/addons/dialogue_manager/example_balloon/example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/example_balloon.tscn
@@ -122,12 +122,13 @@ offset_bottom = -0.552
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/Responses"]
+[node name="ResponsesMenu" type="VBoxContainer" parent="Balloon/Responses" node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 8
 theme_override_constants/separation = 2
 script = ExtResource("3_72ixx")
+response_template = NodePath("ResponseExample")
 
 [node name="ResponseExample" type="Button" parent="Balloon/Responses/ResponsesMenu"]
 layout_mode = 2


### PR DESCRIPTION
This adds an optional export property to `DialogueResponsesMenu`s for specifying a response template. If provided, the template will be duplicated for each response instead of using the default `Button` control.

Closes #328 