### PR TITLE
Fix crash in mono if missing dotnet solution file

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -94,7 +94,10 @@ func _ready() -> void:
 
 	# Connect up the C# signals if need be
 	if ResourceLoader.exists("res://addons/dialogue_manager/DialogueManager.cs"):
-		load("res://addons/dialogue_manager/DialogueManager.cs").new().Prepare()
+		var csharp_dialogue_manager = load("res://addons/dialogue_manager/DialogueManager.cs")
+		# Make sure the C# dialogue manager could be loaded
+		if csharp_dialogue_manager != null:
+			csharp_dialogue_manager.new().Prepare()
 
 
 ## Step through lines and run any mutations until we either hit some dialogue or the end of the conversation


### PR DESCRIPTION
This fixes a crash when using the mono version of Godot without a dotnet solution file.