### PR TITLE
Fix POT generation

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -305,6 +305,10 @@ func parse(text: String, path: String) -> Error:
 		elif is_line_empty(raw_line):
 			continue
 
+		# Import line
+		elif is_import_line(raw_line):
+			line["type"] = DialogueConstants.TYPE_IMPORT
+
 		# Regular dialogue
 		else:
 			# Work out any weighted random siblings

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -302,12 +302,8 @@ func parse(text: String, path: String) -> Error:
 
 			continue
 
-		elif is_line_empty(raw_line):
+		elif is_line_empty(raw_line) or is_import_line(raw_line):
 			continue
-
-		# Import line
-		elif is_import_line(raw_line):
-			line["type"] = DialogueConstants.TYPE_IMPORT
 
 		# Regular dialogue
 		else:

--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -38,7 +38,6 @@ const TOKEN_ERROR = "error"
 # Line types
 
 const TYPE_UNKNOWN = "unknown"
-const TYPE_IMPORT = "import"
 const TYPE_RESPONSE = "response"
 const TYPE_TITLE = "title"
 const TYPE_CONDITION = "condition"

--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -38,6 +38,7 @@ const TOKEN_ERROR = "error"
 # Line types
 
 const TYPE_UNKNOWN = "unknown"
+const TYPE_IMPORT = "import"
 const TYPE_RESPONSE = "response"
 const TYPE_TITLE = "title"
 const TYPE_CONDITION = "condition"

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -20,7 +20,7 @@ func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> v
 
 			known_keys.append(character_name)
 
-			msgids_context_plural.append([character_name, "dialogue", ""])
+			msgids_context_plural.append([character_name.replace('"', '\\"'), "dialogue", ""])
 
 	# Add all dialogue lines and responses
 	var dialogue: Dictionary = data.lines

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -33,9 +33,9 @@ func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> v
 		known_keys.append(line.translation_key)
 
 		if line.translation_key == "" or line.translation_key == line.text:
-			msgids_context_plural.append([line.text, "", ""])
+			msgids_context_plural.append([line.text.replace('"', '\\"'), "", ""])
 		else:
-			msgids_context_plural.append([line.text, line.translation_key, ""])
+			msgids_context_plural.append([line.text.replace('"', '\\"'), line.translation_key.replace('"', '\\"'), ""])
 
 
 func _get_recognized_extensions() -> PackedStringArray:


### PR DESCRIPTION
Fixes #366.

Introduces a new type constant to make sure the parser doesn't lump import lines with general dialogue lines.
Uses a small manual quoting on the lines added to the POT files. Godot 4.2 will not double the backslash, and will escape the quotes on its own so it is forward-compatible.