### PR TITLE
Allow passing Signal arguments to functions

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1009,10 +1009,6 @@ func resolve(tokens: Array, extra_game_states: Array):
 	if limit >= 1000:
 		assert(false, DialogueConstants.translate("runtime.something_went_wrong"))
 
-	# Account for Signal literals in emit calls
-	if tokens[0].value is Signal:
-		return tokens[0].value.get_name()
-
 	return tokens[0].value
 
 
@@ -1146,6 +1142,9 @@ func thing_has_property(thing: Object, property: String) -> bool:
 
 
 func resolve_signal(args: Array, extra_game_states: Array):
+	if args[0] is Signal:
+		args[0] = args[0].get_name()
+
 	for state in get_game_states(extra_game_states):
 		if typeof(state) == TYPE_DICTIONARY:
 			continue


### PR DESCRIPTION
I was trying to create a function that receives a signal as one of the arguments, but the signal gets converted to string by the time the function is called. Something like:

```gdscript
func wait_for_stuff_to_happen(something_happened: Signal, target: Node):
    target.do_stuff()
    await something_happened
    target.do_more_stuff()
```
It would be called from dialogue like `do wait_for_stuff_to_happen(...)`.

Changing the conversion to `resolve_signal` allowed me to pass the signal, so I thought it might be a good idea to change it. If it isn't or it should be handled in a different way let me know.