### PR TITLE
Make the C# balloon clean up mutation signal

### DIFF
--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -84,19 +84,13 @@ namespace DialogueManagerRuntime
         Next(response.NextId);
       }));
 
-      DialogueManager.Mutated += (mutation) =>
-      {
-        isWaitingForInput = false;
-        willHideBalloon = true;
-        GetTree().CreateTimer(0.1f).Timeout += () =>
-        {
-          if (willHideBalloon)
-          {
-            willHideBalloon = false;
-            balloon.Hide();
-          }
-        };
-      };
+      DialogueManager.Mutated += OnMutated;
+    }
+
+
+    public override void _ExitTree()
+    {
+      DialogueManager.Mutated -= OnMutated;
     }
 
 
@@ -177,6 +171,27 @@ namespace DialogueManagerRuntime
         balloon.FocusMode = Control.FocusModeEnum.All;
         balloon.GrabFocus();
       }
+    }
+
+
+    #endregion
+
+
+    #region signals
+
+
+    private void OnMutated(Dictionary _mutation)
+    {
+      isWaitingForInput = false;
+      willHideBalloon = true;
+      GetTree().CreateTimer(0.1f).Timeout += () =>
+      {
+        if (willHideBalloon)
+        {
+          willHideBalloon = false;
+          balloon.Hide();
+        }
+      };
     }
 
 


### PR DESCRIPTION
This makes the C# custom balloon template clean up its `mutated` signal handler when freeing the balloon.