### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,19 +11,17 @@
 
 ### Methods
 
-#### `func show_dialogue_balloon(resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> Node`
+#### `func show_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node`
 
 Opens the dialogue balloon configured in settings (or the example balloon if none has been set).
 
 Returns the balloon's base node in case you want to `queue_free()` it yourself.
 
-
-#### `func show_dialogue_balloon_scene(balloon_scene: Node | String, resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> Node`
+#### `func show_dialogue_balloon_scene(balloon_scene: Node | String, resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> Node`
 
 Opens a dialogue balloon given in `balloon_scene`.
 
 Returns the balloon's base node in case you want to `queue_free()` it yourself.
-
 
 #### `func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine`
 
@@ -54,7 +52,7 @@ Pass an array of nodes as `extra_game_states` in order to temporarily add to the
 
 You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases you should leave this as the default. _The example balloon only supports `Wait`_.
 
-#### `func show_example_dialogue_balloon(resource: DialoueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer`
+#### `func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer`
 
 Opens the example balloon.
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -14,7 +14,7 @@
 
 ### Custom balloon
 
-You can configure a default balloon to show when calling [`DialogueManager.show_dialogue_balloon()`](./API.md#func-show_dialogue_balloonresource-dialoueresource-title-string--0-extra_game_states-array-----node). This balloon will also be used when testing dialogue from the dialogue editor.
+You can configure a default balloon to show when calling [`DialogueManager.show_dialogue_balloon()`](./API.md#func-show_dialogue_balloonresource-dialogueresource-title-string--0-extra_game_states-array-----node). This balloon will also be used when testing dialogue from the dialogue editor.
 
 ### Globals shortcuts
 

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -1,6 +1,6 @@
 # Using dialogue in your game
 
-The simplest way to show dialogue in your game is to call [`DialogueManager.show_dialogue_balloon(resource, title)`](./API.md#func-show_dialogue_balloonresource-dialoueresource-title-string--0-extra_game_states-array-----node) with a dialogue resource and a title to start from. This will show the example balloon by default but you can configure it in [Settings](./Settings.md) to show your custom balloon.
+The simplest way to show dialogue in your game is to call [`DialogueManager.show_dialogue_balloon(resource, title)`](./API.md#func-show_dialogue_balloonresource-dialogueresource-title-string--0-extra_game_states-array-----node) with a dialogue resource and a title to start from. This will show the example balloon by default but you can configure it in [Settings](./Settings.md) to show your custom balloon.
 
 It's up to you to implement/customise any dialogue rendering and input control to match your game but there are [a few example balloons](Example_Balloons.md) included to get you started with some of the more common things.
 


### PR DESCRIPTION
Fixes minor typo in documentation and corresponding markdown links.