### PR TITLE
Simplify/centralise typing skip handling

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -1,6 +1,7 @@
 @icon("./assets/icon.svg")
 
 @tool
+
 ## A RichTextLabel specifically for use with [b]Dialogue Manager[/b] dialogue.
 class_name DialogueLabel extends RichTextLabel
 
@@ -18,7 +19,7 @@ signal skipped_typing()
 signal finished_typing()
 
 
-## The action to press to skip typing.
+# The action to press to skip typing.
 @export var skip_action: StringName = &"ui_cancel"
 
 ## The speed with which the text types out.
@@ -79,6 +80,9 @@ func _process(delta: float) -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
+	# Note: this will no longer be reached if using Dialogue Manager > 2.32.2. To make skip handling
+	# simpler (so all of mouse/keyboard/joypad are together) it is now the responsibility of the
+	# dialogue balloon.
 	if self.is_typing and visible_ratio < 1 and InputMap.has_action(skip_action) and event.is_action_pressed(skip_action):
 		get_viewport().set_input_as_handled()
 		skip_typing()

--- a/docs/API.md
+++ b/docs/API.md
@@ -61,7 +61,6 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 
 ### Exports
 
-- `skip_action: StringName = &"ui_cancel"` - the action to press to skip typing, if any.
 - `seconds_per_step: float = 0.02` - the speed with which the text types out.
 - `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
 - `skip_pause_at_character_if_followed_by: String = ")\""` - ignore automatic pausing if the pause character is followed by one of these.
@@ -83,5 +82,4 @@ Starts typing out the text of the label.
 
 #### `func skip_typing() -> void`
 
-Stop typing out the text and jump right to the end.
-Automatically called when skip_action is pressed.
+Stop typing out the text and jump right to the end. This will emit `skipped_typing`.


### PR DESCRIPTION
Previously, skip handling was split into both the balloon (for mouse handling) and the `DialogueLabel` for key/button handling. To simplify things I've moved all skip handling into the balloon.

_**Note:** the code  for skip handling buttons is still in the `DialogueLabel` for now but under regular use of the balloon that code will never be reached. It is only there for now so that anybody who already set it up can keep using it until they have time to update their balloon - it will be removed at some point in the future._

Related to #445 