### PR TITLE
Fix missing error when indenting titles

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -231,10 +231,10 @@ func parse(text: String, path: String) -> Error:
 
 		# Title
 		elif is_title_line(raw_line):
+			line["type"] = DialogueConstants.TYPE_TITLE
 			if not raw_lines[id].begins_with("~"):
 				add_error(id, indent_size + 2, DialogueConstants.ERR_NESTED_TITLE)
 			else:
-				line["type"] = DialogueConstants.TYPE_TITLE
 				line["text"] = extract_title(raw_line)
 				# Titles can't have numbers as the first letter (unless they are external titles which get replaced with hashes)
 				if id >= _imported_line_count and BEGINS_WITH_NUMBER_REGEX.search(line.text):

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -259,7 +259,7 @@ msgid "errors.duplicate_title"
 msgstr "There is already a title with that name."
 
 msgid "errors.nested_title"
-msgstr "Titles cannot be nested."
+msgstr "Titles cannot be indented."
 
 msgid "errors.invalid_title_string"
 msgstr "Titles can only contain alphanumeric characters and numbers."

--- a/tests/test.gd
+++ b/tests/test.gd
@@ -2,7 +2,12 @@ class_name AbstractTest extends Node
 
 
 func parse(text: String) -> DialogueManagerParseResult:
-	return DialogueManagerParser.parse_string(text, "")
+	var parser: DialogueManagerParser = DialogueManagerParser.new()
+	parser.parse(text, "")
+	var data: DialogueManagerParseResult = parser.get_data()
+	parser.free()
+
+	return data
 
 
 func create_resource(text: String) -> DialogueResource:

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -1,6 +1,24 @@
 extends AbstractTest
 
 
+const DialogueConstants = preload("res://addons/dialogue_manager/constants.gd")
+
+
+func test_can_parse_titles() -> void:
+	var output = parse("~ some_title\nNathan: Hello.")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.titles.size() == 1, "Should have one title.")
+	assert(output.titles.has("some_title"), "Should have known title.")
+	assert(output.titles["some_title"] == "2", "Should point to the next line.")
+
+	output = parse(" ~ indented_title\nNathan: Oh no!")
+
+	assert(output.errors.size() > 0, "Should have an error.")
+	assert(output.errors[0].line_number == 0, "Should be an indentation error.")
+	assert(output.errors[0].error == DialogueConstants.ERR_NESTED_TITLE, "Should be an indentation error.")
+
+
 func test_can_parse_basic_dialogue() -> void:
 	var output = parse("Nathan: This is dialogue with a name.\nThis is dialogue without a name")
 


### PR DESCRIPTION
This fixes the missing error when indenting a title.

Fixes #404 