### PR TITLE
Allow response templates to accept whole response

### DIFF
--- a/addons/dialogue_manager/dialogue_reponses_menu.gd
+++ b/addons/dialogue_manager/dialogue_reponses_menu.gd
@@ -49,7 +49,14 @@ func set_responses(next_responses: Array) -> void:
 			if not response.is_allowed:
 				item.name = String(item.name) + "Disallowed"
 				item.disabled = true
-			item.text = response.text
+
+			# If the item has a response property then use that
+			if "response" in item:
+				item.response = response
+			# Otherwise assume we can just set the text
+			else:
+				item.text = response.text
+
 			add_child(item)
 
 		_configure_focus()


### PR DESCRIPTION
This allows for more custom response templates when using the `DialogueResponsesMenu` node. If the template has a `response` property then it will be given the whole response object.