### PR TITLE
Force en locale for tests

### DIFF
--- a/tests/tests.gd
+++ b/tests/tests.gd
@@ -10,6 +10,8 @@ var assertions_count: int = 0
 
 
 func _ready() -> void:
+	TranslationServer.set_locale("en")
+
 	visible = false
 
 	tests_count = 0


### PR DESCRIPTION
This forces the locale when running tests to be "en" so that any tested dialogue lines match the text as written and don't get auto translated.

Closes #441 