### PR TITLE
Allow escaping bracket literals

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1161,6 +1161,17 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var bbcodes: Array = []
 	var time: String = ""
 
+	# Remove any escaped brackets (ie. "\[")
+	var escaped_open_brackets: PackedInt32Array = []
+	var escaped_close_brackets: PackedInt32Array = []
+	for i in range(0, text.length() - 1):
+		if text.substr(i, 2) == "\\[":
+			text = text.erase(i, 2).insert(i, "!")
+			escaped_open_brackets.append(i)
+		elif text.substr(i, 2) == "\\]":
+			text = text.erase(i, 2).insert(i, "!")
+			escaped_close_brackets.append(i)
+
 	# Extract all of the BB codes so that we know the actual text (we could do this easier with
 	# a RichTextLabel but then we'd need to await idle_frame which is annoying)
 	var bbcode_positions = find_bbcode_positions_in_string(text)
@@ -1233,6 +1244,12 @@ func extract_markers(line: String) -> ResolvedLineData:
 	# Put the BB Codes back in
 	for bb in bbcodes:
 		text = text.insert(bb.start, bb.bbcode)
+
+	# Put the escaped brackets back in
+	for index in escaped_open_brackets:
+		text = text.erase(index, 1).insert(index, "[")
+	for index in escaped_close_brackets:
+		text = text.erase(index, 1).insert(index, "]")
 
 	return ResolvedLineData.new({
 		text = text,

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -68,6 +68,8 @@ If you use the `DialogueLabel` node then you can also make use of the `[wait=N]`
 
 There is also a `[next]` code that you can use to signify that a line should be auto advanced. If given no arguments it will auto advance immediately after the text has typed out. If given something like `[next=0.5]` it will wait for 0.5s after typing has finished before moving to the next line. If given `[next=auto]` it will wait for an automatic amount of time based on the length of the line.
 
+If you need to use `[` or `]` in general dialogue without markup then you can escape them like `\[` and `\]`.
+
 ### Tags
 
 If you need to annotate your lines with tags then you can wrap them in `[#` and `]`, separated by commas. So to specify "happy" and "surprised" tags for a line you would do something like:


### PR DESCRIPTION
Allow literal brackets to be escaped using `\[` and `\]`.