### PR TITLE
Defer evaluating assert messages

### DIFF
--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -255,9 +255,11 @@ static func get_error_message(error: int) -> String:
 
 
 static func translate(string: String) -> String:
+	var base_path = DialogueResource.new().get_script().resource_path.get_base_dir()
+
 	var language: String = TranslationServer.get_tool_locale()
-	var translations_path: String = "res://addons/dialogue_manager/l10n/%s.po" % language
-	var fallback_translations_path: String = "res://addons/dialogue_manager/l10n/"+TranslationServer.get_tool_locale().substr(0, 2)+".po"
-	var en_translations_path: String = "res://addons/dialogue_manager/l10n/en.po"
+	var translations_path: String = "%s/l10n/%s.po" % [base_path, language]
+	var fallback_translations_path: String = "%s/l10n/%s.po" % [base_path, TranslationServer.get_tool_locale().substr(0, 2)]
+	var en_translations_path: String = "%s/l10n/en.po" % base_path
 	var translations: Translation = load(translations_path if FileAccess.file_exists(translations_path) else (fallback_translations_path if FileAccess.file_exists(fallback_translations_path) else en_translations_path))
 	return translations.get_message(string)

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -103,8 +103,10 @@ func _ready() -> void:
 ## Step through lines and run any mutations until we either hit some dialogue or the end of the conversation
 func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine:
 	# You have to provide a valid dialogue resource
-	assert(resource != null, DialogueConstants.translate("runtime.no_resource"))
-	assert(resource.lines.size() > 0, DialogueConstants.translate("runtime.no_content").format({ file_path = resource.resource_path }))
+	if resource == null:
+		assert(false, DialogueConstants.translate("runtime.no_resource"))
+	if resource.lines.size() == 0:
+		assert(false, DialogueConstants.translate("runtime.no_content").format({ file_path = resource.resource_path }))
 
 	# Inject any "using" states into the game_states
 	for state_name in resource.using_states:
@@ -345,7 +347,8 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 	if key in resource.titles.values():
 		passed_title.emit(resource.titles.find_key(key))
 
-	assert(resource.lines.has(key), DialogueConstants.translate("errors.key_not_found").format({ key = key }))
+	if not resource.lines.has(key):
+		assert(false, DialogueConstants.translate("errors.key_not_found").format({ key = key }))
 
 	var data: Dictionary = resource.lines.get(key)
 
@@ -405,10 +408,10 @@ func show_error_for_missing_state_value(message: String, will_show: bool = true)
 
 	if DialogueSettings.get_setting("ignore_missing_state_values", false):
 		push_error(message)
-	else:
+	elif will_show:
 		# If you're here then you're missing a method or property in your game state. The error
 		# message down in the debugger will give you some more information.
-		assert(not will_show, message)
+		assert(false, message)
 
 
 # Translate a string
@@ -880,7 +883,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Then addition and subtraction
 	i = 0
@@ -896,7 +900,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Then negations
 	i = 0
@@ -911,7 +916,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Then comparisons
 	i = 0
@@ -927,7 +933,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Then and/or
 	i = 0
@@ -943,7 +950,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Lastly, resolve any assignments
 	i = 0
@@ -985,7 +993,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 			i -= 1
 		i += 1
 
-	assert(limit < 1000, DialogueConstants.translate("runtime.something_went_wrong"))
+	if limit >= 1000:
+		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
 	# Account for Signal literals in emit calls
 	if tokens[0].value is Signal:
@@ -1155,7 +1164,8 @@ func resolve_thing_method(thing, method: String, args: Array):
 	if thing.has_method(method):
 		# Try to convert any literals to the right type
 		var method_args = thing.get_method_list().filter(func(m): return method == m.name)[0].args
-		assert(method_args.size() >= args.size(), DialogueConstants.translate("runtime.expected_n_got_n_args").format({ expected = method_args.size(), method = method, received = args.size()}))
+		if method_args.size() < args.size():
+			assert(false, DialogueConstants.translate("runtime.expected_n_got_n_args").format({ expected = method_args.size(), method = method, received = args.size()}))
 		for i in range(0, args.size()):
 			var m: Dictionary = method_args[i]
 			var to_type:int = typeof(args[i])
@@ -1172,7 +1182,8 @@ func resolve_thing_method(thing, method: String, args: Array):
 					"Vector3":
 						to_type = TYPE_PACKED_VECTOR3_ARRAY
 					_:
-						assert(m.hint_string == "", DialogueConstants.translate("runtime.unsupported_array_type").format({ type = m.hint_string}))
+						if m.hint_string != "":
+							assert(false, DialogueConstants.translate("runtime.unsupported_array_type").format({ type = m.hint_string}))
 			if typeof(args[i]) != to_type:
 				args[i] = type_convert(args[i], to_type)
 


### PR DESCRIPTION
This moves all runtime assertions to be behind conditional checks so that their message isn't evaluated early.

Related to #459 