### PR TITLE
Swap out String method missing from Godot 4.0

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1280,9 +1280,9 @@ func extract_markers(line: String) -> ResolvedLineData:
 
 	# Put the escaped brackets back in
 	for index in escaped_open_brackets:
-		text = text.erase(index, 1).insert(index, "[")
+		text = text.left(index) + "[" + text.right(text.length() - index - 1)
 	for index in escaped_close_brackets:
-		text = text.erase(index, 1).insert(index, "]")
+		text = text.left(index) + "]" + text.right(text.length() - index - 1)
 
 	return ResolvedLineData.new({
 		text = text,

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -17,7 +17,7 @@ var dialogue_cache: DialogueCache
 
 
 func _enter_tree() -> void:
-	add_autoload_singleton("DialogueManager", "dialogue_manager.gd")
+	add_autoload_singleton("DialogueManager", get_plugin_path() + "/dialogue_manager.gd")
 
 	if Engine.is_editor_hint():
 		Engine.set_meta("DialogueManagerPlugin", self)
@@ -82,7 +82,7 @@ func _get_plugin_name() -> String:
 
 
 func _get_plugin_icon() -> Texture2D:
-	return load(get_script().resource_path.get_base_dir() + "/assets/icon.svg")
+	return load(get_plugin_path() + "/assets/icon.svg")
 
 
 func _handles(object) -> bool:


### PR DESCRIPTION
This swaps out String `erase` for a combination of `left` and `right` to restore compatibility with Godot 4.0 where `erase` didn't exist on Strings.