### PR TITLE
Add support for find/replace across files

### DIFF
--- a/addons/dialogue_manager/components/find_in_files.gd
+++ b/addons/dialogue_manager/components/find_in_files.gd
@@ -1,0 +1,229 @@
+@tool
+extends Control
+
+signal result_selected(path: String, cursor: Vector2, length: int)
+
+
+const DialogueConstants = preload("../constants.gd")
+
+
+@export var main_view: Control
+@export var code_edit: CodeEdit
+
+@onready var input: LineEdit = %Input
+@onready var search_button: Button = %SearchButton
+@onready var match_case_button: CheckBox = %MatchCaseButton
+@onready var replace_toggle: CheckButton = %ReplaceToggle
+@onready var replace_container: VBoxContainer = %ReplaceContainer
+@onready var replace_input: LineEdit = %ReplaceInput
+@onready var replace_selected_button: Button = %ReplaceSelectedButton
+@onready var replace_all_button: Button = %ReplaceAllButton
+@onready var results_container: VBoxContainer = %ResultsContainer
+@onready var result_template: HBoxContainer = %ResultTemplate
+
+var current_results: Dictionary = {}:
+	set(value):
+		current_results = value
+		update_results_view()
+		if current_results.size() == 0:
+			replace_selected_button.disabled = true
+			replace_all_button.disabled = true
+		else:
+			replace_selected_button.disabled = false
+			replace_all_button.disabled = false
+	get:
+		return current_results
+
+var selections: PackedStringArray = []
+
+
+func prepare() -> void:
+	input.grab_focus()
+
+	var template_label = result_template.get_node("Label")
+	template_label.get_theme_stylebox(&"focus").bg_color = code_edit.theme_overrides.current_line_color
+	template_label.add_theme_font_override(&"normal_font", code_edit.get_theme_font(&"font"))
+
+	replace_toggle.set_pressed_no_signal(false)
+	replace_container.hide()
+
+	$VBoxContainer/HBoxContainer/FindContainer/Label.text = DialogueConstants.translate("search.find")
+	input.placeholder_text = DialogueConstants.translate("search.placeholder")
+	input.text = ""
+	search_button.text = DialogueConstants.translate("search.find_all")
+	match_case_button.text = DialogueConstants.translate("search.match_case")
+	replace_toggle.text = DialogueConstants.translate("search.toggle_replace")
+	$VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceLabel.text = DialogueConstants.translate("search.replace_with")
+	replace_input.placeholder_text = DialogueConstants.translate("search.replace_placeholder")
+	replace_input.text = ""
+	replace_all_button.text = DialogueConstants.translate("search.replace_all")
+	replace_selected_button.text = DialogueConstants.translate("search.replace_selected")
+
+	selections.clear()
+	self.current_results = {}
+
+#region helpers
+
+
+func update_results_view() -> void:
+	for child in results_container.get_children():
+		child.queue_free()
+
+	for path in current_results.keys():
+		var path_label: Label = Label.new()
+		path_label.text = path
+		# Show open files
+		if main_view.open_buffers.has(path):
+			path_label.text += "(*)"
+		results_container.add_child(path_label)
+		for path_result in current_results.get(path):
+			var result_item: HBoxContainer = result_template.duplicate()
+
+			var checkbox: CheckBox = result_item.get_node("CheckBox") as CheckBox
+			var key: String = get_selection_key(path, path_result)
+			checkbox.toggled.connect(func(is_pressed):
+				if is_pressed:
+					if not selections.has(key):
+						selections.append(key)
+				else:
+					if selections.has(key):
+						selections.remove_at(selections.find(key))
+			)
+			checkbox.set_pressed_no_signal(selections.has(key))
+			checkbox.visible = replace_toggle.button_pressed
+
+			var result_label: RichTextLabel = result_item.get_node("Label") as RichTextLabel
+			var colors: Dictionary = code_edit.theme_overrides
+			var highlight: String = ""
+			if replace_toggle.button_pressed:
+				var matched_word: String = "[bgcolor=" + colors.critical_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + path_result.matched_text + "[/color][/bgcolor]"
+				highlight = "[s]" + matched_word + "[/s][bgcolor=" + colors.notice_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + replace_input.text + "[/color][/bgcolor]"
+			else:
+				highlight = "[bgcolor=" + colors.symbols_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + path_result.matched_text + "[/color][/bgcolor]"
+			var text: String = path_result.text.substr(0, path_result.index) + highlight + path_result.text.substr(path_result.index + path_result.query.length())
+			result_label.text = "%s: %s" % [str(path_result.line).lpad(4), text]
+			result_label.gui_input.connect(func(event):
+				if event is InputEventMouseButton and (event as InputEventMouseButton).button_index == MOUSE_BUTTON_LEFT and (event as InputEventMouseButton).double_click:
+					result_selected.emit(path, Vector2(path_result.index, path_result.line), path_result.query.length())
+			)
+
+			results_container.add_child(result_item)
+
+
+func find_in_files() -> Dictionary:
+	var results: Dictionary = {}
+
+	var q: String = input.text
+	var cache = Engine.get_meta("DialogueCache")
+	var file: FileAccess
+	for path in cache.get_files():
+		var path_results: Array = []
+		var lines: PackedStringArray = []
+
+		if main_view.open_buffers.has(path):
+			lines = main_view.open_buffers.get(path).text.split("\n")
+		else:
+			file = FileAccess.open(path, FileAccess.READ)
+			lines = file.get_as_text().split("\n")
+
+		for i in range(0, lines.size()):
+			var index: int = find_in_line(lines[i], q)
+			while index > -1:
+				path_results.append({
+					line = i,
+					index = index,
+					text = lines[i],
+					matched_text = lines[i].substr(index, q.length()),
+					query = q
+				})
+				index = find_in_line(lines[i], q, index + q.length())
+
+		if file != null and file.is_open():
+			file.close()
+
+		if path_results.size() > 0:
+			results[path] = path_results
+
+	return results
+
+
+func get_selection_key(path: String, path_result: Dictionary) -> String:
+	return "%s-%d-%d" % [path, path_result.line, path_result.index]
+
+
+func find_in_line(line: String, query: String, from_index: int = 0) -> int:
+	if match_case_button.button_pressed:
+		return line.find(query, from_index)
+	else:
+		return line.findn(query, from_index)
+
+
+func replace_results(only_selected: bool) -> void:
+	var file: FileAccess
+	var lines: PackedStringArray = []
+	for path in current_results:
+		if main_view.open_buffers.has(path):
+			lines = main_view.open_buffers.get(path).text.split("\n")
+		else:
+			file = FileAccess.open(path, FileAccess.READ_WRITE)
+			lines = file.get_as_text().split("\n")
+
+		# Read the results in reverse because we're going to be modifying them as we go
+		var path_results: Array = current_results.get(path).duplicate()
+		path_results.reverse()
+		for path_result in path_results:
+			var key: String = get_selection_key(path, path_result)
+			if not only_selected or (only_selected and selections.has(key)):
+				lines[path_result.line] = lines[path_result.line].substr(0, path_result.index) + replace_input.text + lines[path_result.line].substr(path_result.index + path_result.matched_text.length())
+
+		var replaced_text: String = "\n".join(lines)
+		if file != null and file.is_open():
+			file.seek(0)
+			file.store_string(replaced_text)
+			file.close()
+		else:
+			main_view.open_buffers.get(path).text = replaced_text
+			if main_view.current_file_path == path:
+				code_edit.text = replaced_text
+
+	current_results = find_in_files()
+
+
+#endregion
+
+#region signals
+
+
+func _on_search_button_pressed() -> void:
+	selections.clear()
+	self.current_results = find_in_files()
+
+
+func _on_input_text_submitted(new_text: String) -> void:
+	_on_search_button_pressed()
+
+
+func _on_replace_toggle_toggled(toggled_on: bool) -> void:
+	replace_container.visible = toggled_on
+	if toggled_on:
+		replace_input.grab_focus()
+	update_results_view()
+
+
+func _on_replace_input_text_changed(new_text: String) -> void:
+	update_results_view()
+
+
+func _on_replace_selected_button_pressed() -> void:
+	replace_results(true)
+
+
+func _on_replace_all_button_pressed() -> void:
+	replace_results(false)
+
+
+func _on_match_case_button_toggled(toggled_on: bool) -> void:
+	_on_search_button_pressed()
+
+
+#endregion

--- a/addons/dialogue_manager/components/find_in_files.tscn
+++ b/addons/dialogue_manager/components/find_in_files.tscn
@@ -1,0 +1,139 @@
+[gd_scene load_steps=3 format=3 uid="uid://0n7hwviyyly4"]
+
+[ext_resource type="Script" path="res://addons/dialogue_manager/components/find_in_files.gd" id="1_3xicy"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_owohg"]
+bg_color = Color(0.266667, 0.278431, 0.352941, 0.243137)
+corner_detail = 1
+
+[node name="FindInFiles" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource("1_3xicy")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="FindContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/FindContainer"]
+layout_mode = 2
+text = "Find:"
+
+[node name="Input" type="LineEdit" parent="VBoxContainer/HBoxContainer/FindContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+clear_button_enabled = true
+
+[node name="FindToolbar" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/FindContainer"]
+layout_mode = 2
+
+[node name="SearchButton" type="Button" parent="VBoxContainer/HBoxContainer/FindContainer/FindToolbar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Find all..."
+
+[node name="MatchCaseButton" type="CheckBox" parent="VBoxContainer/HBoxContainer/FindContainer/FindToolbar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Match case"
+
+[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer/FindContainer/FindToolbar"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ReplaceToggle" type="CheckButton" parent="VBoxContainer/HBoxContainer/FindContainer/FindToolbar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Replace"
+
+[node name="ReplaceContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ReplaceLabel" type="Label" parent="VBoxContainer/HBoxContainer/ReplaceContainer"]
+layout_mode = 2
+text = "Replace with:"
+
+[node name="ReplaceInput" type="LineEdit" parent="VBoxContainer/HBoxContainer/ReplaceContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+clear_button_enabled = true
+
+[node name="ReplaceToolbar" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/ReplaceContainer"]
+layout_mode = 2
+
+[node name="ReplaceSelectedButton" type="Button" parent="VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceToolbar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Replace selected"
+
+[node name="ReplaceAllButton" type="Button" parent="VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceToolbar"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Replace all"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ReplaceToolbar" type="HBoxContainer" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+follow_focus = true
+
+[node name="ResultsContainer" type="VBoxContainer" parent="VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 0
+
+[node name="ResultTemplate" type="HBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 0
+offset_left = 155.0
+offset_top = -74.0
+offset_right = 838.0
+offset_bottom = -51.0
+
+[node name="CheckBox" type="CheckBox" parent="ResultTemplate"]
+layout_mode = 2
+
+[node name="Label" type="RichTextLabel" parent="ResultTemplate"]
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 2
+theme_override_styles/focus = SubResource("StyleBoxFlat_owohg")
+bbcode_enabled = true
+text = "Result"
+fit_content = true
+scroll_active = false
+
+[connection signal="text_submitted" from="VBoxContainer/HBoxContainer/FindContainer/Input" to="." method="_on_input_text_submitted"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/FindContainer/FindToolbar/SearchButton" to="." method="_on_search_button_pressed"]
+[connection signal="toggled" from="VBoxContainer/HBoxContainer/FindContainer/FindToolbar/MatchCaseButton" to="." method="_on_match_case_button_toggled"]
+[connection signal="toggled" from="VBoxContainer/HBoxContainer/FindContainer/FindToolbar/ReplaceToggle" to="." method="_on_replace_toggle_toggled"]
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceInput" to="." method="_on_replace_input_text_changed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceToolbar/ReplaceSelectedButton" to="." method="_on_replace_selected_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/ReplaceContainer/ReplaceToolbar/ReplaceAllButton" to="." method="_on_replace_all_button_pressed"]

--- a/addons/dialogue_manager/components/search_and_replace.gd
+++ b/addons/dialogue_manager/components/search_and_replace.gd
@@ -50,6 +50,7 @@ var result_index: int = -1:
 func _ready() -> void:
 	apply_theme()
 
+	input.placeholder_text = DialogueConstants.translate("search.placeholder")
 	previous_button.tooltip_text = DialogueConstants.translate("search.previous")
 	next_button.tooltip_text = DialogueConstants.translate("search.next")
 	match_case_button.text = DialogueConstants.translate("search.match_case")

--- a/addons/dialogue_manager/components/search_and_replace.tscn
+++ b/addons/dialogue_manager/components/search_and_replace.tscn
@@ -17,6 +17,7 @@ layout_mode = 2
 [node name="Input" type="LineEdit" parent="Search"]
 layout_mode = 2
 size_flags_horizontal = 3
+placeholder_text = "Text to search for"
 metadata/_edit_use_custom_anchors = true
 
 [node name="MatchCaseCheckBox" type="CheckBox" parent="Search"]

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -30,6 +30,9 @@ msgstr "Clear recent files"
 msgid "save_all_files"
 msgstr "Save all files"
 
+msgid "find_in_files"
+msgstr "Find in files..."
+
 msgid "test_dialogue"
 msgstr "Test dialogue"
 
@@ -218,6 +221,21 @@ msgstr "Check for updates"
 
 msgid "n_of_n"
 msgstr "{index} of {total}"
+
+msgid "search.find"
+msgstr "Find:"
+
+msgid "search.find_all"
+msgstr "Find all..."
+
+msgid "search.placeholder"
+msgstr "Text to search for"
+
+msgid "search.replace_placeholder"
+msgstr "Text to replace it with"
+
+msgid "search.replace_selected"
+msgstr "Replace selected"
 
 msgid "search.previous"
 msgstr "Previous"

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -23,6 +23,9 @@ msgstr ""
 msgid "save_all_files"
 msgstr ""
 
+msgid "find_in_files"
+msgstr ""
+
 msgid "test_dialogue"
 msgstr ""
 
@@ -207,6 +210,21 @@ msgid "settings.check_for_updates"
 msgstr ""
 
 msgid "n_of_n"
+msgstr ""
+
+msgid "search.find"
+msgstr ""
+
+msgid "search.find_all"
+msgstr ""
+
+msgid "search.placeholder"
+msgstr ""
+
+msgid "search.replace_placeholder"
+msgstr ""
+
+msgid "search.replace_selected"
 msgstr ""
 
 msgid "search.previous"

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -41,11 +41,14 @@ enum TranslationSource {
 @onready var build_error_dialog: AcceptDialog = $BuildErrorDialog
 @onready var close_confirmation_dialog: ConfirmationDialog = $CloseConfirmationDialog
 @onready var updated_dialog: AcceptDialog = $UpdatedDialog
+@onready var find_in_files_dialog: AcceptDialog = $FindInFilesDialog
+@onready var find_in_files: Control = $FindInFilesDialog/FindInFiles
 
 # Toolbar
 @onready var new_button: Button = %NewButton
 @onready var open_button: MenuButton = %OpenButton
 @onready var save_all_button: Button = %SaveAllButton
+@onready var find_in_files_button: Button = %FindInFilesButton
 @onready var test_button: Button = %TestButton
 @onready var search_button: Button = %SearchButton
 @onready var insert_button: MenuButton = %InsertButton
@@ -188,6 +191,9 @@ func _unhandled_input(event: InputEvent) -> void:
 			"Ctrl+F5", "Command+F5":
 				get_viewport().set_input_as_handled()
 				_on_test_button_pressed()
+			"Ctrl+Shift+F", "Command+Shift+F":
+				get_viewport().set_input_as_handled()
+				_on_find_in_files_button_pressed()
 
 
 func apply_changes() -> void:
@@ -354,6 +360,9 @@ func apply_theme() -> void:
 			current_line_color = editor_settings.get_setting("text_editor/theme/highlighting/current_line_color"),
 			error_line_color = editor_settings.get_setting("text_editor/theme/highlighting/mark_color"),
 
+			critical_color = editor_settings.get_setting("text_editor/theme/highlighting/comment_markers/critical_color"),
+			notice_color = editor_settings.get_setting("text_editor/theme/highlighting/comment_markers/notice_color"),
+
 			titles_color = editor_settings.get_setting("text_editor/theme/highlighting/control_flow_keyword_color"),
 			text_color = editor_settings.get_setting("text_editor/theme/highlighting/text_color"),
 			conditions_color = editor_settings.get_setting("text_editor/theme/highlighting/keyword_color"),
@@ -376,6 +385,9 @@ func apply_theme() -> void:
 
 		save_all_button.icon = get_theme_icon("Save", "EditorIcons")
 		save_all_button.tooltip_text = DialogueConstants.translate("start_all_files")
+
+		find_in_files_button.icon = get_theme_icon("ViewportZoom", "EditorIcons")
+		find_in_files_button.tooltip_text = DialogueConstants.translate("find_in_files")
 
 		test_button.icon = get_theme_icon("PlayScene", "EditorIcons")
 		test_button.tooltip_text = DialogueConstants.translate("test_dialogue")
@@ -437,6 +449,7 @@ func apply_theme() -> void:
 		import_dialog.min_size = Vector2(600, 500) * scale
 		settings_dialog.min_size = Vector2(1000, 600) * scale
 		settings_dialog.max_size = Vector2(1000, 600) * scale
+		find_in_files_dialog.min_size = Vector2(800, 600) * scale
 
 
 ### Helpers
@@ -921,6 +934,11 @@ func _on_save_all_button_pressed() -> void:
 	save_files()
 
 
+func _on_find_in_files_button_pressed() -> void:
+	find_in_files_dialog.popup_centered()
+	find_in_files.prepare()
+
+
 func _on_code_edit_text_changed() -> void:
 	title_list.titles = code_edit.get_titles()
 
@@ -1075,3 +1093,8 @@ func _on_close_confirmation_dialog_custom_action(action: StringName) -> void:
 	if action == "discard":
 		remove_file_from_open_buffers(current_file_path)
 	close_confirmation_dialog.hide()
+
+
+func _on_find_in_files_result_selected(path: String, cursor: Vector2, length: int) -> void:
+	open_file(path)
+	code_edit.select(cursor.y, cursor.x, cursor.y, cursor.x + length)

--- a/addons/dialogue_manager/views/main_view.tscn
+++ b/addons/dialogue_manager/views/main_view.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://cbuf1q3xsse3q"]
+[gd_scene load_steps=14 format=3 uid="uid://cbuf1q3xsse3q"]
 
 [ext_resource type="Script" path="res://addons/dialogue_manager/views/main_view.gd" id="1_h6qfq"]
 [ext_resource type="PackedScene" uid="uid://civ6shmka5e8u" path="res://addons/dialogue_manager/components/code_edit.tscn" id="2_f73fm"]
@@ -9,8 +9,9 @@
 [ext_resource type="PackedScene" uid="uid://cs8pwrxr5vxix" path="res://addons/dialogue_manager/components/errors_panel.tscn" id="7_5cvl4"]
 [ext_resource type="Script" path="res://addons/dialogue_manager/components/code_edit_syntax_highlighter.gd" id="7_necsa"]
 [ext_resource type="PackedScene" uid="uid://cpg4lg1r3ff6m" path="res://addons/dialogue_manager/views/settings_view.tscn" id="9_8bf36"]
+[ext_resource type="PackedScene" uid="uid://0n7hwviyyly4" path="res://addons/dialogue_manager/components/find_in_files.tscn" id="10_yold3"]
 
-[sub_resource type="Image" id="Image_gxr16"]
+[sub_resource type="Image" id="Image_xvtti"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -20,9 +21,9 @@ data = {
 }
 
 [sub_resource type="ImageTexture" id="ImageTexture_fguub"]
-image = SubResource("Image_gxr16")
+image = SubResource("Image_xvtti")
 
-[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_8u3np"]
+[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_dvnxt"]
 script = ExtResource("7_necsa")
 
 [node name="MainView" type="Control"]
@@ -80,6 +81,11 @@ tooltip_text = "Open a file"
 unique_name_in_owner = true
 layout_mode = 2
 disabled = true
+flat = true
+
+[node name="FindInFilesButton" type="Button" parent="Margin/Content/SidePanel/Toolbar"]
+unique_name_in_owner = true
+layout_mode = 2
 flat = true
 
 [node name="Bookmarks" type="VSplitContainer" parent="Margin/Content/SidePanel"]
@@ -207,7 +213,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_colors/bookmark_color = Color(1, 0.333333, 0.333333, 1)
 text = ""
-syntax_highlighter = SubResource("SyntaxHighlighter_8u3np")
+syntax_highlighter = SubResource("SyntaxHighlighter_dvnxt")
 
 [node name="ErrorsPanel" parent="Margin/Content/CodePanel" instance=ExtResource("7_5cvl4")]
 unique_name_in_owner = true
@@ -262,7 +268,6 @@ offset_left = 8.0
 offset_top = 8.0
 offset_right = -8.0
 offset_bottom = -49.0
-current_tab = 0
 
 [node name="BuildErrorDialog" type="AcceptDialog" parent="."]
 title = "Errors"
@@ -277,12 +282,27 @@ title = "Updated"
 size = Vector2i(191, 100)
 dialog_text = "You're now up to date!"
 
+[node name="FindInFilesDialog" type="AcceptDialog" parent="."]
+title = "Find in files"
+size = Vector2i(416, 457)
+ok_button_text = "Done"
+
+[node name="FindInFiles" parent="FindInFilesDialog" node_paths=PackedStringArray("main_view", "code_edit") instance=ExtResource("10_yold3")]
+custom_minimum_size = Vector2(400, 400)
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+main_view = NodePath("../..")
+code_edit = NodePath("../../Margin/Content/CodePanel/CodeEdit")
+
 [connection signal="theme_changed" from="." to="." method="_on_main_view_theme_changed"]
 [connection signal="visibility_changed" from="." to="." method="_on_main_view_visibility_changed"]
 [connection signal="timeout" from="ParseTimer" to="." method="_on_parse_timer_timeout"]
 [connection signal="pressed" from="Margin/Content/SidePanel/Toolbar/NewButton" to="." method="_on_new_button_pressed"]
 [connection signal="about_to_popup" from="Margin/Content/SidePanel/Toolbar/OpenButton" to="." method="_on_open_button_about_to_popup"]
 [connection signal="pressed" from="Margin/Content/SidePanel/Toolbar/SaveAllButton" to="." method="_on_save_all_button_pressed"]
+[connection signal="pressed" from="Margin/Content/SidePanel/Toolbar/FindInFilesButton" to="." method="_on_find_in_files_button_pressed"]
 [connection signal="file_middle_clicked" from="Margin/Content/SidePanel/Bookmarks/FilesList" to="." method="_on_files_list_file_middle_clicked"]
 [connection signal="file_popup_menu_requested" from="Margin/Content/SidePanel/Bookmarks/FilesList" to="." method="_on_files_list_file_popup_menu_requested"]
 [connection signal="file_selected" from="Margin/Content/SidePanel/Bookmarks/FilesList" to="." method="_on_files_list_file_selected"]
@@ -311,3 +331,4 @@ dialog_text = "You're now up to date!"
 [connection signal="script_button_pressed" from="SettingsDialog/SettingsView" to="." method="_on_settings_view_script_button_pressed"]
 [connection signal="confirmed" from="CloseConfirmationDialog" to="." method="_on_close_confirmation_dialog_confirmed"]
 [connection signal="custom_action" from="CloseConfirmationDialog" to="." method="_on_close_confirmation_dialog_custom_action"]
+[connection signal="result_selected" from="FindInFilesDialog/FindInFiles" to="." method="_on_find_in_files_result_selected"]


### PR DESCRIPTION
This adds support for finding and replacing text across all dialogue files.

![image](https://github.com/nathanhoad/godot_dialogue_manager/assets/78984/eab0a6de-32e5-4c0d-8425-51cbe3e2de40)

Closes #424 