### PR TITLE
Show images as they are typed out

### DIFF
--- a/addons/dialogue_manager/dialogue_label.tscn
+++ b/addons/dialogue_manager/dialogue_label.tscn
@@ -14,5 +14,4 @@ shortcut_keys_enabled = false
 meta_underlined = false
 hint_underlined = false
 deselect_on_focus_loss_enabled = false
-visible_characters_behavior = 1
 script = ExtResource("1_cital")


### PR DESCRIPTION
This changes the default `DialogueLabel` text shaping to only show images as the typing out cursor gets to them.