### PR TITLE
Set null value of time from null to ""

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1159,7 +1159,7 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var speeds: Dictionary = {}
 	var mutations: Array[Array] = []
 	var bbcodes: Array = []
-	var time:String = ""
+	var time: String = ""
 
 	# Extract all of the BB codes so that we know the actual text (we could do this easier with
 	# a RichTextLabel but then we'd need to await idle_frame which is annoying)

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1159,7 +1159,7 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var speeds: Dictionary = {}
 	var mutations: Array[Array] = []
 	var bbcodes: Array = []
-	var time = null
+	var time:String = ""
 
 	# Extract all of the BB codes so that we know the actual text (we could do this easier with
 	# a RichTextLabel but then we'd need to await idle_frame which is annoying)

--- a/addons/dialogue_manager/components/resolved_line_data.gd
+++ b/addons/dialogue_manager/components/resolved_line_data.gd
@@ -4,7 +4,7 @@ var text: String = ""
 var pauses: Dictionary = {}
 var speeds: Dictionary = {}
 var mutations: Array[Array] = []
-var time:String = ""
+var time: String = ""
 
 
 func _init(data: Dictionary) -> void:

--- a/addons/dialogue_manager/components/resolved_line_data.gd
+++ b/addons/dialogue_manager/components/resolved_line_data.gd
@@ -4,7 +4,7 @@ var text: String = ""
 var pauses: Dictionary = {}
 var speeds: Dictionary = {}
 var mutations: Array[Array] = []
-var time = null
+var time:String = ""
 
 
 func _init(data: Dictionary) -> void:

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -45,7 +45,7 @@ var responses: Array[DialogueResponse] = []
 var extra_game_states: Array = []
 
 ## How long to show this line before advancing to the next. Either a float (of seconds), [code]"auto"[/code], or [code]null[/code].
-var time = null
+var time:String = ""
 
 ## Any #tags that were included in the line
 var tags: PackedStringArray = []

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -45,7 +45,7 @@ var responses: Array[DialogueResponse] = []
 var extra_game_states: Array = []
 
 ## How long to show this line before advancing to the next. Either a float (of seconds), [code]"auto"[/code], or [code]null[/code].
-var time:String = ""
+var time: String = ""
 
 ## Any #tags that were included in the line
 var tags: PackedStringArray = []

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -52,7 +52,7 @@ var dialogue_line: DialogueLine:
 		if dialogue_line.responses.size() > 0:
 			balloon.focus_mode = Control.FOCUS_NONE
 			responses_menu.show()
-		elif dialogue_line.time != null:
+		elif dialogue_line.time != "":
 			var time = dialogue_line.text.length() * 0.02 if dialogue_line.time == "auto" else dialogue_line.time.to_float()
 			await get_tree().create_timer(time).timeout
 			next(dialogue_line.next_id)

--- a/examples/portraits_balloon/balloon.gd
+++ b/examples/portraits_balloon/balloon.gd
@@ -76,7 +76,7 @@ var dialogue_line: DialogueLine:
 		if dialogue_line.responses.size() > 0:
 			responses_menu.modulate.a = 1
 			configure_menu()
-		elif dialogue_line.time != null:
+		elif dialogue_line.time != "":
 			var time = dialogue_line.text.length() * 0.02 if dialogue_line.time == "auto" else dialogue_line.time.to_float()
 			await get_tree().create_timer(time).timeout
 			next(dialogue_line.next_id)

--- a/examples/visual_novel_balloon/balloon.gd
+++ b/examples/visual_novel_balloon/balloon.gd
@@ -66,7 +66,7 @@ var dialogue_line: DialogueLine:
 		if dialogue_line.responses.size() > 0:
 			responses_menu.modulate.a = 1
 			configure_menu()
-		elif dialogue_line.time != null:
+		elif dialogue_line.time != "":
 			var time = dialogue_line.text.length() * 0.02 if dialogue_line.time == "auto" else dialogue_line.time.to_float()
 			await get_tree().create_timer(time).timeout
 			next(dialogue_line.next_id)


### PR DESCRIPTION
When 'Project Setting -> GDScript -> Unsafe Cast' enabled, the `DialogueLine::time` is a variant, the cast from variant to String will lead to a warn.
To keep the variable type of the `DialogueLine::time` consistent throughout, the initial value of time is set to the empty string "".