### PR TITLE
Avoid outofbounds when DialogueLabel changes language while typing

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -195,6 +195,10 @@ func _should_auto_pause() -> bool:
 
 	var parsed_text: String = get_parsed_text()
 
+	# Avoid outofbounds when the label auto-translates and the text changes to one shorter while typing out
+	# Note: visible characters can be larger than parsed_text after a translation event
+	if visible_characters >= parsed_text.length(): return false
+
 	# Ignore pause characters if they are next to a non-pause character
 	if parsed_text[visible_characters] in skip_pause_at_character_if_followed_by.split():
 		return false


### PR DESCRIPTION
How to replicate:
![Screenshot 2024-03-20 131755](https://github.com/nathanhoad/godot_dialogue_manager/assets/137085727/d7d8dcfa-6578-4893-b284-b283c0eb845b)

I found an edge case where you get an out of bounds exception while typing out if the text translates to one shorter. It seems the "visible_characters" property can be larger than the "parsed_text" when the text is localized.

How to replicate:
1. Create a dialogue label with auto-translate enabled
2. Change the TranslationServer language while typing out. 
> For example English: ```Clive: In the year 1988...``` to Spanish: ```Clive: En el año 1988```

