### PR TITLE
Use older type convert method for older Godot 4s

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1185,7 +1185,7 @@ func resolve_thing_method(thing, method: String, args: Array):
 						if m.hint_string != "":
 							assert(false, DialogueConstants.translate("runtime.unsupported_array_type").format({ type = m.hint_string}))
 			if typeof(args[i]) != to_type:
-				args[i] = type_convert(args[i], to_type)
+				args[i] = convert(args[i], to_type)
 
 		return await thing.callv(method, args)
 


### PR DESCRIPTION
This swaps `type_convert` for the older (and deprecated) `convert` that works in Godot before 4.2.

Fixes #466 