### PR TITLE
Escape keyword line starts

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -336,6 +336,7 @@ func parse(text: String, path: String) -> Error:
 			if raw_line.begins_with("\\if"): raw_line = raw_line.substr(1)
 			if raw_line.begins_with("\\elif"): raw_line = raw_line.substr(1)
 			if raw_line.begins_with("\\else"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\while"): raw_line = raw_line.substr(1)
 			if raw_line.begins_with("\\-"): raw_line = raw_line.substr(1)
 			if raw_line.begins_with("\\~"): raw_line = raw_line.substr(1)
 			if raw_line.begins_with("\\=>"): raw_line = raw_line.substr(1)

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -96,7 +96,7 @@ static func extract_markers_from_string(string: String) -> ResolvedLineData:
 func parse(text: String, path: String) -> Error:
 	prepare(text, path)
 	raw_text = text
-	
+
 	# Parse all of the content
 	var known_translations = {}
 
@@ -332,6 +332,14 @@ func parse(text: String, path: String) -> Error:
 
 		# Regular dialogue
 		else:
+			# Remove escape character
+			if raw_line.begins_with("\\if"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\elif"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\else"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\-"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\~"): raw_line = raw_line.substr(1)
+			if raw_line.begins_with("\\=>"): raw_line = raw_line.substr(1)
+
 			# Add any doc notes
 			line["notes"] = "\n".join(doc_comments)
 			doc_comments = []

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -206,6 +206,8 @@ while SomeGlobal.some_property < 10
 Nathan: Now, we can move on.
 ```
 
+To escape a condition line (ie. if you wanted to start a dialogue line with "if") then you can prefix the condition keyword with a "\".
+
 Responses can also have "if" conditions. Wrap these in "[" and "]".
 
 ```

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -38,6 +38,24 @@ Nathan: After.")
 	assert(condition.next_id_after == "8", "Should reference after conditions.")
 
 
+func test_ignore_escaped_conditions() -> void:
+	var output = parse("
+\\if this is dialogue.
+\\elif this too.
+\\else and this one.")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+
+	assert(output.lines["2"].type == DialogueConstants.TYPE_DIALOGUE, "Should be dialogue.")
+	assert(output.lines["2"].text == "if this is dialogue.", "Should escape slash.")
+
+	assert(output.lines["3"].type == DialogueConstants.TYPE_DIALOGUE, "Should be dialogue.")
+	assert(output.lines["3"].text == "elif this too.", "Should escape slash.")
+
+	assert(output.lines["4"].type == DialogueConstants.TYPE_DIALOGUE, "Should be dialogue.")
+	assert(output.lines["4"].text == "else and this one.", "Should escape slash.")
+
+
 func test_can_run_conditions() -> void:
 	var resource = create_resource("
 ~ start


### PR DESCRIPTION
This allows for lines that start with `if`, `elif`, and `else` to be escaped to dialogue instead of being parsed as conditionals. To escape a condition line, prefix it with `/` (eg. `/if this line is dialogue`).