### PR TITLE
Reset wait index when starting to type

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -77,11 +77,11 @@ func type_out() -> void:
 	text = dialogue_line.text
 	visible_characters = 0
 	visible_ratio = 0
-	self.is_typing = true
 	_waiting_seconds = 0
+	_last_wait_index = -1
+	_last_mutation_index = -1
 
-	# Text isn't calculated until the next frame
-	await get_tree().process_frame
+	self.is_typing = true
 
 	if get_total_character_count() == 0:
 		self.is_typing = false


### PR DESCRIPTION
This fixes an issue where the wait index wasn't being reset to subsequent `wait` calls were being ignored.

Fixes #353 