### PR TITLE
Keep compatibility with Godot 4.0

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1181,10 +1181,10 @@ func extract_markers(line: String) -> ResolvedLineData:
 	var escaped_close_brackets: PackedInt32Array = []
 	for i in range(0, text.length() - 1):
 		if text.substr(i, 2) == "\\[":
-			text = text.erase(i, 2).insert(i, "!")
+			text = text.substr(0, i) + "!" + text.substr(i + 2)
 			escaped_open_brackets.append(i)
 		elif text.substr(i, 2) == "\\]":
-			text = text.erase(i, 2).insert(i, "!")
+			text = text.substr(0, i) + "!" + text.substr(i + 2)
 			escaped_close_brackets.append(i)
 
 	# Extract all of the BB codes so that we know the actual text (we could do this easier with
@@ -1252,6 +1252,14 @@ func extract_markers(line: String) -> ResolvedLineData:
 			if bb.offset_start > bbcode.start:
 				bb.offset_start -= length
 				bb.start -= length
+
+		# Find any escaped brackets after this that need moving
+		for i in range(0, escaped_open_brackets.size()):
+			if escaped_open_brackets[i] > bbcode.start:
+				escaped_open_brackets[i] -= length
+		for i in range(0, escaped_close_brackets.size()):
+			if escaped_close_brackets[i] > bbcode.start:
+				escaped_close_brackets[i] -= length
 
 		text = text.substr(0, index) + text.substr(index + length)
 		next_bbcode_position = find_bbcode_positions_in_string(text, false)

--- a/tests/test_extracting_markers.gd
+++ b/tests/test_extracting_markers.gd
@@ -69,3 +69,8 @@ func test_can_resolve_inline_conditions() -> void:
 
 	data = await _resolve("Nathan: What I'm saying is [if true]true[else]false[/if].")
 	assert(data.text == "What I'm saying is true.", "Should resolve condition with else in it.")
+
+
+func test_can_handle_escaped_brackets() -> void:
+	var data = await _resolve("Nathan: This[wait=1] is a \\[[color=lime]special[/color]\\] thing")
+	assert(data.text == "This is a [[color=lime]special[/color]] thing")


### PR DESCRIPTION
It seems `String.erase()` wasn't available in Godot 4.0 so this replaces it with a couple of `substr`s.

Fixes #411 