### PR TITLE
Fix compiler issue with "not" keyword

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -42,12 +42,12 @@ var TOKEN_DEFINITIONS: Dictionary = {
 	DialogueConstants.TOKEN_COMMA: RegEx.create_from_string("^,"),
 	DialogueConstants.TOKEN_DOT: RegEx.create_from_string("^\\."),
 	DialogueConstants.TOKEN_STRING: RegEx.create_from_string("^(\".*?\"|\'.*?\')"),
+	DialogueConstants.TOKEN_NOT: RegEx.create_from_string("^(not( |$)|!)"),
+	DialogueConstants.TOKEN_AND_OR: RegEx.create_from_string("^(and|or)( |$)"),
 	DialogueConstants.TOKEN_VARIABLE: RegEx.create_from_string("^[a-zA-Z_][a-zA-Z_0-9]*"),
 	DialogueConstants.TOKEN_COMMENT: RegEx.create_from_string("^#.*"),
 	DialogueConstants.TOKEN_CONDITION: RegEx.create_from_string("^(if|elif|else)"),
-	DialogueConstants.TOKEN_BOOL: RegEx.create_from_string("^(true|false)"),
-	DialogueConstants.TOKEN_NOT: RegEx.create_from_string("^(not( |$)|!)"),
-	DialogueConstants.TOKEN_AND_OR: RegEx.create_from_string("^(and|or)( |$)")
+	DialogueConstants.TOKEN_BOOL: RegEx.create_from_string("^(true|false)")
 }
 
 var WEIGHTED_RANDOM_SIBLINGS_REGEX: RegEx = RegEx.create_from_string("^\\%(?<weight>[\\d.]+)? ")


### PR DESCRIPTION
This rearranges the compiler tokens to make sure "not" is processed before variables.

Fixes #385 