### PR TITLE
Improve DialogueLabel flexibliity

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -1,7 +1,12 @@
 @icon("./assets/icon.svg")
 
+@tool
 ## A RichTextLabel specifically for use with [b]Dialogue Manager[/b] dialogue.
 class_name DialogueLabel extends RichTextLabel
+
+
+const DEFAULT_SECONDS_PER_STEP: float = 0.02
+const DEFAULT_SECONDS_PER_PAUSE_STEP: float = DEFAULT_SECONDS_PER_STEP * 15
 
 
 ## Emitted for each letter typed out.
@@ -18,13 +23,15 @@ signal finished_typing()
 
 
 ## The action to press to skip typing.
-@export var skip_action: String = "ui_cancel"
+@export var skip_action: StringName = &"ui_cancel"
 
 ## The speed with which the text types out.
-@export var seconds_per_step: float = 0.02
+@export var seconds_per_step: float = DEFAULT_SECONDS_PER_STEP
 
 ## Automatically have a brief pause when these characters are encountered.
 @export var pause_at_characters: String = ".?!"
+
+@export var seconds_per_pause_step: float = DEFAULT_SECONDS_PER_PAUSE_STEP
 
 
 ## The current line of dialogue.
@@ -67,7 +74,7 @@ func _process(delta: float) -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if self.is_typing and visible_ratio < 1 and event.is_action_pressed(skip_action):
+	if self.is_typing and visible_ratio < 1 and InputMap.has_action(skip_action) and event.is_action_pressed(skip_action):
 		get_viewport().set_input_as_handled()
 		skip_typing()
 

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -31,6 +31,7 @@ signal finished_typing()
 ## Automatically have a brief pause when these characters are encountered.
 @export var pause_at_characters: String = ".?!"
 
+## The amount of time to pause when exposing a character in pause_at_characters.
 @export var seconds_per_pause_step: float = DEFAULT_SECONDS_PER_PAUSE_STEP
 
 

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -31,7 +31,7 @@ signal finished_typing()
 ## Automatically have a brief pause when these characters are encountered.
 @export var pause_at_characters: String = ".?!"
 
-## The amount of time to pause when exposing a character in pause_at_characters.
+## The amount of time to pause when exposing a character present in pause_at_characters.
 @export var seconds_per_pause_step: float = DEFAULT_SECONDS_PER_PAUSE_STEP
 
 
@@ -123,7 +123,7 @@ func _type_next(delta: float, seconds_needed: float) -> void:
 
 	# Pause on characters like "."
 	if _should_auto_pause():
-		additional_waiting_seconds += seconds_per_step * 15
+		additional_waiting_seconds += seconds_per_pause_step
 
 	# Pause at literal [wait] directives
 	if _last_wait_index != visible_characters and additional_waiting_seconds > 0:

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,9 +60,10 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 
 ### Exports
 
-- `skip_action: String = "ui_cancel"` - the action to press to skip typing.
-- `seconds_per_step: float = 0.02` - the speed with which the text types out.
-- `start_with_full_height: bool = true` - when off, the label will grow in height as the text types out.
+- `skip_action: StringName = &"ui_cancel"` - the action to press to skip typing, if any.
+- `seconds_per_step: float = DEFAULT_SECONDS_PER_STEP` - the speed with which the text types out.
+- `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
+- `seconds_per_pause_step: float = DEFAULT_SECONDS_PER_PAUSE_STEP` - the amount of time to pause when exposing a character present in pause_at_characters.
 
 ### Signals
 
@@ -76,3 +77,8 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 #### `func type_out() -> void`
 
 Starts typing out the text of the label.
+
+#### `func skip_typing() -> void`
+
+Stop typing out the text and jump right to the end.
+Automatically called when skip_action is pressed.


### PR DESCRIPTION
Allow the user to set the length of pauses, don't spit an error when the skip input action isn't found, and run the DialogueLabel script in-editor.