### PR TITLE
Add `show_dialogue_balloon()` method

### DIFF
--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -16,7 +16,8 @@ const DEFAULT_SETTINGS = {
 	include_all_responses = false,
 	ignore_missing_state_values = false,
 	custom_test_scene_path = preload("../test_scene.tscn").resource_path,
-	default_csv_locale = "en"
+	default_csv_locale = "en",
+	balloon_path = ""
 }
 
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -262,15 +262,26 @@ func create_resource_from_text(text: String) -> Resource:
 
 ## Show the example balloon
 func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer:
-	var ExampleBalloonScene = load("res://addons/dialogue_manager/example_balloon/example_balloon.tscn")
-	var SmallExampleBalloonScene = load("res://addons/dialogue_manager/example_balloon/small_example_balloon.tscn")
-
-	var is_small_window: bool = ProjectSettings.get_setting("display/window/size/viewport_width") < 400
-	var balloon: Node = (SmallExampleBalloonScene if is_small_window else ExampleBalloonScene).instantiate()
+	var balloon: Node = load(_get_example_balloon_path()).instantiate()
 	get_current_scene.call().add_child(balloon)
 	balloon.start(resource, title, extra_game_states)
 
 	return balloon
+
+
+## Show the configured dialogue balloon
+func show_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node:
+	var balloon: Node = load(DialogueSettings.get_setting("balloon_path", _get_example_balloon_path())).instantiate()
+	get_current_scene.call().add_child(balloon)
+	balloon.start(resource, title, extra_game_states)
+	return balloon
+
+
+# Get the path to the example balloon
+func _get_example_balloon_path() -> String:
+	var is_small_window: bool = ProjectSettings.get_setting("display/window/size/viewport_width") < 400
+	var balloon_path: String = "/example_balloon/small_example_balloon.tscn" if is_small_window else "/example_balloon/example_balloon.tscn"
+	return get_script().resource_path.get_base_dir() + balloon_path
 
 
 ### Dotnet bridge

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -138,6 +138,15 @@ msgstr "Show in FileSystem"
 msgid "settings.revert_to_default_test_scene"
 msgstr "Revert to default test scene"
 
+msgid "settings.default_balloon_hint"
+msgstr "Custom balloon to use when calling \"DialogueManager.show_balloon()\""
+
+msgid "settings.revert_to_default_balloon"
+msgstr "Revert to default balloon"
+
+msgid "settings.default_balloon_path"
+msgstr "<example balloon>"
+
 msgid "settings.autoload"
 msgstr "Autoload"
 
@@ -168,8 +177,8 @@ msgstr "Skip over missing state value errors (not recommended)"
 msgid "settings.custom_test_scene"
 msgstr "Custom test scene (must extend BaseDialogueTestScene)"
 
-msgid "settings.default_csv_local"
-msgstr "Default CSV Local"
+msgid "settings.default_csv_locale"
+msgstr "Default CSV Locale"
 
 msgid "settings.states_shortcuts"
 msgstr "State Shortcuts"

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -128,6 +128,15 @@ msgstr ""
 msgid "settings.revert_to_default_test_scene"
 msgstr ""
 
+msgid "settings.default_balloon_hint"
+msgstr ""
+
+msgid "settings.revert_to_default_balloon"
+msgstr ""
+
+msgid "settings.default_balloon_path"
+msgstr ""
+
 msgid "settings.autoload"
 msgstr ""
 
@@ -158,7 +167,7 @@ msgstr ""
 msgid "settings.custom_test_scene"
 msgstr ""
 
-msgid "settings.default_csv_local"
+msgid "settings.default_csv_locale"
 msgstr ""
 
 msgid "settings.states_shortcuts"

--- a/addons/dialogue_manager/l10n/zh.po
+++ b/addons/dialogue_manager/l10n/zh.po
@@ -164,7 +164,7 @@ msgstr "忽略全局变量缺失错误（不建议）"
 msgid "settings.custom_test_scene"
 msgstr "自定义测试场景（必须继承自BaseDialogueTestScene）"
 
-msgid "settings.default_csv_local"
+msgid "settings.default_csv_locale"
 msgstr "默认 CSV 区域格式"
 
 msgid "settings.states_shortcuts"

--- a/addons/dialogue_manager/l10n/zh_TW.po
+++ b/addons/dialogue_manager/l10n/zh_TW.po
@@ -164,7 +164,7 @@ msgstr "忽略全局變量缺失錯誤（不建議）"
 msgid "settings.custom_test_scene"
 msgstr "自訂測試場景（必須繼承自BaseDialogueTestScene）"
 
-msgid "settings.default_csv_local"
+msgid "settings.default_csv_locale"
 msgstr "預設 CSV 區域格式"
 
 msgid "settings.states_shortcuts"

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -236,6 +236,8 @@ func _copy_dialogue_balloon() -> void:
 		get_editor_interface().get_resource_filesystem().scan()
 		get_editor_interface().get_file_system_dock().call_deferred("navigate_to_path", path + "/balloon.tscn")
 
+		DialogueSettings.set_setting("balloon_path", path + "/balloon.tscn")
+
 		directory_dialog.queue_free()
 	)
 	get_editor_interface().get_base_control().add_child(directory_dialog)

--- a/addons/dialogue_manager/test_scene.gd
+++ b/addons/dialogue_manager/test_scene.gd
@@ -17,7 +17,7 @@ func _ready():
 	# enabled in settings will throw a compiler error here so I'm using get_singleton instead.
 	var dialogue_manager = Engine.get_singleton("DialogueManager")
 	dialogue_manager.dialogue_ended.connect(_on_dialogue_ended)
-	dialogue_manager.show_example_dialogue_balloon(resource, title)
+	dialogue_manager.show_dialogue_balloon(resource, title)
 
 
 func _enter_tree() -> void:

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -9,6 +9,12 @@ const DialogueConstants = preload("../constants.gd")
 const DialogueSettings = preload("../components/settings.gd")
 
 
+enum PathTarget {
+	CustomTestScene,
+	Balloon
+}
+
+
 # Editor
 @onready var new_template_button: CheckBox = $Editor/NewTemplateButton
 @onready var missing_translations_button: CheckBox = $Editor/MissingTranslationsButton
@@ -17,18 +23,23 @@ const DialogueSettings = preload("../components/settings.gd")
 @onready var test_scene_path_input: LineEdit = $Editor/CustomTestScene/TestScenePath
 @onready var revert_test_scene_button: Button = $Editor/CustomTestScene/RevertTestScene
 @onready var load_test_scene_button: Button = $Editor/CustomTestScene/LoadTestScene
+@onready var custom_test_scene_file_dialog: FileDialog = $CustomTestSceneFileDialog
 @onready var default_csv_locale: LineEdit = $Editor/DefaultCSVLocale
 
 # Runtime
 @onready var include_all_responses_button: CheckBox = $Runtime/IncludeAllResponsesButton
 @onready var ignore_missing_state_values: CheckBox = $Runtime/IgnoreMissingStateValues
+@onready var balloon_path_input: LineEdit = $Runtime/CustomBalloon/BalloonPath
+@onready var revert_balloon_button: Button = $Runtime/CustomBalloon/RevertBalloonPath
+@onready var load_balloon_button: Button = $Runtime/CustomBalloon/LoadBalloonPath
 @onready var states_title: Label = $Runtime/StatesTitle
 @onready var globals_list: Tree = $Runtime/GlobalsList
-@onready var custom_test_scene_file_dialog: FileDialog = $CustomTestSceneFileDialog
 
 var editor_plugin: EditorPlugin
 var all_globals: Dictionary = {}
 var enabled_globals: Array = []
+var path_target: PathTarget = PathTarget.CustomTestScene
+
 var _default_test_scene_path: String = preload("../test_scene.tscn").resource_path
 
 
@@ -39,10 +50,11 @@ func _ready() -> void:
 	characters_translations_button.text = DialogueConstants.translate("settings.characters_translations")
 	wrap_lines_button.text = DialogueConstants.translate("settings.wrap_long_lines")
 	$Editor/CustomTestSceneLabel.text = DialogueConstants.translate("settings.custom_test_scene")
-	$Editor/DefaultCSVLocaleLabel.text = DialogueConstants.translate("settings.default_csv_local")
+	$Editor/DefaultCSVLocaleLabel.text = DialogueConstants.translate("settings.default_csv_locale")
 
 	include_all_responses_button.text = DialogueConstants.translate("settings.include_failed_responses")
 	ignore_missing_state_values.text = DialogueConstants.translate("settings.ignore_missing_state_values")
+	$Runtime/CustomBalloonLabel.text = DialogueConstants.translate("settings.default_balloon_hint")
 	states_title.text = DialogueConstants.translate("settings.states_shortcuts")
 	$Runtime/StatesMessage.text = DialogueConstants.translate("settings.states_message")
 	$Runtime/StatesHint.text = DialogueConstants.translate("settings.states_hint")
@@ -54,6 +66,13 @@ func prepare() -> void:
 	revert_test_scene_button.icon = get_theme_icon("RotateLeft", "EditorIcons")
 	revert_test_scene_button.tooltip_text = DialogueConstants.translate("settings.revert_to_default_test_scene")
 	load_test_scene_button.icon = get_theme_icon("Load", "EditorIcons")
+
+	var balloon_path: String = DialogueSettings.get_setting("balloon_path", "")
+	balloon_path_input.placeholder_text = balloon_path if balloon_path != "" else DialogueConstants.translate("settings.default_balloon_path")
+	revert_balloon_button.visible = balloon_path != ""
+	revert_balloon_button.icon = get_theme_icon("RotateLeft", "EditorIcons")
+	revert_balloon_button.tooltip_text = DialogueConstants.translate("settings.revert_to_default_balloon")
+	load_balloon_button.icon = get_theme_icon("Load", "EditorIcons")
 
 	var scale: float = editor_plugin.get_editor_interface().get_editor_scale()
 	custom_test_scene_file_dialog.min_size = Vector2(600, 500) * scale
@@ -150,13 +169,21 @@ func _on_revert_test_scene_pressed() -> void:
 
 
 func _on_load_test_scene_pressed() -> void:
+	path_target = PathTarget.CustomTestScene
 	custom_test_scene_file_dialog.popup_centered()
 
 
 func _on_custom_test_scene_file_dialog_file_selected(path: String) -> void:
-	DialogueSettings.set_setting("custom_test_scene_path", path)
-	test_scene_path_input.placeholder_text = path
-	revert_test_scene_button.visible = test_scene_path_input.placeholder_text != _default_test_scene_path
+	match path_target:
+		PathTarget.CustomTestScene:
+			DialogueSettings.set_setting("custom_test_scene_path", path)
+			test_scene_path_input.placeholder_text = path
+			revert_test_scene_button.visible = test_scene_path_input.placeholder_text != _default_test_scene_path
+
+		PathTarget.Balloon:
+			DialogueSettings.set_setting("balloon_path", path)
+			balloon_path_input.placeholder_text = path
+			revert_balloon_button.visible = balloon_path_input.placeholder_text != ""
 
 
 func _on_ignore_missing_state_values_toggled(button_pressed: bool) -> void:
@@ -165,3 +192,14 @@ func _on_ignore_missing_state_values_toggled(button_pressed: bool) -> void:
 
 func _on_default_csv_locale_text_changed(new_text: String) -> void:
 	DialogueSettings.set_setting("default_csv_locale", new_text)
+
+
+func _on_revert_balloon_path_pressed() -> void:
+	DialogueSettings.set_setting("balloon_path", "")
+	balloon_path_input.placeholder_text = DialogueConstants.translate("settings.default_balloon_path")
+	revert_balloon_button.visible = DialogueSettings.get_setting("balloon_path", "") != ""
+
+
+func _on_load_balloon_path_pressed() -> void:
+	path_target = PathTarget.Balloon
+	custom_test_scene_file_dialog.popup_centered()

--- a/addons/dialogue_manager/views/settings_view.tscn
+++ b/addons/dialogue_manager/views/settings_view.tscn
@@ -75,7 +75,6 @@ layout_mode = 2
 
 [node name="DefaultCSVLocaleLabel" type="Label" parent="Editor"]
 layout_mode = 2
-text = "Default CSV Locale"
 
 [node name="DefaultCSVLocale" type="LineEdit" parent="Editor"]
 layout_mode = 2
@@ -93,6 +92,33 @@ layout_mode = 2
 text = "Skip over missing state value errors (not recommended)"
 
 [node name="HSeparator" type="HSeparator" parent="Runtime"]
+layout_mode = 2
+
+[node name="CustomBalloonLabel" type="Label" parent="Runtime"]
+layout_mode = 2
+text = "Custom balloon to use when calling \"DialogueManager.show_balloon()\""
+
+[node name="CustomBalloon" type="HBoxContainer" parent="Runtime"]
+layout_mode = 2
+
+[node name="BalloonPath" type="LineEdit" parent="Runtime/CustomBalloon"]
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 0
+editable = false
+shortcut_keys_enabled = false
+middle_mouse_paste_enabled = false
+
+[node name="RevertBalloonPath" type="Button" parent="Runtime/CustomBalloon"]
+visible = false
+layout_mode = 2
+tooltip_text = "Revert to default test scene"
+flat = true
+
+[node name="LoadBalloonPath" type="Button" parent="Runtime/CustomBalloon"]
+layout_mode = 2
+
+[node name="HSeparator2" type="HSeparator" parent="Runtime"]
 layout_mode = 2
 
 [node name="StatesTitle" type="Label" parent="Runtime"]
@@ -135,6 +161,8 @@ filters = PackedStringArray("*.tscn ; Scene")
 [connection signal="text_changed" from="Editor/DefaultCSVLocale" to="." method="_on_default_csv_locale_text_changed"]
 [connection signal="toggled" from="Runtime/IncludeAllResponsesButton" to="." method="_on_include_all_responses_button_toggled"]
 [connection signal="toggled" from="Runtime/IgnoreMissingStateValues" to="." method="_on_ignore_missing_state_values_toggled"]
+[connection signal="pressed" from="Runtime/CustomBalloon/RevertBalloonPath" to="." method="_on_revert_balloon_path_pressed"]
+[connection signal="pressed" from="Runtime/CustomBalloon/LoadBalloonPath" to="." method="_on_load_balloon_path_pressed"]
 [connection signal="button_clicked" from="Runtime/GlobalsList" to="." method="_on_globals_list_button_clicked"]
 [connection signal="item_selected" from="Runtime/GlobalsList" to="." method="_on_globals_list_item_selected"]
 [connection signal="file_selected" from="CustomTestSceneFileDialog" to="." method="_on_custom_test_scene_file_dialog_file_selected"]

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,7 +11,14 @@
 
 ### Methods
 
-#### `func get_next_dialogue_line(resource: DialogueResource, key: String = "0", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine`
+#### `func show_dialogue_balloon(resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> Node`
+
+Opens the dialogue balloon configured in settings (or the example balloon if none has been set).
+
+Returns the balloon's base node in case you want to `queue_free()` it yourself.
+
+
+#### `func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine`
 
 **Must be used with `await`.**
 
@@ -39,7 +46,7 @@ Pass an array of nodes as `extra_game_states` in order to temporarily add to the
 
 You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases you should leave this as the default. _The example balloon only supports `Wait`_.
 
-#### `func show_example_dialogue_balloon(resource: DialoueResource, title: String = "0", extra_game_states: Array = []) -> CanvasLayer`
+#### `func show_example_dialogue_balloon(resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer`
 
 Opens the example balloon.
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -14,6 +14,10 @@
 - `Include responses with failed conditions` will include responses that failed their condition check in the list of responses attached to a given line.
 - `Skip over missing state value errors` will let you run dialogue and ignore any errors that occur when you reference state values that don't exist.
 
+### Custom balloon
+
+You can configure a default balloon to show when calling [`DialogueManager.show_dialogue_balloon()`](./API.md#func-show_dialogue_balloonresource-dialoueresource-title-string--0-extra_game_states-array-----node). This balloon will also be used when testing dialogue from the dialogue editor.
+
 ### Globals shortcuts
 
 The dialogue runtime itself is stateless, meaning it looks to your game to provide values for variables and for methods to run. At run time, the dialogue manager will check the current scene first and then check any globals.

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -1,8 +1,8 @@
 # Using dialogue in your game
 
-It's up to you to implement the actual dialogue rendering and input control but there are [a few example balloons](Example_Balloons.md) included to get you started.
+The simplest way to show dialogue in your game is to call [`DialogueManager.show_dialogue_balloon(resource, title)`](./API.md#func-show_dialogue_balloonresource-dialoueresource-title-string--0-extra_game_states-array-----node) with a dialogue resource and a title to start from. This will show the example balloon by default but you can configure it in [Settings](./Settings.md) to show your custom balloon.
 
-To use the built-in example balloon you can call [`DialogueManager.show_example_dialogue_balloon(resource, title)`](API.md) with a dialogue resource and the title you want to start from.
+It's up to you to implement/customise any dialogue rendering and input control to match your game but there are [a few example balloons](Example_Balloons.md) included to get you started with some of the more common things.
 
 Once you get to the stage of building your own balloon you'll need to know how to get a line of dialogue and how to use the dialogue label node.
 


### PR DESCRIPTION
This adds a [`show_dialogue_balloon`](https://github.com/nathanhoad/godot_dialogue_manager/blob/ac819bc0168732d43a93bb98377ec3b5ae2a7909/docs/API.md#func-show_dialogue_balloonresource-dialoueresource-title-string---extra_game_states-array-----node) method to the Dialogue Manager which can be configured in settings to show your custom balloon. This is essentially a shortcut to implementing a method that adds the balloon to the scene tree. If you need more complicated logic then it's still recommended to implement it yourself.