### PR TITLE
Allow some array types as mutation args

### DIFF
--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -455,3 +455,9 @@ msgstr "\"{autoload}\" doesn't appear to be a valid autoload."
 
 msgid "runtime.something_went_wrong"
 msgstr "Something went wrong."
+
+msgid "runtime.expected_n_got_n_args"
+msgstr "\"{method}\" was called with {received} arguments but it only has {expected}."
+
+msgid "runtime.unsupported_array_type"
+msgstr "Array[{type}] isn't supported in mutations. Use Array as a type instead."

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -445,3 +445,9 @@ msgstr ""
 
 msgid "runtime.something_went_wrong"
 msgstr ""
+
+msgid "runtime.expected_n_got_n_args"
+msgstr ""
+
+msgid "runtime.unsupported_array_type"
+msgstr ""

--- a/tests/state_for_tests.gd
+++ b/tests/state_for_tests.gd
@@ -15,3 +15,7 @@ func some_method(number: int, string: String) -> int:
 
 func long_mutation() -> void:
 	await get_tree().create_timer(0.5).timeout
+
+
+func typed_array_method(numbers: Array[int], strings: Array[String], dictionaries: Array) -> String:
+	return str(numbers) + str(strings) + str(dictionaries)

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -97,6 +97,14 @@ Nathan: Done.")
 	assert(duration > 0.2, "Mutation should take some time.")
 
 
+func test_can_run_mutations_with_typed_arrays() -> void:
+	var resource = create_resource("
+~ start
+Nathan: {{StateForTests.typed_array_method([-1, 27], [\"something\"], [{ \"key\": \"value\" }])}}")
+
+	var line = await resource.get_next_dialogue_line("start")
+	assert(line.text == "[-1, 27][\"something\"][{ \"key\": \"value\" }]", "Should match output.")
+
 
 func test_can_run_expressions() -> void:
 	var resource = create_resource("


### PR DESCRIPTION
This adds a workaround for Godot's typed array conversion when using some array types for mutation arguments.

_*Note:* Only some typed arrays (`String`, `int`, `float`, `Vector2`, and `Vector3`) are supported. Complex types will throw an error and suggest using just `Array` instead._

Fixes #458 