### PR TITLE
Allow awaiting inline mutations

### DIFF
--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -266,7 +266,7 @@ Nathan: I'm not sure we've met before [do wave()]I'm Nathan.
 Nathan: I can also emit signals[do emit("some_signal")] inline.
 ```
 
-One thing to note is that _inline mutations_ that use `await` won't be awaited so the dialogue will continue right away.
+Inline mutations that use `await` in their implementation will pause typing of dialogue until they resolve.
 
 ### State shortcuts
 


### PR DESCRIPTION
This makes inline mutations behave the same as regular mutations in that if they use `await` in their implementation they will pause execution of dialogue (in this case typing dialogue) until they resolve.

Related to #515 