### PR TITLE
Add a workaround for C# forgetting classes

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -23,6 +23,9 @@ const DialogueSettings = preload("./components/settings.gd")
 const DialogueResource = preload("./dialogue_resource.gd")
 const DialogueLine = preload("./dialogue_line.gd")
 const DialogueResponse = preload("./dialogue_response.gd")
+const DialogueManagerParser = preload("./components/parser.gd")
+const DialogueManagerParseResult = preload("./components/parse_result.gd")
+const ResolvedLineData = preload("./components/resolved_line_data.gd")
 
 
 enum MutationBehaviour {


### PR DESCRIPTION
This adds a workaround for C# sometimes forgetting that some classes exist.