### PR TITLE
Include character names and notes in translations

### DIFF
--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -204,6 +204,12 @@ msgstr "Open dialogue files in external editor"
 msgid "settings.external_editor_warning"
 msgstr "Note: Syntax highlighting and detailed error checking are not supported in external editors."
 
+msgid "settings.include_characters_in_translations"
+msgstr "Include character names in translation exports"
+
+msgid "settings.include_notes_in_translations"
+msgstr "Include notes (## comments) in translation exports"
+
 msgid "n_of_n"
 msgstr "{index} of {total}"
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -194,6 +194,12 @@ msgstr ""
 msgid "settings.external_editor_warning"
 msgstr ""
 
+msgid "settings.include_characters_in_translations"
+msgstr ""
+
+msgid "settings.include_notes_in_translations"
+msgstr ""
+
 msgid "n_of_n"
 msgstr ""
 

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -18,7 +18,9 @@ const DEFAULT_SETTINGS = {
 	custom_test_scene_path = preload("./test_scene.tscn").resource_path,
 	default_csv_locale = "en",
 	balloon_path = "",
-	create_lines_for_responses_with_characters = true
+	create_lines_for_responses_with_characters = true,
+	include_character_in_translation_exports = false,
+	include_notes_in_translation_exports = false
 }
 
 

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -31,6 +31,8 @@ enum PathTarget {
 @onready var globals_list: Tree = $Runtime/GlobalsList
 
 # Advanced
+@onready var include_characters_in_translations: CheckBox = $Advanced/IncludeCharactersInTranslations
+@onready var include_notes_in_translations: CheckBox = $Advanced/IncludeNotesInTranslations
 @onready var open_in_external_editor_button: CheckBox = $Advanced/OpenInExternalEditorButton
 @onready var test_scene_path_input: LineEdit = $Advanced/CustomTestScene/TestScenePath
 @onready var revert_test_scene_button: Button = $Advanced/CustomTestScene/RevertTestScene
@@ -63,6 +65,8 @@ func _ready() -> void:
 	$Runtime/StatesMessage.text = DialogueConstants.translate("settings.states_message")
 	$Runtime/StatesHint.text = DialogueConstants.translate("settings.states_hint")
 
+	include_characters_in_translations.text = DialogueConstants.translate("settings.include_characters_in_translations")
+	include_notes_in_translations.text = DialogueConstants.translate("settings.include_notes_in_translations")
 	open_in_external_editor_button.text = DialogueConstants.translate("settings.open_in_external_editor")
 	$Advanced/ExternalWarning.text = DialogueConstants.translate("settings.external_editor_warning")
 	$Advanced/CustomTestSceneLabel.text = DialogueConstants.translate("settings.custom_test_scene")
@@ -102,6 +106,8 @@ func prepare() -> void:
 	missing_translations_button.set_pressed_no_signal(DialogueSettings.get_setting("missing_translations_are_errors", false))
 	create_lines_for_response_characters.set_pressed_no_signal(DialogueSettings.get_setting("create_lines_for_responses_with_characters", true))
 
+	include_characters_in_translations.set_pressed_no_signal(DialogueSettings.get_setting("include_character_in_translation_exports", false))
+	include_notes_in_translations.set_pressed_no_signal(DialogueSettings.get_setting("include_notes_in_translation_exports", false))
 	open_in_external_editor_button.set_pressed_no_signal(DialogueSettings.get_user_value("open_in_external_editor", false))
 
 	var editor_settings: EditorSettings = editor_plugin.get_editor_interface().get_editor_settings()
@@ -252,3 +258,11 @@ func _on_create_lines_for_response_characters_toggled(toggled_on: bool) -> void:
 
 func _on_open_in_external_editor_button_toggled(toggled_on: bool) -> void:
 	DialogueSettings.set_user_value("open_in_external_editor", toggled_on)
+
+
+func _on_include_characters_in_translations_toggled(toggled_on: bool) -> void:
+	DialogueSettings.set_setting("include_character_in_translation_exports", toggled_on)
+
+
+func _on_include_notes_in_translations_toggled(toggled_on: bool) -> void:
+	DialogueSettings.set_setting("include_notes_in_translation_exports", toggled_on)

--- a/addons/dialogue_manager/views/settings_view.tscn
+++ b/addons/dialogue_manager/views/settings_view.tscn
@@ -16,9 +16,11 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = SubResource("Theme_3a8rc")
+current_tab = 2
 script = ExtResource("1_06uxa")
 
 [node name="Editor" type="VBoxContainer" parent="."]
+visible = false
 layout_mode = 2
 
 [node name="NewTemplateButton" type="CheckBox" parent="Editor"]
@@ -121,7 +123,17 @@ hide_root = true
 select_mode = 1
 
 [node name="Advanced" type="VBoxContainer" parent="."]
-visible = false
+layout_mode = 2
+
+[node name="IncludeCharactersInTranslations" type="CheckBox" parent="Advanced"]
+layout_mode = 2
+text = "Include character names in translation exports"
+
+[node name="IncludeNotesInTranslations" type="CheckBox" parent="Advanced"]
+layout_mode = 2
+text = "Include notes  (## comments) names in translation exports"
+
+[node name="HSeparator" type="HSeparator" parent="Advanced"]
 layout_mode = 2
 
 [node name="OpenInExternalEditorButton" type="CheckBox" parent="Advanced"]
@@ -132,7 +144,7 @@ text = "Open dialogue files in external editor"
 layout_mode = 2
 text = "Note: Syntax highlighting and detailed error checking are not supported in external editors."
 
-[node name="HSeparator" type="HSeparator" parent="Advanced"]
+[node name="HSeparator3" type="HSeparator" parent="Advanced"]
 layout_mode = 2
 
 [node name="CustomTestSceneLabel" type="Label" parent="Advanced"]
@@ -191,6 +203,8 @@ filters = PackedStringArray("*.tscn ; Scene")
 [connection signal="pressed" from="Runtime/CustomBalloon/LoadBalloonPath" to="." method="_on_load_balloon_path_pressed"]
 [connection signal="button_clicked" from="Runtime/GlobalsList" to="." method="_on_globals_list_button_clicked"]
 [connection signal="item_selected" from="Runtime/GlobalsList" to="." method="_on_globals_list_item_selected"]
+[connection signal="toggled" from="Advanced/IncludeCharactersInTranslations" to="." method="_on_include_characters_in_translations_toggled"]
+[connection signal="toggled" from="Advanced/IncludeNotesInTranslations" to="." method="_on_include_notes_in_translations_toggled"]
 [connection signal="toggled" from="Advanced/OpenInExternalEditorButton" to="." method="_on_open_in_external_editor_button_toggled"]
 [connection signal="pressed" from="Advanced/CustomTestScene/RevertTestScene" to="." method="_on_revert_test_scene_pressed"]
 [connection signal="pressed" from="Advanced/CustomTestScene/LoadTestScene" to="." method="_on_load_test_scene_pressed"]

--- a/addons/dialogue_manager/views/settings_view.tscn
+++ b/addons/dialogue_manager/views/settings_view.tscn
@@ -16,11 +16,9 @@ grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = SubResource("Theme_3a8rc")
-current_tab = 2
 script = ExtResource("1_06uxa")
 
 [node name="Editor" type="VBoxContainer" parent="."]
-visible = false
 layout_mode = 2
 
 [node name="NewTemplateButton" type="CheckBox" parent="Editor"]
@@ -123,6 +121,7 @@ hide_root = true
 select_mode = 1
 
 [node name="Advanced" type="VBoxContainer" parent="."]
+visible = false
 layout_mode = 2
 
 [node name="IncludeCharactersInTranslations" type="CheckBox" parent="Advanced"]
@@ -131,7 +130,7 @@ text = "Include character names in translation exports"
 
 [node name="IncludeNotesInTranslations" type="CheckBox" parent="Advanced"]
 layout_mode = 2
-text = "Include notes  (## comments) names in translation exports"
+text = "Include notes (## comments) in translation exports"
 
 [node name="HSeparator" type="HSeparator" parent="Advanced"]
 layout_mode = 2

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -28,6 +28,8 @@ For example, instead of having to type out `GameState.some_variable`, you could 
 
 ## Advanced
 
+- `Include character names in translation exports` - will include a `_character` column in CSV exports.
+- `Include notes (## comments) in translation exports` - will include a `_notes` column in CSV exports populated from doc-style comments (eg. `## This is a comment`) above translatable lines.
 - `Custom Test Scene` can be used to override the default test scene that gets run when you click the "Test dialogue" button in the dialogue editor.
 
 Changing any of the following values will result in a recompile of all dialogue files in your project.


### PR DESCRIPTION
This adds advanced options to include the character name and doc-style comments (eg. `## This is a comment`) to translation exports.

Characters will be in a column labelled `_character` and notes will be under `_notes`. If the file being exported over already has either of these columns the setting will be assumed to be on and write characters/notes accordingly.

_**Note:** Depending on your version of Godot, you may see errors in the Output tab (and for older Godot 4s you may end up with invalid translation import files._

Closes #323 
Closes #440 