### PR TITLE
Fix order of resolves for state

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -142,7 +142,7 @@ func parse(text: String, path: String) -> Error:
 		if raw_line.begins_with("using "):
 			var using_match: RegExMatch = USING_REGEX.search(raw_line)
 			if "state" in using_match.names:
-				var using_state: String = using_match.strings[using_match.names.state]
+				var using_state: String = using_match.strings[using_match.names.state].strip_edges()
 				if not using_state in autoload_names:
 					add_error(id, 0, DialogueConstants.ERR_UNKNOWN_USING)
 				elif not using_state in using_states:

--- a/addons/dialogue_manager/utilities/builtins.gd
+++ b/addons/dialogue_manager/utilities/builtins.gd
@@ -15,6 +15,9 @@ const SUPPORTED_BUILTIN_TYPES = [
 ]
 
 
+static var resolve_method_error: Error = OK
+
+
 static func is_supported(thing) -> bool:
 	return typeof(thing) in SUPPORTED_BUILTIN_TYPES
 
@@ -37,6 +40,8 @@ static func resolve_property(builtin, property: String):
 
 
 static func resolve_method(thing, method_name: String, args: Array):
+	resolve_method_error = OK
+
 	# Resolve static methods manually
 	match typeof(thing):
 		TYPE_VECTOR2:
@@ -69,9 +74,14 @@ static func resolve_method(thing, method_name: String, args: Array):
 		assert(false, expression.get_error_text())
 	var result = expression.execute([thing] + args, null, false)
 	if expression.has_execute_failed():
-		assert(false, expression.get_error_text())
+		resolve_method_error = ERR_CANT_RESOLVE
+		return null
 
 	return result
+
+
+static func has_resolve_method_failed() -> bool:
+	return resolve_method_error != OK
 
 
 static func resolve_color_property(color: Color, property: String):

--- a/examples/state.gd
+++ b/examples/state.gd
@@ -6,7 +6,7 @@ var player_name: String = ""
 
 func ask_for_name() -> void:
 	var name_input_dialog = load("res://examples/name_input_dialog/name_input_dialog.tscn").instantiate()
-	get_tree().root.add_child(name_input_dialog)
+	get_tree().current_scene.add_child(name_input_dialog)
 	name_input_dialog.popup_centered()
 	await name_input_dialog.confirmed
 	player_name = name_input_dialog.name_edit.text


### PR DESCRIPTION
This better handles builtin `resolve_method` calls when the method doesn't exist. It will now fall back to the standard "not found in any states" error.

Fixes #498 