### PR TITLE
Add setting for using external editor

### DIFF
--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -198,6 +198,12 @@ msgstr "Changing these settings will force a recompile of all dialogue. Only cha
 msgid "settings.create_lines_for_responses_with_characters"
 msgstr "Create child dialogue line for responses with character names in them"
 
+msgid "settings.open_in_external_editor"
+msgstr "Open dialogue files in external editor"
+
+msgid "settings.external_editor_warning"
+msgstr "Note: Syntax highlighting and detailed error checking are not supported in external editors."
+
 msgid "n_of_n"
 msgstr "{index} of {total}"
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -188,6 +188,12 @@ msgstr ""
 msgid "settings.create_lines_for_responses_with_characters"
 msgstr ""
 
+msgid "settings.open_in_external_editor"
+msgstr ""
+
+msgid "settings.external_editor_warning"
+msgstr ""
+
 msgid "n_of_n"
 msgstr ""
 

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -86,9 +86,10 @@ func _get_plugin_icon() -> Texture2D:
 
 
 func _handles(object) -> bool:
-	if object is DialogueResource and DialogueSettings.get_user_value("open_in_external_editor", false):
-		var settings: EditorSettings = get_editor_interface().get_editor_settings()
-		var external_editor: String = settings.get_setting("text_editor/external/exec_path")
+	var editor_settings: EditorSettings = get_editor_interface().get_editor_settings()
+	var external_editor: String = editor_settings.get_setting("text_editor/external/exec_path")
+	var use_external_editor: bool = editor_settings.get_setting("text_editor/external/use_external_editor") and external_editor != ""
+	if object is DialogueResource and use_external_editor and DialogueSettings.get_user_value("open_in_external_editor", false):
 		var project_path: String = ProjectSettings.globalize_path("res://")
 		var file_path: String = ProjectSettings.globalize_path(object.resource_path)
 		OS.create_process(external_editor, [project_path, file_path])

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -86,6 +86,14 @@ func _get_plugin_icon() -> Texture2D:
 
 
 func _handles(object) -> bool:
+	if object is DialogueResource and DialogueSettings.get_user_value("open_in_external_editor", false):
+		var settings: EditorSettings = get_editor_interface().get_editor_settings()
+		var external_editor: String = settings.get_setting("text_editor/external/exec_path")
+		var project_path: String = ProjectSettings.globalize_path("res://")
+		var file_path: String = ProjectSettings.globalize_path(object.resource_path)
+		OS.create_process(external_editor, [project_path, file_path])
+		return false
+
 	return object is DialogueResource
 
 

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -77,7 +77,8 @@ static func get_user_config() -> Dictionary:
 		carets = {},
 		run_title = "",
 		run_resource_path = "",
-		is_running_test_scene = false
+		is_running_test_scene = false,
+		open_in_external_editor = false
 	}
 
 	if FileAccess.file_exists(DialogueConstants.USER_CONFIG_PATH):

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -31,6 +31,7 @@ enum PathTarget {
 @onready var globals_list: Tree = $Runtime/GlobalsList
 
 # Advanced
+@onready var open_in_external_editor_button: CheckBox = $Advanced/OpenInExternalEditorButton
 @onready var test_scene_path_input: LineEdit = $Advanced/CustomTestScene/TestScenePath
 @onready var revert_test_scene_button: Button = $Advanced/CustomTestScene/RevertTestScene
 @onready var load_test_scene_button: Button = $Advanced/CustomTestScene/LoadTestScene
@@ -62,6 +63,8 @@ func _ready() -> void:
 	$Runtime/StatesMessage.text = DialogueConstants.translate("settings.states_message")
 	$Runtime/StatesHint.text = DialogueConstants.translate("settings.states_hint")
 
+	open_in_external_editor_button.text = DialogueConstants.translate("settings.open_in_external_editor")
+	$Advanced/ExternalWarning.text = DialogueConstants.translate("settings.external_editor_warning")
 	$Advanced/CustomTestSceneLabel.text = DialogueConstants.translate("settings.custom_test_scene")
 	$Advanced/RecompileWarning.text = DialogueConstants.translate("settings.recompile_warning")
 	missing_translations_button.text = DialogueConstants.translate("settings.missing_keys")
@@ -98,6 +101,8 @@ func prepare() -> void:
 
 	missing_translations_button.set_pressed_no_signal(DialogueSettings.get_setting("missing_translations_are_errors", false))
 	create_lines_for_response_characters.set_pressed_no_signal(DialogueSettings.get_setting("create_lines_for_responses_with_characters", true))
+
+	open_in_external_editor_button.set_pressed_no_signal(DialogueSettings.get_user_value("open_in_external_editor", false))
 
 	var project = ConfigFile.new()
 	var err = project.load("res://project.godot")
@@ -235,3 +240,7 @@ func _on_load_balloon_path_pressed() -> void:
 
 func _on_create_lines_for_response_characters_toggled(toggled_on: bool) -> void:
 	DialogueSettings.set_setting("create_lines_for_responses_with_characters", toggled_on)
+
+
+func _on_open_in_external_editor_button_toggled(toggled_on: bool) -> void:
+	DialogueSettings.set_user_value("open_in_external_editor", toggled_on)

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -104,6 +104,14 @@ func prepare() -> void:
 
 	open_in_external_editor_button.set_pressed_no_signal(DialogueSettings.get_user_value("open_in_external_editor", false))
 
+	var editor_settings: EditorSettings = editor_plugin.get_editor_interface().get_editor_settings()
+	var external_editor: String = editor_settings.get_setting("text_editor/external/exec_path")
+	var use_external_editor: bool = editor_settings.get_setting("text_editor/external/use_external_editor") and external_editor != ""
+	if not use_external_editor:
+		open_in_external_editor_button.hide()
+		$Advanced/ExternalWarning.hide()
+		$Advanced/HSeparator.hide()
+
 	var project = ConfigFile.new()
 	var err = project.load("res://project.godot")
 	assert(err == OK, "Could not find the project file")

--- a/addons/dialogue_manager/views/settings_view.tscn
+++ b/addons/dialogue_manager/views/settings_view.tscn
@@ -124,6 +124,17 @@ select_mode = 1
 visible = false
 layout_mode = 2
 
+[node name="OpenInExternalEditorButton" type="CheckBox" parent="Advanced"]
+layout_mode = 2
+text = "Open dialogue files in external editor"
+
+[node name="ExternalWarning" type="Label" parent="Advanced"]
+layout_mode = 2
+text = "Note: Syntax highlighting and detailed error checking are not supported in external editors."
+
+[node name="HSeparator" type="HSeparator" parent="Advanced"]
+layout_mode = 2
+
 [node name="CustomTestSceneLabel" type="Label" parent="Advanced"]
 layout_mode = 2
 text = "Custom test scene (must extend BaseDialogueTestScene)"
@@ -149,7 +160,7 @@ flat = true
 [node name="LoadTestScene" type="Button" parent="Advanced/CustomTestScene"]
 layout_mode = 2
 
-[node name="HSeparator" type="HSeparator" parent="Advanced"]
+[node name="HSeparator2" type="HSeparator" parent="Advanced"]
 layout_mode = 2
 
 [node name="RecompileWarning" type="Label" parent="Advanced"]
@@ -180,6 +191,7 @@ filters = PackedStringArray("*.tscn ; Scene")
 [connection signal="pressed" from="Runtime/CustomBalloon/LoadBalloonPath" to="." method="_on_load_balloon_path_pressed"]
 [connection signal="button_clicked" from="Runtime/GlobalsList" to="." method="_on_globals_list_button_clicked"]
 [connection signal="item_selected" from="Runtime/GlobalsList" to="." method="_on_globals_list_item_selected"]
+[connection signal="toggled" from="Advanced/OpenInExternalEditorButton" to="." method="_on_open_in_external_editor_button_toggled"]
 [connection signal="pressed" from="Advanced/CustomTestScene/RevertTestScene" to="." method="_on_revert_test_scene_pressed"]
 [connection signal="pressed" from="Advanced/CustomTestScene/LoadTestScene" to="." method="_on_load_test_scene_pressed"]
 [connection signal="toggled" from="Advanced/MissingTranslationsButton" to="." method="_on_missing_translations_button_toggled"]


### PR DESCRIPTION
This adds an advanced option for opening dialogue files in an external editor (if configured in Editor Settings).

**⚠ Note: Syntax highlighting and detailed error checking is not supported in external editors.**

Closes #410 