### PR TITLE
Fix C# async methods returning without await

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -186,6 +186,9 @@ namespace DialogueManagerRuntime
                 }
             }
 
+            // Add a single frame wait in case the method returns before signals can listen
+            await ToSignal(Engine.GetMainLoop(), SceneTree.SignalName.ProcessFrame);
+
             if (info.ReturnType == typeof(Task))
             {
                 await (Task)info.Invoke(thing, _args);


### PR DESCRIPTION
This stops C# methods that use `async` without encountering an `await` from infinitely blocking flow.

Fixes #537 