### PR TITLE
Emit passed_title if title found between line and responses

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -465,6 +465,11 @@ func parse(text: String, path: String) -> Error:
 		# Done!
 		parsed_lines[str(id)] = line
 
+	# Assume the last line ends the dialogue
+	var last_line: Dictionary = parsed_lines.values()[parsed_lines.values().size() - 1]
+	if last_line.next_id == "":
+		last_line.next_id = DialogueConstants.ID_END
+
 	if errors.size() > 0:
 		return ERR_PARSE_ERROR
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -411,7 +411,7 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 	if data.type == DialogueConstants.TYPE_RESPONSE:
 		# Note: For some reason C# has occasional issues with using the responses property directly
 		# so instead we use set and get here.
-		line.set("responses", await get_responses(data.get("responses"), resource, id_trail, extra_game_states))
+		line.set("responses", await get_responses(data.get("responses", []), resource, id_trail, extra_game_states))
 		return line
 
 	# Inject the next node's responses if they have any
@@ -429,7 +429,7 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 		if next_line != null and next_line.type == DialogueConstants.TYPE_RESPONSE:
 			# Note: For some reason C# has occasional issues with using the responses property directly
 			# so instead we use set and get here.
-			line.set("responses", await get_responses(next_line.get("responses"), resource, id_trail, extra_game_states))
+			line.set("responses", await get_responses(next_line.get("responses", []), resource, id_trail, extra_game_states))
 
 	line.next_id = "|".join(stack) if line.next_id == DialogueConstants.ID_NULL else line.next_id + id_trail
 	return line

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -409,14 +409,27 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 
 	# If we are the first of a list of responses then get the other ones
 	if data.type == DialogueConstants.TYPE_RESPONSE:
-		line.responses = await get_responses(data.responses, resource, id_trail, extra_game_states)
+		# Note: For some reason C# has occasional issues with using the responses property directly
+		# so instead we use set and get here.
+		line.set("responses", await get_responses(data.get("responses"), resource, id_trail, extra_game_states))
 		return line
 
 	# Inject the next node's responses if they have any
 	if resource.lines.has(line.next_id):
 		var next_line: Dictionary = resource.lines.get(line.next_id)
+
+		# If the response line is marked as a title then make sure to emit the passed_title signal.
+		if line.next_id in resource.titles.values():
+			passed_title.emit(resource.titles.find_key(line.next_id))
+
+		# If the next line is a title then check where it points to see if that is a set of responses.
+		if next_line.type == DialogueConstants.TYPE_GOTO:
+			next_line = resource.lines.get(next_line.next_id)
+
 		if next_line != null and next_line.type == DialogueConstants.TYPE_RESPONSE:
-			line.responses = await get_responses(next_line.responses, resource, id_trail, extra_game_states)
+			# Note: For some reason C# has occasional issues with using the responses property directly
+			# so instead we use set and get here.
+			line.set("responses", await get_responses(next_line.get("responses"), resource, id_trail, extra_game_states))
 
 	line.next_id = "|".join(stack) if line.next_id == DialogueConstants.ID_NULL else line.next_id + id_trail
 	return line


### PR DESCRIPTION
Previously, if a title was found between a line and responses the `passed_title` signal wouldn't be emitted.

This change also makes sure responses found through a jump after a line will now be attached to the line.

For example:

```
Nathan: Will you do it?
~ responses
- Yes
- No
	Nathan: Pleeeaaase...
	=> responses
Nathan: Great!
```

The "Pleeeaaase..." line will now have "Yes" and "No" attached to it.

Fixes #503 
Fixes #505 