### PR TITLE
Fix: inline conditions not working when chained

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -153,7 +153,6 @@ func get_resolved_line_data(data: Dictionary, extra_game_states: Array = []) -> 
 
 	# Resolve any conditionals and update marker positions as needed
 	var resolved_text: String = ""
-	var shifted_markers_index: int = 0
 	var previous_should_display_character: bool = true
 	var hidden_characters_from_index: int = -1
 	for index in range(markers.text.length()):

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1012,7 +1012,7 @@ func adjust_marker_indices(from: int, to: int, markers: ResolvedLineData) -> voi
 		for index in marker:
 			if index < from:
 				next_marker[index] = marker[index]
-			elif index >= to:
+			elif index > to:
 				next_marker[index - (to - from)] = marker[index]
 		markers.set(key, next_marker)
 
@@ -1022,7 +1022,7 @@ func adjust_marker_indices(from: int, to: int, markers: ResolvedLineData) -> voi
 		var index = mutation[0]
 		if index < from:
 			next_mutations.append(mutation)
-		elif index >= to:
+		elif index > to:
 			next_mutations.append([index - (to - from), mutation[1]])
 	markers.mutations = next_mutations
 

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -223,6 +223,18 @@ Conditions can also be used inline in a dialogue line when wrapped with "[if pre
 Nathan: I have done this [if already_done]once again[/if]
 ```
 
+When using a combination of mutations/speed/pauses and conditions, always use at least one character between a mutation and start or end of a condition block.
+This results in the speed tags not being processed, and it works the same for pauses `[wait=1.0]` and inline mutations `[do something()]`:
+```
+Nathan: I have done this [speed=5][if already_done]once again[/if][speed=10] faster
+Nathan: I have done this [if already_done][speed=5]once again[speed=10][/if] faster
+```
+Do instead:
+```
+Nathan: I have done this[speed=5] [if already_done]once again[/if] [speed=10]faster
+Nathan: I have done this[if already_done] [speed=5]once again[speed=10] [/if]faster
+```
+
 ## Mutations
 
 You can modify state with either a "set" or a "do" line.


### PR DESCRIPTION
Fixes #349.

The logic for markers conditions check has been slightly simplified, especially when it comes to keeping track of the previous character displaying, as well as the current condition block status.

`adjust_marker_indices` has also received a fix:
- when using mutations within a condition block, the function crashed due to accessing `mutation[index]` instead of `mutation[1]`, which is the mutation expression

I have also noticed a weird behavior when using a mix of mutation/wait/speed and conditions: when using the tag right next to the `[if]`/`[/if]` tag: the way markers are processed internally does not allow to tell whether the tag is inside or outside of the block. So I have documented the issue to make sure people are not surprised by the behavior, since it doesn't seem like an easy fix.

This test file now properly works, aside from the issue where you cannot tell if tags right next to the if-tags are inside or outside of them, so they're dropped.
 ```
 Someone: [speed=5]You have {{num_apples}}[wait=0.5][speed=10] [if num_apples == 1]apple[do nothing()][/if][if num_apples > 1]ap[wait=0.5]ples[do nothing()][/if], [speed=5]nice[wait=0.5]! [do nothing()]
: You have {{num_apples}}[if num_apples == 1] [wait=0.5]apple[/if][if num_apples > 1] [wait=0.5]apples[/if]
 ```