### PR TITLE
Allow auto pause characters to be skipped

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -27,6 +27,9 @@ signal finished_typing()
 ## Automatically have a brief pause when these characters are encountered.
 @export var pause_at_characters: String = ".?!"
 
+## Don't auto pause if the charcter after the pause is one of these.
+@export var skip_pause_at_character_if_followed_by: String = ")\""
+
 ## The amount of time to pause when exposing a character present in pause_at_characters.
 @export var seconds_per_pause_step: float = 0.3
 
@@ -175,6 +178,10 @@ func _should_auto_pause() -> bool:
 	if visible_characters == 0: return false
 
 	var parsed_text: String = get_parsed_text()
+
+	# Ignore pause characters if they are next to a non-pause character
+	if visible_characters < parsed_text.length() and parsed_text[visible_characters] in skip_pause_at_character_if_followed_by.split():
+		return false
 
 	# Ignore "." if it's between two numbers
 	if visible_characters > 3 and parsed_text[visible_characters - 1] == ".":

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -180,7 +180,7 @@ func _should_auto_pause() -> bool:
 	var parsed_text: String = get_parsed_text()
 
 	# Ignore pause characters if they are next to a non-pause character
-	if visible_characters < parsed_text.length() and parsed_text[visible_characters] in skip_pause_at_character_if_followed_by.split():
+	if parsed_text[visible_characters] in skip_pause_at_character_if_followed_by.split():
 		return false
 
 	# Ignore "." if it's between two numbers

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,6 +64,7 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 - `skip_action: StringName = &"ui_cancel"` - the action to press to skip typing, if any.
 - `seconds_per_step: float = 0.02` - the speed with which the text types out.
 - `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
+- `skip_pause_at_character_if_followed_by: String = ")\""` - ignore automatic pausing if the pause character is followed by one of these.
 - `seconds_per_pause_step: float = 0.3` - the amount of time to pause when exposing a character present in pause_at_characters.
 
 ### Signals


### PR DESCRIPTION
This allows for auto pause characters (eg. ".") on the `DialogueLabel` to be skipped if they are followed by given characters (eg. ")").