### PR TITLE
Mark response input as handled in examples

### DIFF
--- a/examples/point_n_click_balloon/balloon.gd
+++ b/examples/point_n_click_balloon/balloon.gd
@@ -167,6 +167,7 @@ func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == 1:
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
+		get_viewport().set_input_as_handled()
 		next(dialogue_line.responses[item.get_index()].next_id)
 
 

--- a/examples/point_n_click_balloon/balloon.gd
+++ b/examples/point_n_click_balloon/balloon.gd
@@ -164,10 +164,11 @@ func _on_response_mouse_entered(item: Control) -> void:
 func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 	if "Disallowed" in item.name: return
 
+	get_viewport().set_input_as_handled()
+
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == 1:
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
-		get_viewport().set_input_as_handled()
 		next(dialogue_line.responses[item.get_index()].next_id)
 
 

--- a/examples/portraits_balloon/balloon.gd
+++ b/examples/portraits_balloon/balloon.gd
@@ -187,11 +187,11 @@ func _on_response_mouse_entered(item: Control) -> void:
 func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 	if "Disallowed" in item.name: return
 
+	get_viewport().set_input_as_handled()
+
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == 1:
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
-		# When there are no response options
-		get_viewport().set_input_as_handled()
 		next(dialogue_line.responses[item.get_index()].next_id)
 
 

--- a/examples/visual_novel_balloon/balloon.gd
+++ b/examples/visual_novel_balloon/balloon.gd
@@ -204,11 +204,12 @@ func _on_response_mouse_entered(item: Control) -> void:
 func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 	if "Disallowed" in item.name: return
 
+	get_viewport().set_input_as_handled()
+
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == 1:
 		responses_menu.modulate.a = 0.0
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
-		get_viewport().set_input_as_handled() # When there are no response options 
 		responses_menu.modulate.a = 0.0
 		next(dialogue_line.responses[item.get_index()].next_id)
 

--- a/examples/visual_novel_balloon/balloon.gd
+++ b/examples/visual_novel_balloon/balloon.gd
@@ -208,6 +208,7 @@ func _on_response_gui_input(event: InputEvent, item: Control) -> void:
 		responses_menu.modulate.a = 0.0
 		next(dialogue_line.responses[item.get_index()].next_id)
 	elif event.is_action_pressed("ui_accept") and item in get_responses():
+		get_viewport().set_input_as_handled() # When there are no response options 
 		responses_menu.modulate.a = 0.0
 		next(dialogue_line.responses[item.get_index()].next_id)
 


### PR DESCRIPTION
Hi Nathan,

Found and fixed a small bug. The "ui_accept" input is never marked as handled after the user chooses a "response" which itself has no responses. On my end, dialogue was getting re-entered in a loop as the same "unhandled" input exited dialogue but remained unhandled, and so was handled by my game's unhandled-input-handler.

The fix was simple. The same line of code that was added to `_on_balloon_gui_input_` function, for what I imagine what a similar problem, is added to `_on_response_gui_input_`. 

I added the fix to the 3 examples I could find. Sadly, Github's web interface insisted each change was a commit. If you want to merge, please squash them if you know how!