### PR TITLE
Prevent project showing as unsaved when opening

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -46,6 +46,18 @@ func _enter_tree() -> void:
 
 		add_tool_menu_item("Create copy of dialogue example balloon...", _copy_dialogue_balloon)
 
+		# Prevent the project from showing as unsaved even though it was only just opened
+		if Engine.get_physics_frames() < 120:
+			var timer: Timer = Timer.new()
+			var suppress_unsaved_marker: Callable
+			suppress_unsaved_marker = func():
+				timer.stop()
+				get_editor_interface().save_all_scenes()
+				timer.queue_free()
+			timer.timeout.connect(suppress_unsaved_marker)
+			add_child(timer)
+			timer.start(0.1)
+
 
 func _exit_tree() -> void:
 	remove_autoload_singleton("DialogueManager")


### PR DESCRIPTION
This is kind of a hack to stop the project showing as unsaved just after it has been opened and nothing has changed yet.

Closes #536 