### PR TITLE
Allow titles to follow titles

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -692,12 +692,7 @@ func get_line_after_line(id: int, indent_size: int, line: Dictionary) -> String:
 	var next_nonempty_line_id = get_next_nonempty_line_id(id)
 	if next_nonempty_line_id != DialogueConstants.ID_NULL \
 		and indent_size <= get_indent(raw_lines[next_nonempty_line_id.to_int()]):
-		# The next line is a title so we need the next nonempty line after that
-		if is_title_line(raw_lines[next_nonempty_line_id.to_int()]):
-			return get_next_nonempty_line_id(next_nonempty_line_id.to_int())
-		# Otherwise it's a normal line
-		else:
-			return next_nonempty_line_id
+		return next_nonempty_line_id
 	# Otherwise, we grab the ID from the parents next ID after children
 	elif line.has("parent_id") and parsed_lines.has(line.parent_id):
 		return parsed_lines[line.parent_id].next_id_after

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -361,6 +361,10 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 
 	var data: Dictionary = resource.lines.get(key)
 
+	# This title key points to another title key so we should jump there instead
+	if data.type == DialogueConstants.TYPE_TITLE and data.next_id in resource.titles.values():
+		return await get_line(resource, data.next_id + id_trail, extra_game_states)
+
 	# Check for weighted random lines
 	if data.has(&"siblings"):
 		var target_weight: float = randf_range(0, data.siblings.reduce(func(total, sibling): return total + sibling.weight, 0))

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -8,7 +8,7 @@ signal compiled_resource(resource: Resource)
 const DialogueResource = preload("./dialogue_resource.gd")
 const DialogueManagerParseResult = preload("./components/parse_result.gd")
 
-const compiler_version = 11
+const compiler_version = 12
 
 
 func _get_importer_name() -> String:

--- a/examples/dialogue.dialogue.import
+++ b/examples/dialogue.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_11"
+importer="dialogue_manager_compiler_12"
 type="Resource"
 uid="uid://c7xhr8kec0j4l"
 path="res://.godot/imported/dialogue.dialogue-7261ed8f1fc7558828110057cd7de1cd.tres"

--- a/examples/dialogue_for_csharp.dialogue.import
+++ b/examples/dialogue_for_csharp.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_11"
+importer="dialogue_manager_compiler_12"
 type="Resource"
 uid="uid://crw6v7sw0tx34"
 path="res://.godot/imported/dialogue_for_csharp.dialogue-9c843d92323bc3ce3a6860c848251c23.tres"

--- a/examples/dialogue_for_point_n_click.dialogue.import
+++ b/examples/dialogue_for_point_n_click.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_11"
+importer="dialogue_manager_compiler_12"
 type="Resource"
 uid="uid://c21ogqvaf7u0p"
 path="res://.godot/imported/dialogue_for_point_n_click.dialogue-3f5e4d7e9b600a1465fdfd8417d06976.tres"

--- a/examples/dialogue_for_visual_novel.dialogue.import
+++ b/examples/dialogue_for_visual_novel.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_11"
+importer="dialogue_manager_compiler_12"
 type="Resource"
 uid="uid://dd5gx2wq6xojd"
 path="res://.godot/imported/dialogue_for_visual_novel.dialogue-68b4d7220d88c358e1312ba2f42ceb11.tres"

--- a/examples/dialogue_with_input.dialogue.import
+++ b/examples/dialogue_with_input.dialogue.import
@@ -1,6 +1,6 @@
 [remap]
 
-importer="dialogue_manager_compiler_11"
+importer="dialogue_manager_compiler_12"
 type="Resource"
 uid="uid://bnya3clsjvb71"
 path="res://.godot/imported/dialogue_with_input.dialogue-c39aeeef4356c037cffb9524fd896bb5.tres"

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -198,6 +198,7 @@ class TestClass:
 		string = s
 		number = i
 
+
 func test_can_run_methods() -> void:
 	var resource = create_resource("
 ~ start
@@ -216,3 +217,14 @@ Nathan: With optional arguments.
 	line = await resource.get_next_dialogue_line(line.next_id, [test])
 	assert(test.string == "bar", "Method call should set required argument")
 	assert(test.number == 1, "Method call should set optional argument")
+
+
+func test_can_have_subsequent_titles() -> void:
+	var resource = create_resource("
+~ start
+~ another_title
+~ third_title
+Nathan: Hello.")
+
+	var line = await resource.get_next_dialogue_line("start")
+	assert(line.text == "Hello.", "Should jump to dialogue.")


### PR DESCRIPTION
This fixes an issue where titles wouldn't pass through another title if it was directly after it.

Fixes #548 