### PR TITLE
Fix conjoined conditionals

### DIFF
--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -12,7 +12,7 @@ var regex_comments: RegEx = RegEx.create_from_string("(?:(?>\"(?:\\\\\"|[^\"\\n]
 var regex_mutation: RegEx = RegEx.create_from_string("^\\s*(do|set) (?<mutation>.*)")
 var regex_condition: RegEx = RegEx.create_from_string("^\\s*(if|elif|while|else if) (?<condition>.*)")
 var regex_wcondition: RegEx = RegEx.create_from_string("\\[if (?<condition>((?:[^\\[\\]]*)|(?:\\[(?1)\\]))*?)\\]")
-var regex_wendif: RegEx = RegEx.create_from_string("\\[\\/(if)\\]")
+var regex_wendif: RegEx = RegEx.create_from_string("\\[(\\/if|else)\\]")
 var regex_rgroup: RegEx = RegEx.create_from_string("\\[\\[(?<options>.*?)\\]\\]")
 var regex_endconditions: RegEx = RegEx.create_from_string("^\\s*(endif|else):?\\s*$")
 var regex_tags: RegEx = RegEx.create_from_string("\\[(?<tag>(?!(?:ID:.*)|if)[a-zA-Z_][a-zA-Z0-9_]*)(?:[= ](?<val>[^\\[\\]]+))?\\](?:(?<text>(?!\\[\\/\\k<tag>\\]).*?)?(?<end>\\[\\/\\k<tag>\\]))?")

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1123,7 +1123,6 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var pauses: Dictionary = {}
 	var speeds: Dictionary = {}
 	var mutations: Array[Array] = []
-	var conditions: Dictionary = {}
 	var bbcodes: Array = []
 	var time = null
 
@@ -1133,7 +1132,7 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var accumulaive_length_offset = 0
 	for position in bbcode_positions:
 		# Ignore our own markers
-		if position.code in ["wait", "speed", "/speed", "do", "set", "next", "if", "/if"]:
+		if position.code in ["wait", "speed", "/speed", "do", "set", "next", "if", "else", "/if"]:
 			continue
 
 		bbcodes.append({
@@ -1160,8 +1159,6 @@ func extract_markers(line: String) -> ResolvedLineData:
 		var args = {}
 		if code in ["do", "set"]:
 			args["value"] = extract_mutation("%s %s" % [code, raw_args])
-		elif code == "if":
-			args["value"] = extract_condition(bbcode["bbcode"], true, 0)
 		else:
 			# Could be something like:
 			# 	"=1.0"
@@ -1187,10 +1184,6 @@ func extract_markers(line: String) -> ResolvedLineData:
 				mutations.append([index, args.get("value")])
 			"next":
 				time = args.get("value") if args.has("value") else "0"
-			"if":
-				conditions[index] = args.get("value")
-			"/if":
-				conditions[index] = null
 
 		# Find any BB codes that are after this index and remove the length from their start
 		var length = bbcode.bbcode.length()
@@ -1211,7 +1204,6 @@ func extract_markers(line: String) -> ResolvedLineData:
 		pauses = pauses,
 		speeds = speeds,
 		mutations = mutations,
-		conditions = conditions,
 		time = time
 	})
 
@@ -1246,7 +1238,7 @@ func find_bbcode_positions_in_string(string: String, find_all: bool = true) -> A
 
 		if string[i] == "]":
 			open_brace_count -= 1
-			if open_brace_count == 0:
+			if open_brace_count == 0 and not code in ["if", "else", "/if"]:
 				positions.append({
 					bbcode = bbcode,
 					code = code,

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -18,6 +18,8 @@ var WRAPPED_CONDITION_REGEX: RegEx = RegEx.create_from_string("\\[if (?<conditio
 var REPLACEMENTS_REGEX: RegEx = RegEx.create_from_string("{{(.*?)}}")
 var GOTO_REGEX: RegEx = RegEx.create_from_string("=><? (?<jump_to_title>.*)")
 var INDENT_REGEX: RegEx = RegEx.create_from_string("^\\t+")
+var INLINE_RANDOM_REGEX: RegEx = RegEx.create_from_string("\\[\\[(?<options>.*?)\\]\\]")
+var INLINE_CONDITIONALS_REGEX: RegEx = RegEx.create_from_string("\\[if (?<condition>.+?)\\](?<body>.*?)\\[\\/if\\]")
 
 var TOKEN_DEFINITIONS: Dictionary = {
 	DialogueConstants.TOKEN_FUNCTION: RegEx.create_from_string("^[a-zA-Z_][a-zA-Z_0-9]*\\("),

--- a/addons/dialogue_manager/components/resolved_line_data.gd
+++ b/addons/dialogue_manager/components/resolved_line_data.gd
@@ -4,7 +4,6 @@ var text: String = ""
 var pauses: Dictionary = {}
 var speeds: Dictionary = {}
 var mutations: Array[Array] = []
-var conditions: Dictionary = {}
 var time = null
 
 
@@ -13,5 +12,4 @@ func _init(data: Dictionary) -> void:
 	pauses = data.pauses
 	speeds = data.speeds
 	mutations = data.mutations
-	conditions = data.conditions
 	time = data.time

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -74,7 +74,6 @@ func _init(data: Dictionary = {}) -> void:
 				pauses = data.pauses
 				speeds = data.speeds
 				inline_mutations = data.inline_mutations
-				conditions = data.conditions
 				time = data.time
 				tags = data.tags
 
@@ -89,6 +88,7 @@ func _to_string() -> String:
 		_DialogueConstants.TYPE_MUTATION:
 			return "<DialogueLine mutation>"
 	return ""
+
 
 func get_tag_value(tag_name: String) -> String:
 	var wrapped := "%s=" % tag_name

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -139,20 +139,19 @@ func get_resolved_line_data(data: Dictionary, extra_game_states: Array = []) -> 
 		var value = await resolve(replacement.expression.duplicate(true), extra_game_states)
 		text = text.replace(replacement.value_in_text, str(value))
 
+	var parser: DialogueManagerParser = DialogueManagerParser.new()
+
 	# Resolve random groups
-	var random_regex: RegEx = RegEx.new()
-	random_regex.compile("\\[\\[(?<options>.*?)\\]\\]")
-	for found in random_regex.search_all(text):
+	for found in parser.INLINE_RANDOM_REGEX.search_all(text):
 		var options = found.get_string("options").split("|")
 		text = text.replace("[[%s]]" % found.get_string("options"), options[randi_range(0, options.size() - 1)])
 	# Do a pass on the markers to find any conditionals
-	var parser: DialogueManagerParser = DialogueManagerParser.new()
+
 	var markers: ResolvedLineData = parser.extract_markers(text)
 
 	# Resolve any conditionals and update marker positions as needed
 	var resolved_text: String = markers.text
-	var conditionals_regex: RegEx = RegEx.create_from_string("\\[if (?<condition>.+?)\\](?<body>.*?)\\[\\/if\\]")
-	var conditionals: Array[RegExMatch] = conditionals_regex.search_all(resolved_text)
+	var conditionals: Array[RegExMatch] = parser.INLINE_CONDITIONALS_REGEX.search_all(resolved_text)
 	var replacements: Array = []
 	for conditional in conditionals:
 		var condition_raw: String = conditional.strings[conditional.names.condition]

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -84,7 +84,6 @@ Nathan: [#mood=happy] Oh, Hello!
 
 For this line of dialogue, the `tags` array would be `["mood=happy"]`, and `line.get_tag_value("mood")` would return `"happy"`.
 
-
 ### Randomising lines of dialogue
 
 If you want to pick one from a few lines of dialogue you can mark the line with a `%` at the start like this:
@@ -221,6 +220,12 @@ Conditions can also be used inline in a dialogue line when wrapped with "[if pre
 
 ```
 Nathan: I have done this [if already_done]once again[/if]
+```
+
+For simple this-or-that conditions you can write them like this:
+
+```
+Nathan: You have {{num_apples}} [if num_apples == 1]apple[else]apples[/if], nice!
 ```
 
 ## Mutations


### PR DESCRIPTION
This fixes an issue where conditionals that were right next to each other would fail to execute properly (it also adds inline `[else]`).

Fixes #352 