### PR TITLE
Fix character replacements in response shortcuts

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -230,6 +230,7 @@ func parse(text: String, path: String) -> Error:
 					line["character"] = first_child.character
 					line["character_replacements"] = first_child.character_replacements
 					line["text"] = first_child.text
+					line["text_replacements"] = extract_dialogue_replacements(line.text, indent_size + 2)
 					line["translation_key"] = first_child.translation_key
 					parsed_lines[str(id) + ".2"] = first_child
 					line["next_id"] = str(id) + ".2"

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -142,7 +142,8 @@ func get_resolved_line_data(data: Dictionary, extra_game_states: Array = []) -> 
 	for replacement in data.text_replacements:
 		var value = await resolve(replacement.expression.duplicate(true), extra_game_states)
 		var index: int = text.find(replacement.value_in_text)
-		text = text.substr(0, index) + str(value) + text.substr(index + replacement.value_in_text.length())
+		if index > -1:
+			text = text.substr(0, index) + str(value) + text.substr(index + replacement.value_in_text.length())
 
 	var parser: DialogueManagerParser = DialogueManagerParser.new()
 
@@ -218,7 +219,8 @@ func get_resolved_character(data: Dictionary, extra_game_states: Array = []) -> 
 	for replacement in data.get(&"character_replacements", []):
 		var value = await resolve(replacement.expression.duplicate(true), extra_game_states)
 		var index: int = character.find(replacement.value_in_text)
-		character = character.substr(0, index) + str(value) + character.substr(index + replacement.value_in_text.length())
+		if index > -1:
+			character = character.substr(0, index) + str(value) + character.substr(index + replacement.value_in_text.length())
 
 	# Resolve random groups
 	var random_regex: RegEx = RegEx.new()


### PR DESCRIPTION
This fixes an issue when a character name was a variable in a auto-line response prompt. For example, given this dialogue and assuming `player_name` was an available variable with a value of "Coco":

```
Nathan: Here are some responses.
- {{player_name}}: Some response.
- {{player_name}}: Another response.
```

Previously, this would resolve the prompt text to be something like `Some response. Coco` but will now correctly resolve to just `Some response.`.