### PR TITLE
Allow inherited mutations in C#

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -159,14 +159,14 @@ namespace DialogueManagerRuntime
 
         public bool ThingHasMethod(GodotObject thing, string method)
         {
-            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
             return info != null;
         }
 
 
         public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
         {
-            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
             if (info == null) return;
 


### PR DESCRIPTION
This fixes an issue where mutation methods that were defined in a parent class to the current scene weren't visible to the dialogue runtime.

Related to #487 