### PR TITLE
Free response template on balloon close

### DIFF
--- a/addons/dialogue_manager/dialogue_reponses_menu.gd
+++ b/addons/dialogue_manager/dialogue_reponses_menu.gd
@@ -25,6 +25,11 @@ func _ready() -> void:
 		response_template.get_parent().remove_child(response_template)
 
 
+func _exit_tree() -> void:
+	if is_instance_valid(response_template):
+		response_template.free()
+
+
 ## Set the list of responses to show.
 func set_responses(next_responses: Array) -> void:
 	_responses = next_responses


### PR DESCRIPTION
This fixes an issue where the response template was being leaked when the balloon was closed.

Fixes #340 