### PR TITLE
Adding support for skipping pauses after "." when using abbreviations

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -30,6 +30,11 @@ signal finished_typing()
 ## Don't auto pause if the charcter after the pause is one of these.
 @export var skip_pause_at_character_if_followed_by: String = ")\""
 
+## Don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).[br]
+## Abbreviations are limitted to 5 characters in length [br]
+## Does not support multi-period abbreviations (ex. "p.m.")
+@export var skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"]
+
 ## The amount of time to pause when exposing a character present in pause_at_characters.
 @export var seconds_per_pause_step: float = 0.3
 
@@ -188,6 +193,24 @@ func _should_auto_pause() -> bool:
 		var possible_number: String = parsed_text.substr(visible_characters - 2, 3)
 		if str(float(possible_number)) == possible_number:
 			return false
+
+    # Ignore "." if it's used in an abbreviation
+    # Note: does NOT support multi-period abbreviations (ex. p.m.)
+    if visible_characters > 1 and parsed_text[visible_characters - 1] == "." and "." in pause_at_characters.split():
+        # Look backwards 5 characters from "." for the first whitespace, building a possible
+        # abbreviation as we go
+        var possible_abbrev: String = ""
+        for i in range(2, 6):
+            if visible_characters - i < 0:
+                break
+            if (parsed_text[visible_characters - i] == " " or
+                parsed_text[visible_characters - i] == "\n"):
+                break
+            else:
+                possible_abbrev = parsed_text[visible_characters - i] + possible_abbrev
+
+        if possible_abbrev in skip_pause_at_abbreviations:
+            return false
 
 	# Ignore two non-"." characters next to each other
 	var other_pause_characters: PackedStringArray = pause_at_characters.replace(".", "").split()

--- a/docs/API.md
+++ b/docs/API.md
@@ -65,6 +65,7 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 - `seconds_per_step: float = 0.02` - the speed with which the text types out.
 - `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
 - `skip_pause_at_character_if_followed_by: String = ")\""` - ignore automatic pausing if the pause character is followed by one of these.
+- `skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"] - Don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).
 - `seconds_per_pause_step: float = 0.3` - the amount of time to pause when exposing a character present in pause_at_characters.
 
 ### Signals


### PR DESCRIPTION
_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

_If this is a change to the compiler then make sure to add/update any tests that may be affected._

_If this change needs updates to the documentation then make sure you've made those changes too._

# What
- Adding an additional export variable to define abbreviations
- Logic to check if recent visible characters make up one of the defined abbreviations. If so, and "." is a `pause_character`, skip pausing

# Why
My game involves many doctors, and has a formal hospital setting. As a result, there was a lot of additional pausing after every `Dr. Foo` and `Mrs. Bar`. By doing a short look back, we can determine if an abbreviation was used and skip the pause.

# Testing
I tested with a script, like so:
```
~ abbrev_test
Dr. Tom: How're you doing this morning, Mr. Phelps?
Mr. Phelps: Not so good Dr. Tom. My tummy hurts.
Dr. Tom: Dr. Jim, can you take a quick look at the patient?
	Mrs. Phelps, what have you seen at home?
Mrs. Phelps: I saw this, that, etc.
Mr. Phelps: Gov. Greg is on TV
```
This was testing:
- A few different abbreviations
- An abbreviation as the first character in a line (line 3)
- An abbreviation after a newline character (line 4)
- An abbreviation not in the default list (line 6)
- Periods at end of sentences still pause (line 2)

Here is a short clip of it in action:
https://github.com/nathanhoad/godot_dialogue_manager/assets/6420955/c8172dbe-ccfd-4fd5-93cb-e55329b40a6a


