### PR TITLE
Use editor shortcuts where possible

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -70,25 +70,27 @@ func _ready() -> void:
 
 
 func _gui_input(event: InputEvent) -> void:
+	# Handle shortcuts that come from the editor
 	if event is InputEventKey and event.is_pressed():
-		match event.as_text():
-			"Ctrl+Equal", "Command+Equal":
-				self.font_size += 1
-				get_viewport().set_input_as_handled()
-			"Ctrl+Minus", "Command+Minus":
-				self.font_size -= 1
-				get_viewport().set_input_as_handled()
-			"Ctrl+0", "Command+0":
-				self.font_size = theme_overrides.font_size
-				get_viewport().set_input_as_handled()
-			"Ctrl+K", "Command+K":
+		var shortcut: String = Engine.get_meta("DialogueManagerPlugin").get_editor_shortcut(event)
+		match shortcut:
+			"toggle_comment":
 				toggle_comment()
 				get_viewport().set_input_as_handled()
-			"Alt+Up":
+			"move_up":
 				move_line(-1)
 				get_viewport().set_input_as_handled()
-			"Alt+Down":
+			"move_down":
 				move_line(1)
+				get_viewport().set_input_as_handled()
+			"text_size_increase":
+				self.font_size += 1
+				get_viewport().set_input_as_handled()
+			"text_size_decrease":
+				self.font_size -= 1
+				get_viewport().set_input_as_handled()
+			"text_size_reset":
+				self.font_size = theme_overrides.font_size
 				get_viewport().set_input_as_handled()
 
 	elif event is InputEventMouse:

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -145,6 +145,85 @@ func _build() -> bool:
 	return true
 
 
+## Get the shortcuts used by the plugin
+func get_editor_shortcuts() -> Dictionary:
+	var shortcuts: Dictionary = {
+		toggle_comment = [
+			_create_event("Ctrl+K"),
+			_create_event("Ctrl+Slash")
+		],
+		move_up = [
+			_create_event("Alt+Up")
+		],
+		move_down = [
+			_create_event("Alt+Down")
+		],
+		save = [
+			_create_event("Ctrl+Alt+S")
+		],
+		close_file = [
+			_create_event("Ctrl+W")
+		],
+		find_in_files = [
+			_create_event("Ctrl+Shift+F")
+		],
+
+		run_test_scene = [
+			_create_event("Ctrl+F5")
+		],
+		text_size_increase = [
+			_create_event("Ctrl+Equal")
+		],
+		text_size_decrease = [
+			_create_event("Ctrl+Minus")
+		],
+		text_size_reset = [
+			_create_event("Ctrl+0")
+		]
+	}
+
+	var paths = get_editor_interface().get_editor_paths()
+	var settings = load(paths.get_config_dir() + "/editor_settings-4.tres")
+
+	if not settings: return shortcuts
+
+	for s in settings.get("shortcuts"):
+		for key in shortcuts:
+			if s.name == "script_text_editor/%s" % key or s.name == "script_editor/%s" % key:
+				shortcuts[key] = []
+				for event in s.shortcuts:
+					if event is InputEventKey:
+						shortcuts[key].append(event)
+
+	return shortcuts
+
+
+func _create_event(string: String) -> InputEventKey:
+	var event: InputEventKey = InputEventKey.new()
+	var bits = string.split("+")
+	event.keycode = OS.find_keycode_from_string(bits[bits.size() - 1])
+	if "Shift" in bits:
+		event.shift_pressed = true
+	if "Alt" in bits:
+		event.alt_pressed = true
+	if "Ctrl" in bits:
+		event.ctrl_pressed = true
+	if "Command" in bits:
+		event.meta_pressed = true
+	event.command_or_control_autoremap = true
+	return event
+
+
+## Get the editor shortcut that matches an event
+func get_editor_shortcut(event: InputEventKey) -> String:
+	var shortcuts: Dictionary = get_editor_shortcuts()
+	for key in shortcuts:
+		for shortcut in shortcuts.get(key, []):
+			if event.is_match(shortcut, false):
+				return key
+	return ""
+
+
 ## Get the current version
 func get_version() -> String:
 	var config: ConfigFile = ConfigFile.new()

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -181,19 +181,20 @@ func _unhandled_input(event: InputEvent) -> void:
 	if not visible: return
 
 	if event is InputEventKey and event.is_pressed():
-		match event.as_text():
-			"Ctrl+Alt+S", "Command+Alt+S":
-				get_viewport().set_input_as_handled()
-				save_file(current_file_path)
-			"Ctrl+W", "Command+W":
+		var shortcut: String = Engine.get_meta("DialogueManagerPlugin").get_editor_shortcut(event)
+		match shortcut:
+			"close_file":
 				get_viewport().set_input_as_handled()
 				close_file(current_file_path)
-			"Ctrl+F5", "Command+F5":
+			"save":
 				get_viewport().set_input_as_handled()
-				_on_test_button_pressed()
-			"Ctrl+Shift+F", "Command+Shift+F":
+				save_file(current_file_path)
+			"find_in_files":
 				get_viewport().set_input_as_handled()
 				_on_find_in_files_button_pressed()
+			"run_test_scene":
+				get_viewport().set_input_as_handled()
+				_on_test_button_pressed()
 
 
 func apply_changes() -> void:
@@ -1044,9 +1045,11 @@ func _on_files_list_file_middle_clicked(path: String):
 func _on_files_popup_menu_about_to_popup() -> void:
 	files_popup_menu.clear()
 
-	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.save"), ITEM_SAVE, KEY_MASK_CTRL | KEY_MASK_ALT | KEY_S)
+	var shortcuts: Dictionary = Engine.get_meta("DialogueManagerPlugin").get_editor_shortcuts()
+
+	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.save"), ITEM_SAVE, OS.find_keycode_from_string(shortcuts.get("save")[0].as_text_keycode()))
 	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.save_as"), ITEM_SAVE_AS)
-	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.close"), ITEM_CLOSE, KEY_MASK_CTRL | KEY_W)
+	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.close"), ITEM_CLOSE, OS.find_keycode_from_string(shortcuts.get("close_file")[0].as_text_keycode()))
 	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.close_all"), ITEM_CLOSE_ALL)
 	files_popup_menu.add_item(DialogueConstants.translate(&"buffer.close_other_files"), ITEM_CLOSE_OTHERS)
 	files_popup_menu.add_separator()


### PR DESCRIPTION
This changes the keyboard shortcuts (eg. toggle comment) to use the native Godot editor shortcuts where possible.

Godot doesn't seem to expose the shortcuts directly so this attempts to read the `editor_settings-4.tres` resource for any shortcut overrides.

Related to #549 