### PR TITLE
Add get_tag_value() to DialogueResponse

### DIFF
--- a/addons/dialogue_manager/dialogue_response.gd
+++ b/addons/dialogue_manager/dialogue_response.gd
@@ -44,3 +44,11 @@ func _init(data: Dictionary = {}) -> void:
 
 func _to_string() -> String:
 	return "<DialogueResponse text=\"%s\">" % text
+
+
+func get_tag_value(tag_name: String) -> String:
+	var wrapped := "%s=" % tag_name
+	for t in tags:
+		if t.begins_with(wrapped):
+			return t.replace(wrapped, "").strip_edges()
+	return ""


### PR DESCRIPTION
Unifying the interface for both `DialogueLine` and `DialogueResponse` when it comes to tags.
Will allow people to get the tag value within the `ResponsesMenu`.