### PR TITLE
Allow non-blocking mutations with "do!"

### DIFF
--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -9,13 +9,13 @@ var dialogue_manager_parser: DialogueManagerParser = DialogueManagerParser.new()
 
 var regex_titles: RegEx = RegEx.create_from_string("^\\s*(?<title>~\\s+[^\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\-\\=\\+\\{\\}\\[\\]\\;\\:\\\"\\'\\,\\.\\<\\>\\?\\/\\s]+)")
 var regex_comments: RegEx = RegEx.create_from_string("(?:(?>\"(?:\\\\\"|[^\"\\n])*\")[^\"\\n]*?\\s*(?<comment>#[^\\n]*)$|^[^\"#\\n]*?\\s*(?<comment2>#[^\\n]*))")
-var regex_mutation: RegEx = RegEx.create_from_string("^\\s*(do|set) (?<mutation>.*)")
+var regex_mutation: RegEx = RegEx.create_from_string("^\\s*(do|do!|set) (?<mutation>.*)")
 var regex_condition: RegEx = RegEx.create_from_string("^\\s*(if|elif|while|else if) (?<condition>.*)")
 var regex_wcondition: RegEx = RegEx.create_from_string("\\[if (?<condition>((?:[^\\[\\]]*)|(?:\\[(?1)\\]))*?)\\]")
 var regex_wendif: RegEx = RegEx.create_from_string("\\[(\\/if|else)\\]")
 var regex_rgroup: RegEx = RegEx.create_from_string("\\[\\[(?<options>.*?)\\]\\]")
 var regex_endconditions: RegEx = RegEx.create_from_string("^\\s*(endif|else):?\\s*$")
-var regex_tags: RegEx = RegEx.create_from_string("\\[(?<tag>(?!(?:ID:.*)|if)[a-zA-Z_][a-zA-Z0-9_]*)(?:[= ](?<val>[^\\[\\]]+))?\\](?:(?<text>(?!\\[\\/\\k<tag>\\]).*?)?(?<end>\\[\\/\\k<tag>\\]))?")
+var regex_tags: RegEx = RegEx.create_from_string("\\[(?<tag>(?!(?:ID:.*)|if)[a-zA-Z_][a-zA-Z0-9_]*!?)(?:[= ](?<val>[^\\[\\]]+))?\\](?:(?<text>(?!\\[\\/\\k<tag>\\]).*?)?(?<end>\\[\\/\\k<tag>\\]))?")
 var regex_dialogue: RegEx = RegEx.create_from_string("^\\s*(?:(?<random>\\%[\\d.]* )|(?<response>- ))?(?:(?<character>[^#:]*): )?(?<dialogue>.*)$")
 var regex_goto: RegEx = RegEx.create_from_string("=><? (?:(?<file>[^\\/]+)\\/)?(?<title>[^\\/]*)")
 var regex_string: RegEx = RegEx.create_from_string("^(?<delimiter>[\"'])(?<content>(?:\\\\{2})*|(?:.*?[^\\\\](?:\\\\{2})*))\\1$")
@@ -245,7 +245,6 @@ func _get_expression_syntax_highlighting(start_index: int, type: ExpressionType,
 
 			colors[start_index + assignment_match.get_start("op")] = {"color": text_edit.theme_overrides.symbols_color}
 			colors[start_index + assignment_match.get_end("op")] = {"color": text_edit.theme_overrides.text_color}
-
 			colors.merge(_get_literal_syntax_highlighting(start_index + assignment_match.get_start("val"), assignment_match.get_string("val")), true)
 	else:
 		colors.merge(_get_literal_syntax_highlighting(start_index, text), true)
@@ -346,7 +345,11 @@ func _get_literal_syntax_highlighting(start_index: int, text: String) -> Diction
 		colors.merge(_get_literal_syntax_highlighting(start_index + comparison_match.get_start("left"), comparison_match.get_string("left")), true)
 		colors[start_index + comparison_match.get_start("op")] = {"color": text_edit.theme_overrides.symbols_color}
 		colors[start_index + comparison_match.get_end("op")] = {"color": text_edit.theme_overrides.text_color}
-		colors.merge(_get_literal_syntax_highlighting(start_index + comparison_match.get_start("right"), comparison_match.get_string("right")), true)
+		var right = comparison_match.get_string("right")
+		if right.ends_with(":"):
+			right = right.substr(0, right.length() - 1)
+		colors.merge(_get_literal_syntax_highlighting(start_index + comparison_match.get_start("right"), right), true)
+		colors[start_index + comparison_match.get_start("right") + right.length()] = { "color": text_edit.theme_overrides.symbols_color }
 
 	# Logical binary operators.
 	var blogical_matches: Array[RegExMatch] = regex_blogical.search_all(text)

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -581,8 +581,11 @@ func mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation: 
 		if not mutation_contains_assignment(mutation.expression) and not is_inline_mutation:
 			mutated.emit(mutation)
 
-		await resolve(mutation.expression.duplicate(true), extra_game_states)
-		return
+		if mutation.get("is_blocking", true):
+			await resolve(mutation.expression.duplicate(true), extra_game_states)
+			return
+		else:
+			resolve(mutation.expression.duplicate(true), extra_game_states)
 
 	# Wait one frame to give the dialogue handler a chance to yield
 	await get_tree().process_frame

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -238,7 +238,7 @@ Nathan: You have {{num_apples}} [if num_apples == 1]apple[else]apples[/if], nice
 
 ## Mutations
 
-You can modify state with either a "set" or a "do" line.
+You can affect state with either a "set" or a "do" line.
 
 ```
 if SomeGlobal.has_met_nathan == false
@@ -266,7 +266,7 @@ Nathan: I'm not sure we've met before [do wave()]I'm Nathan.
 Nathan: I can also emit signals[do emit("some_signal")] inline.
 ```
 
-Inline mutations that use `await` in their implementation will pause typing of dialogue until they resolve.
+Inline mutations that use `await` in their implementation will pause typing of dialogue until they resolve. To ignore awaiting, add a "!" after the "do" keyword - eg. `[do! something()]`.
 
 ### State shortcuts
 

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -115,6 +115,21 @@ Nathan: Done.")
 	assert(duration > 0.2, "Mutation should take some time.")
 
 
+func test_can_run_non_blocking_mutations() -> void:
+	var resource = create_resource("
+~ start
+Nathan: This mutation should not wait.
+do! StateForTests.long_mutation()
+Nathan: Done.")
+
+	var line = await resource.get_next_dialogue_line("start")
+
+	var started_at: float = Time.get_unix_time_from_system()
+	line = await resource.get_next_dialogue_line(line.next_id)
+	var duration: float = Time.get_unix_time_from_system() - started_at
+	assert(duration < 0.1, "Mutation should not take any time.")
+
+
 func test_can_run_mutations_with_typed_arrays() -> void:
 	var resource = create_resource("
 ~ start


### PR DESCRIPTION
This adds support for not having to wait for mutations that use `await`. To do so, add a "!" to "do" - eg. `do! something_that_awaits()`