### PR TITLE
Revert custom balloon path if it no longer exists

### DIFF
--- a/Dialogue Manager.csproj
+++ b/Dialogue Manager.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Godot.NET.Sdk/4.2.1">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net7.0</TargetFramework>
+    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>DialogueManager</RootNamespace>
   </PropertyGroup>

--- a/Dialogue Manager.sln
+++ b/Dialogue Manager.sln
@@ -1,6 +1,6 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dialogue Manager", "Dialogue Manager.csproj", "{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dialogue Manager", "Dialogue Manager.csproj", "{4DF09FFE-C342-4477-9552-02A35FBA3CA3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,11 +9,11 @@ Global
 	ExportRelease|Any CPU = ExportRelease|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
-		{05CFFC51-FD6A-4F8C-ADCD-908F631CA5F9}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{4DF09FFE-C342-4477-9552-02A35FBA3CA3}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -273,8 +273,10 @@ func show_example_dialogue_balloon(resource: DialogueResource, title: String = "
 
 ## Show the configured dialogue balloon
 func show_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node:
-	var balloon: Node = load(DialogueSettings.get_setting("balloon_path", _get_example_balloon_path())).instantiate()
-	return show_dialogue_balloon_scene(balloon, resource, title, extra_game_states)
+	var balloon_path: String = DialogueSettings.get_setting("balloon_path", _get_example_balloon_path())
+	if not ResourceLoader.exists(balloon_path):
+		balloon_path = _get_example_balloon_path()
+	return show_dialogue_balloon_scene(balloon_path, resource, title, extra_game_states)
 
 
 ## Show a given balloon scene

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -85,6 +85,9 @@ func prepare() -> void:
 	load_test_scene_button.icon = get_theme_icon("Load", "EditorIcons")
 
 	var balloon_path: String = DialogueSettings.get_setting("balloon_path", "")
+	if not FileAccess.file_exists(balloon_path):
+		DialogueSettings.set_setting("balloon_path", "")
+		balloon_path = ""
 	balloon_path_input.placeholder_text = balloon_path if balloon_path != "" else DialogueConstants.translate("settings.default_balloon_path")
 	revert_balloon_button.visible = balloon_path != ""
 	revert_balloon_button.icon = get_theme_icon("RotateLeft", "EditorIcons")


### PR DESCRIPTION
This automatically reverts the custom balloon path back to the example balloon if the custom balloon scene file no longer exists.