### PR TITLE
Fix "Array is in read-only state" error

### DIFF
--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -122,7 +122,7 @@ func prepare() -> void:
 			if key != "DialogueManager":
 				all_globals[key] = project.get_value("autoload", key)
 
-	enabled_globals = DialogueSettings.get_setting("states", [])
+	enabled_globals = DialogueSettings.get_setting("states", []).duplicate()
 	globals_list.clear()
 	var root = globals_list.create_item()
 	for name in all_globals.keys():


### PR DESCRIPTION
This fixes the "Array is in read-only state" error that sometimes shows up when setting state shortcuts.