### PR TITLE
adds balloon_gui_input call on every unhandled input

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -83,6 +83,7 @@ func _ready() -> void:
 
 func _unhandled_input(_event: InputEvent) -> void:
 	# Only the balloon is allowed to handle input while it's showing
+	_on_balloon_gui_input(_event)
 	get_viewport().set_input_as_handled()
 
 


### PR DESCRIPTION
This PR adds a function call to `_on_balloon_gui_input` to handle inputs outside of the balloon.

It fixes #456 in my case. I have no idea if it breaks other workflows or does not respect Godot's input handling.