### PR TITLE
Stop finished_typing emitting too soon

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -83,6 +83,9 @@ func type_out() -> void:
 
 	self.is_typing = true
 
+	# Allow typing listeners a chance to connect
+	await get_tree().process_frame
+
 	if get_total_character_count() == 0:
 		self.is_typing = false
 	elif seconds_per_step == 0:


### PR DESCRIPTION
This fixes an issue where setting the `DialogueLabel` seconds per step to 0 would result in the `finished_typing` signal emitting before it could be connected.