### PR TITLE
Simplify choosing actions for next and skip

### DIFF
--- a/addons/dialogue_manager/dialogue_reponses_menu.gd
+++ b/addons/dialogue_manager/dialogue_reponses_menu.gd
@@ -11,6 +11,9 @@ signal response_selected(response)
 ## Optionally specify a control to duplicate for each response
 @export var response_template: Control
 
+## The action for accepting a response (is possibly overridden by parent dialogue balloon).
+@export var next_action: StringName = &""
+
 # The list of dialogue responses.
 var responses: Array = []:
 	set(value):
@@ -124,5 +127,5 @@ func _on_response_gui_input(event: InputEvent, item: Control, response) -> void:
 
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == MOUSE_BUTTON_LEFT:
 		response_selected.emit(response)
-	elif event.is_action_pressed("ui_accept") and item in get_menu_items():
+	elif event.is_action_pressed(&"ui_accept" if next_action.is_empty() else next_action) and item in get_menu_items():
 		response_selected.emit(response)

--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -5,8 +5,8 @@ namespace DialogueManagerRuntime
 {
   public partial class ExampleBalloon : CanvasLayer
   {
-    const string NEXT_ACTION = "ui_accept";
-    const string SKIP_ACTION = "ui_cancel";
+    [Export] public string NextAction = "ui_accept";
+    [Export] public string SkipAction = "ui_cancel";
 
 
     Control balloon;
@@ -55,7 +55,7 @@ namespace DialogueManagerRuntime
         if ((bool)dialogueLabel.Get("is_typing"))
         {
           bool mouseWasClicked = @event is InputEventMouseButton && (@event as InputEventMouseButton).ButtonIndex == MouseButton.Left && @event.IsPressed();
-          bool skipButtonWasPressed = @event.IsActionPressed(SKIP_ACTION);
+          bool skipButtonWasPressed = @event.IsActionPressed(SkipAction);
           if (mouseWasClicked || skipButtonWasPressed)
           {
             GetViewport().SetInputAsHandled();
@@ -73,12 +73,16 @@ namespace DialogueManagerRuntime
         {
           Next(dialogueLine.NextId);
         }
-        else if (@event.IsActionPressed(NEXT_ACTION) && GetViewport().GuiGetFocusOwner() == balloon)
+        else if (@event.IsActionPressed(NextAction) && GetViewport().GuiGetFocusOwner() == balloon)
         {
           Next(dialogueLine.NextId);
         }
       };
 
+      if (string.IsNullOrEmpty((string)responsesMenu.Get("next_action")))
+      {
+        responsesMenu.Set("next_action", NextAction);
+      }
       responsesMenu.Connect("response_selected", Callable.From((DialogueResponse response) =>
       {
         Next(response.NextId);

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -1,11 +1,10 @@
 extends CanvasLayer
 
 ## The action to use for advancing the dialogue
-const NEXT_ACTION = &"ui_accept"
+@export var next_action: StringName = &"ui_accept"
 
 ## The action to use to skip typing the dialogue
-const SKIP_ACTION = &"ui_cancel"
-
+@export var skip_action: StringName = &"ui_cancel"
 
 @onready var balloon: Control = %Balloon
 @onready var character_label: RichTextLabel = %CharacterLabel
@@ -80,6 +79,10 @@ func _ready() -> void:
 	balloon.hide()
 	Engine.get_singleton("DialogueManager").mutated.connect(_on_mutated)
 
+	# If the responses menu doesn't have a next action set, use this one
+	if responses_menu.next_action.is_empty():
+		responses_menu.next_action = next_action
+
 
 func _unhandled_input(_event: InputEvent) -> void:
 	# Only the balloon is allowed to handle input while it's showing
@@ -116,7 +119,7 @@ func _on_balloon_gui_input(event: InputEvent) -> void:
 	# See if we need to skip typing of the dialogue
 	if dialogue_label.is_typing:
 		var mouse_was_clicked: bool = event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.is_pressed()
-		var skip_button_was_pressed: bool = event.is_action_pressed(SKIP_ACTION)
+		var skip_button_was_pressed: bool = event.is_action_pressed(skip_action)
 		if mouse_was_clicked or skip_button_was_pressed:
 			get_viewport().set_input_as_handled()
 			dialogue_label.skip_typing()
@@ -130,7 +133,7 @@ func _on_balloon_gui_input(event: InputEvent) -> void:
 
 	if event is InputEventMouseButton and event.is_pressed() and event.button_index == MOUSE_BUTTON_LEFT:
 		next(dialogue_line.next_id)
-	elif event.is_action_pressed(NEXT_ACTION) and get_viewport().gui_get_focus_owner() == balloon:
+	elif event.is_action_pressed(next_action) and get_viewport().gui_get_focus_owner() == balloon:
 		next(dialogue_line.next_id)
 
 


### PR DESCRIPTION
This simplifies how to replace the actions used for "next" and "skip" in clones of the example dialogue balloon. The action used for accepting responses is now exposed on the responses menu node too - if left blank it will be set to whatever the parent balloon's "next" action is.

Fixes #527 