### PR TITLE
Fix EOF end being too forceful

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -928,8 +928,8 @@ func find_next_line_after_responses(line_number: int) -> String:
 			if get_indent(line) <= expected_indent:
 				return str(line_number)
 
-	# EOF so must be end of conversation
-	return DialogueConstants.ID_END_CONVERSATION
+	# EOF so it's also the end of a block
+	return DialogueConstants.ID_END
 
 
 ## Get the names of any autoloads in the project


### PR DESCRIPTION
This fixes an issue when using a `=><` jump to a snippet at the end of a file that doesn't end with an explicit `=> END`. Previously it would assume an `=> END!` (end conversation) but it will now correctly assume an `=> END` (end block) so that the snippet will return to where it jumped from.

Related to #532 