### PR TITLE
Simplify signal handling in C#

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -1,7 +1,6 @@
 using Godot;
 using Godot.Collections;
 using System;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -9,17 +8,88 @@ using System.Threading.Tasks;
 
 namespace DialogueManagerRuntime
 {
+  public enum TranslationSource
+  {
+    None,
+    Guess,
+    CSV,
+    PO
+  }
+
   public partial class DialogueManager : Node
   {
-    [Signal]
-    public delegate void ResolvedEventHandler(Variant value);
+    public delegate void PassedTitleEventHandler(string title);
+    public delegate void GotDialogueEventHandler(DialogueLine dialogueLine);
+    public delegate void MutatedEventHandler(Dictionary mutation);
+    public delegate void DialogueEndedEventHandler(Resource dialogueResource);
+
+    public static PassedTitleEventHandler? PassedTitle;
+    public static GotDialogueEventHandler? GotDialogue;
+    public static MutatedEventHandler? Mutated;
+    public static DialogueEndedEventHandler? DialogueEnded;
+
+    [Signal] public delegate void ResolvedEventHandler(Variant value);
+
+    private static GodotObject? instance;
+    public static GodotObject Instance
+    {
+      get
+      {
+        if (instance == null)
+        {
+          instance = Engine.GetSingleton("DialogueManager");
+        }
+        return instance;
+      }
+    }
 
 
-    private static GodotObject? singleton;
+    public static Godot.Collections.Array GameStates
+    {
+      get => (Godot.Collections.Array)Instance.Get("game_states");
+      set => Instance.Set("game_states", value);
+    }
+
+
+    public static bool IncludeSingletons
+    {
+      get => (bool)Instance.Get("include_singletons");
+      set => Instance.Set("include_singletons", value);
+    }
+
+
+    public static bool IncludeClasses
+    {
+      get => (bool)Instance.Get("include_classes");
+      set => Instance.Set("include_classes", value);
+    }
+
+
+    public static TranslationSource TranslationSource
+    {
+      get => (TranslationSource)(int)Instance.Get("translation_source");
+      set => Instance.Set("translation_source", (int)value);
+    }
+
+
+    public static Func<Node> GetCurrentScene
+    {
+      set => Instance.Set("get_current_scene", Callable.From(value));
+    }
+
+
+    public void Prepare()
+    {
+      Instance.Connect("passed_title", Callable.From((string title) => PassedTitle?.Invoke(title)));
+      Instance.Connect("got_dialogue", Callable.From((RefCounted line) => GotDialogue?.Invoke(new DialogueLine(line))));
+      Instance.Connect("mutated", Callable.From((Dictionary mutation) => Mutated?.Invoke(mutation)));
+      Instance.Connect("dialogue_ended", Callable.From((Resource dialogueResource) => DialogueEnded?.Invoke(dialogueResource)));
+    }
+
 
     public static async Task<GodotObject> GetSingleton()
     {
-      if (singleton != null) return singleton;
+      if (instance != null) return instance;
 
       var tree = Engine.GetMainLoop();
       int x = 0;
@@ -34,19 +104,18 @@ namespace DialogueManagerRuntime
       // If it times out something is wrong
       if (x >= 300)
       {
-        throw new System.Exception("The DialogueManager singleton is missing.");
+        throw new Exception("The DialogueManager singleton is missing.");
       }
 
-      singleton = Engine.GetSingleton("DialogueManager");
-      return singleton;
+      instance = Engine.GetSingleton("DialogueManager");
+      return instance;
     }
 
 
     public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
     {
-      var dialogueManager = Engine.GetSingleton("DialogueManager");
-      dialogueManager.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
-      var result = await dialogueManager.ToSignal(dialogueManager, "bridge_get_next_dialogue_line_completed");
+      Instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+      var result = await Instance.ToSignal(Instance, "bridge_get_next_dialogue_line_completed");
 
       if ((RefCounted)result[0] == null) return null;
 
@@ -56,7 +125,7 @@ namespace DialogueManagerRuntime
 
     public static void ShowExampleDialogueBalloon(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
     {
-      Engine.GetSingleton("DialogueManager").Call("show_example_dialogue_balloon", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+      Instance.Call("show_example_dialogue_balloon", dialogueResource, key, extraGameStates ?? new Array<Variant>());
     }
 
 
@@ -66,13 +135,13 @@ namespace DialogueManagerRuntime
       return info != null;
     }
 
-#nullable disable
     public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
     {
-      MethodInfo info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+      MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
 
       if (info == null) return;
 
+#nullable disable
       // Convert the method args to something reflection can handle
       ParameterInfo[] argTypes = info.GetParameters();
       object[] _args = new object[argTypes.Length];
@@ -99,8 +168,8 @@ namespace DialogueManagerRuntime
         EmitSignal(SignalName.Resolved, value);
       }
     }
-  }
 #nullable enable
+  }
 
 
   public partial class DialogueLine : RefCounted

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -20,6 +20,7 @@ signal bridge_get_next_dialogue_line_completed(line)
 
 const DialogueConstants = preload("./constants.gd")
 const DialogueSettings = preload("./components/settings.gd")
+const DialogueResource = preload("./dialogue_resource.gd")
 const DialogueLine = preload("./dialogue_line.gd")
 const DialogueResponse = preload("./dialogue_response.gd")
 
@@ -87,6 +88,10 @@ func _ready() -> void:
 		var state: Node = get_node_or_null("/root/" + node_name)
 		if state:
 			game_states.append(state)
+
+	# Connect up the C# signals if need be
+	if ResourceLoader.exists("res://addons/dialogue_manager/DialogueManager.cs"):
+		load("res://addons/dialogue_manager/DialogueManager.cs").new().Prepare()
 
 
 ## Step through lines and run any mutations until we either hit some dialogue or the end of the conversation

--- a/docs/CSharp.md
+++ b/docs/CSharp.md
@@ -57,6 +57,43 @@ do AskForName()
 Nathan: Hello {{PlayerName}}!
 ```
 
+## Signals
+
+There are two ways you can connect to the Dialogue Manager signals - using `Connect` + `Callable` or by attaching event handlers.
+
+Using event handlers is the simpler method (but only works on the Dialogue Manager itself):
+
+```csharp
+DialogueManager.DialogueEnded += (Resource dialogueResource) =>
+{
+  // ...
+};
+
+DialogueManager.PassedTitle += (string title) =>
+{
+  // ...
+};
+
+DialogueManager.GotDialogue += (DialogueLine line) =>
+{
+  // ...
+};
+
+DialogueManager.Mutated += (Godot.Collections.Dictionary mutation) =>
+{
+  // ...
+};
+```
+
+If you are using the built-in responses menu node then you'll have to use the `Connect` approach.
+
+```csharp
+responsesMenu.Connect("response_selected", Callable.From((DialogueResponse response) =>
+{
+  // ...
+}));
+```
+
 ## Example
 
 There is a balloon implemented in C# in the **examples** folder of the repository. If you want to have a closer look at it you'll have to clone the repository down because the automatic download ZIP removes the docs and examples folder.

--- a/examples/test_scenes/TestScene.cs
+++ b/examples/test_scenes/TestScene.cs
@@ -19,9 +19,11 @@ public partial class TestScene : Node2D
 
   public async override void _Ready()
   {
-    var dialogueManager = await DialogueManager.GetSingleton();
-
-    dialogueManager.Connect("dialogue_ended", new Callable(this, "OnDialogueEnded"));
+    DialogueManager.DialogueEnded += async (Resource dialogueResource) =>
+    {
+      await ToSignal(GetTree().CreateTimer(0.4), "timeout");
+      GetTree().Quit();
+    };
 
     await ToSignal(GetTree().CreateTimer(0.4), "timeout");
 
@@ -43,12 +45,5 @@ public partial class TestScene : Node2D
     await ToSignal(nameInputDialogue, "confirmed");
     PlayerName = nameInput.Text;
     nameInputDialogue.QueueFree();
-  }
-
-
-  private async void OnDialogueEnded(Resource resource)
-  {
-    await ToSignal(GetTree().CreateTimer(0.4), "timeout");
-    GetTree().Quit();
   }
 }


### PR DESCRIPTION
This simplifies [how signals are handled in C#](https://github.com/nathanhoad/godot_dialogue_manager/blob/efe7da33a1816238f6e65d97895bc51e954780e3/docs/CSharp.md#signals).

You can now do something like:

```csharp
DialogueManager.DialogueEnded += (Resource dialogueResource) =>
{
  // ...
};
```