### PR TITLE
Ignore C# until Solution file exists

### DIFF
--- a/addons/dialogue_manager/components/settings.gd
+++ b/addons/dialogue_manager/components/settings.gd
@@ -17,7 +17,8 @@ const DEFAULT_SETTINGS = {
 	ignore_missing_state_values = false,
 	custom_test_scene_path = preload("../test_scene.tscn").resource_path,
 	default_csv_locale = "en",
-	balloon_path = ""
+	balloon_path = "",
+	has_dotnet_solution = false
 }
 
 
@@ -36,6 +37,8 @@ static func prepare() -> void:
 			var value = ProjectSettings.get_setting("dialogue_manager/%s" % key)
 			ProjectSettings.set_setting("dialogue_manager/%s" % key, null)
 			set_setting(key, value)
+
+	ProjectSettings.set_as_internal("dialogue_manager/general/has_dotnet_solution", true)
 
 	# Set up defaults
 	for setting in DEFAULT_SETTINGS:

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -101,6 +101,13 @@ func _apply_changes() -> void:
 
 
 func _build() -> bool:
+	# If this is the dotnet Godot then we need to check if the solution file exists
+	if ProjectSettings.has_setting("dotnet/project/solution_directory"):
+		var directory: String = ProjectSettings.get("dotnet/project/solution_directory")
+		var file_name: String = ProjectSettings.get("dotnet/project/assembly_name")
+		var has_dotnet_solution: bool = FileAccess.file_exists("res://%s/%s.sln" % [directory, file_name])
+		DialogueSettings.set_setting("has_dotnet_solution", has_dotnet_solution)
+
 	# Ignore errors in other files if we are just running the test scene
 	if DialogueSettings.get_user_value("is_running_test_scene", true): return true
 


### PR DESCRIPTION
This adds a build-time check for the dotnet solution file so that we know when to ignore C#.

Fixes #388 