### PR TITLE
Add method for showing a specific dialogue balloon

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -121,6 +121,24 @@ namespace DialogueManagerRuntime
       return new DialogueLine((RefCounted)result[0]);
     }
 
+    public static CanvasLayer ShowExampleDialogueBalloon(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+    {
+      return (CanvasLayer)Instance.Call("show_example_dialogue_balloon", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+    }
+
+    public static Node ShowDialogueBalloonScene(string balloonScene, Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+    {
+      return (Node)Instance.Call("show_dialogue_balloon_scene", balloonScene, dialogueResource, key, extraGameStates ?? new Array<Variant>());
+    }
+    public static Node ShowDialogueBalloonScene(PackedScene balloonScene, Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+    {
+      return (Node)Instance.Call("show_dialogue_balloon_scene", balloonScene, dialogueResource, key, extraGameStates ?? new Array<Variant>());
+    }
+    public static Node ShowDialogueBalloonScene(Node balloonScene, Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+    {
+      return (Node)Instance.Call("show_dialogue_balloon_scene", balloonScene, dialogueResource, key, extraGameStates ?? new Array<Variant>());
+    }
+
     public static Node ShowDialogueBalloon(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
     {
       return (Node)Instance.Call("show_dialogue_balloon", dialogueResource, key, extraGameStates ?? new Array<Variant>());
@@ -130,11 +148,6 @@ namespace DialogueManagerRuntime
     {
       Instance.Call("_bridge_mutate", mutation, extraGameStates ?? new Array<Variant>(), isInlineMutation);
       await Instance.ToSignal(Instance, "bridge_mutated");
-    }
-
-    public static CanvasLayer ShowExampleDialogueBalloon(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
-    {
-      return (CanvasLayer)Instance.Call("show_example_dialogue_balloon", dialogueResource, key, extraGameStates ?? new Array<Variant>());
     }
 
     public bool ThingHasMethod(GodotObject thing, string method)

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -1196,7 +1196,7 @@ func extract_tags(line: String) -> ResolvedTagData:
 	var tag_matches: Array[RegExMatch] = TAGS_REGEX.search_all(line)
 	for tag_match in tag_matches:
 		line = line.replace(tag_match.get_string(), "")
-		var tags = tag_match.get_string().replace("[#", "").replace("]", "").replace(" ", "").split(",")
+		var tags = tag_match.get_string().replace("[#", "").replace("]", "").replace(", ", ",").split(",")
 		for tag in tags:
 			tag = tag.replace("#", "")
 			if not tag in resolved_tags:

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -274,6 +274,17 @@ func show_example_dialogue_balloon(resource: DialogueResource, title: String = "
 ## Show the configured dialogue balloon
 func show_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node:
 	var balloon: Node = load(DialogueSettings.get_setting("balloon_path", _get_example_balloon_path())).instantiate()
+	return show_dialogue_balloon_scene(balloon, resource, title, extra_game_states)
+
+
+## Show a given balloon scene
+func show_dialogue_balloon_scene(balloon_scene, resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node:
+	if balloon_scene is String:
+		balloon_scene = load(balloon_scene)
+	if balloon_scene is PackedScene:
+		balloon_scene = balloon_scene.instantiate()
+
+	var balloon: Node = balloon_scene
 	get_current_scene.call().add_child(balloon)
 	if balloon.has_method("start"):
 		balloon.start(resource, title, extra_game_states)

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,13 @@ Opens the dialogue balloon configured in settings (or the example balloon if non
 Returns the balloon's base node in case you want to `queue_free()` it yourself.
 
 
+#### `func show_dialogue_balloon_scene(balloon_scene: Node | String, resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> Node`
+
+Opens a dialogue balloon given in `balloon_scene`.
+
+Returns the balloon's base node in case you want to `queue_free()` it yourself.
+
+
 #### `func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine`
 
 **Must be used with `await`.**

--- a/examples/test_scenes/TestScene.cs
+++ b/examples/test_scenes/TestScene.cs
@@ -4,46 +4,44 @@ using System.Threading.Tasks;
 
 public partial class TestScene : Node2D
 {
-  [Export] PackedScene Balloon;
+    [Export] PackedScene Balloon;
 
-  [Export] PackedScene SmallBalloon;
+    [Export] PackedScene SmallBalloon;
 
-  [Export] string Title = "start";
+    [Export] string Title = "start";
 
-  [Export] Resource DialogueResource;
+    [Export] Resource DialogueResource;
 
-  /* Make sure to add an [Export] decorator so that the Dialogue Manager can see the property */
-  [Export] string PlayerName = "Player";
-  [Export] int TreatsCount = 0;
-
-
-  public async override void _Ready()
-  {
-	DialogueManager.DialogueEnded += async (Resource dialogueResource) =>
-	{
-	  await ToSignal(GetTree().CreateTimer(0.4), "timeout");
-	  GetTree().Quit();
-	};
-
-	await ToSignal(GetTree().CreateTimer(0.4), "timeout");
-
-	// Show the dialogue
-	bool isSmallWindow = (int)ProjectSettings.GetSetting("display/window/size/viewport_width") < 400;
-	Balloon balloon = (Balloon)(isSmallWindow ? SmallBalloon : Balloon).Instantiate();
-	AddChild(balloon);
-	balloon.Start(DialogueResource, Title);
-  }
+    /* Make sure to add an [Export] decorator so that the Dialogue Manager can see the property */
+    [Export] string PlayerName = "Player";
+    [Export] int TreatsCount = 0;
 
 
-  public async Task AskForName(string defaultName = "Player")
-  {
-	var nameInputDialogue = GD.Load<PackedScene>("res://examples/name_input_dialog/name_input_dialog.tscn").Instantiate() as AcceptDialog;
-	var nameInput = nameInputDialogue.GetNode<LineEdit>("NameEdit");
-	GetTree().Root.AddChild(nameInputDialogue);
-	nameInputDialogue.PopupCentered();
-	nameInput.Text = defaultName;
-	await ToSignal(nameInputDialogue, "confirmed");
-	PlayerName = nameInput.Text;
-	nameInputDialogue.QueueFree();
-  }
+    public async override void _Ready()
+    {
+        DialogueManager.DialogueEnded += async (Resource dialogueResource) =>
+        {
+            await ToSignal(GetTree().CreateTimer(0.4), "timeout");
+            GetTree().Quit();
+        };
+
+        await ToSignal(GetTree().CreateTimer(0.4), "timeout");
+
+        // Show the dialogue
+        bool isSmallWindow = (int)ProjectSettings.GetSetting("display/window/size/viewport_width") < 400;
+        DialogueManager.ShowDialogueBalloonScene(isSmallWindow ? SmallBalloon : Balloon, DialogueResource, Title);
+    }
+
+
+    public async Task AskForName(string defaultName = "Player")
+    {
+        var nameInputDialogue = GD.Load<PackedScene>("res://examples/name_input_dialog/name_input_dialog.tscn").Instantiate() as AcceptDialog;
+        var nameInput = nameInputDialogue.GetNode<LineEdit>("NameEdit");
+        GetTree().Root.AddChild(nameInputDialogue);
+        nameInputDialogue.PopupCentered();
+        nameInput.Text = defaultName;
+        await ToSignal(nameInputDialogue, "confirmed");
+        PlayerName = nameInput.Text;
+        nameInputDialogue.QueueFree();
+    }
 }

--- a/examples/test_scenes/test_scene.gd
+++ b/examples/test_scenes/test_scene.gd
@@ -18,9 +18,7 @@ func show_dialogue(key: String) -> void:
 	assert(dialogue_resource != null, "\"dialogue_resource\" property needs a to point to a DialogueResource.")
 
 	var is_small_window: bool = ProjectSettings.get_setting("display/window/size/viewport_width") < 400
-	var balloon: Node = (SmallBalloon if is_small_window else Balloon).instantiate()
-	add_child(balloon)
-	balloon.start(dialogue_resource, key)
+	DialogueManager.show_dialogue_balloon_scene(SmallBalloon if is_small_window else Balloon, dialogue_resource, key)
 
 
 ### Signals


### PR DESCRIPTION
This adds `show_dialogue_balloon_scene` (and `ShowDialogueBalloonScene` for C#) which allows passing a scene path or packed scene or node to show as the dialogue balloon.