### PR TITLE
Prepare settings when enabling plugin

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -285,7 +285,7 @@ func _get_example_balloon_path() -> String:
 
 
 func _has_dotnet_solution() -> bool:
-	if not DialogueSettings.get_setting("has_dotnet_solution", false): return false
+	if not DialogueSettings.get_user_value("has_dotnet_solution", false): return false
 	if not ResourceLoader.exists("res://addons/dialogue_manager/DialogueManager.cs"): return false
 	if load("res://addons/dialogue_manager/DialogueManager.cs") == null: return false
 	return true

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -115,7 +115,7 @@ func _build() -> bool:
 		var directory: String = ProjectSettings.get("dotnet/project/solution_directory")
 		var file_name: String = ProjectSettings.get("dotnet/project/assembly_name")
 		var has_dotnet_solution: bool = FileAccess.file_exists("res://%s/%s.sln" % [directory, file_name])
-		DialogueSettings.set_setting("has_dotnet_solution", has_dotnet_solution)
+		DialogueSettings.set_user_value("has_dotnet_solution", has_dotnet_solution)
 
 	# Ignore errors in other files if we are just running the test scene
 	if DialogueSettings.get_user_value("is_running_test_scene", true): return true

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -18,7 +18,6 @@ const DEFAULT_SETTINGS = {
 	custom_test_scene_path = preload("./test_scene.tscn").resource_path,
 	default_csv_locale = "en",
 	balloon_path = "",
-	has_dotnet_solution = false,
 	create_lines_for_responses_with_characters = true
 }
 
@@ -39,10 +38,19 @@ static func prepare() -> void:
 			ProjectSettings.set_setting("dialogue_manager/%s" % key, null)
 			set_setting(key, value)
 
-	# Set up defaults
-	for setting in DEFAULT_SETTINGS:
-		if ProjectSettings.has_setting("dialogue_manager/general/%s" % setting):
-			ProjectSettings.set_initial_value("dialogue_manager/general/%s" % setting, DEFAULT_SETTINGS[setting])
+	# Set up initial settings
+	for setting: String in DEFAULT_SETTINGS:
+		var setting_name: String = "dialogue_manager/general/%s" % setting
+		if not ProjectSettings.has_setting(setting_name):
+			set_setting(setting, DEFAULT_SETTINGS[setting])
+		ProjectSettings.set_initial_value(setting_name, DEFAULT_SETTINGS[setting])
+		if setting.ends_with("_path"):
+			ProjectSettings.add_property_info({
+				"name": setting_name,
+				"type": TYPE_STRING,
+				"hint": PROPERTY_HINT_FILE,
+			})
+
 	ProjectSettings.save()
 
 
@@ -78,6 +86,7 @@ static func get_user_config() -> Dictionary:
 		run_title = "",
 		run_resource_path = "",
 		is_running_test_scene = false,
+		has_dotnet_solution = false,
 		open_in_external_editor = false
 	}
 

--- a/project.godot
+++ b/project.godot
@@ -25,7 +25,6 @@ DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 [dialogue_manager]
 
 general/states=["State", "Events"]
-general/create_lines_for_responses_with_characters=false
 
 [display]
 


### PR DESCRIPTION
This makes sure dialogue settings are present in the Project Settings window once the plugin has been enabled. Previously settings would only be added there once they had been changed in the settings window in the dialogue editor.

Closes #432 