### PR TITLE
Wait for balloon ready when setting dialogue line

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -28,6 +28,10 @@ var dialogue_line: DialogueLine:
 			queue_free()
 			return
 
+		# If the node isn't ready yet then none of the labels will be ready yet either
+		if not is_node_ready():
+			await ready
+
 		dialogue_line = next_dialogue_line
 
 		character_label.visible = not dialogue_line.character.is_empty()


### PR DESCRIPTION
This makes the example balloon's dialogue setter wait for the balloon to be ready before setting any label properties.