### PR TITLE
Fix: add .mo extension to PO translation behavior

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -460,7 +460,7 @@ func translate(data: Dictionary) -> String:
 
 			TranslationSource.Guess:
 				var translation_files: Array = ProjectSettings.get_setting(&"internationalization/locale/translations")
-				if translation_files.filter(func(f: String): return f.get_extension() == &"po").size() > 0:
+				if translation_files.filter(func(f: String): return f.get_extension() in [&"po", &"mo"]).size() > 0:
 					# Assume PO
 					return tr(data.text, StringName(data.translation_key))
 				else:


### PR DESCRIPTION
When using gettext translations, [Godot supports both `.po` and `.mo` files.](https://docs.godotengine.org/en/stable/tutorials/i18n/localization_using_gettext.html#using-binary-mo-files-useful-for-large-projects-only)

When guessing for a translation source, Dialogue Manager did not consider sources that ended in `.mo` as gettext sources. So the lines were not translated, and only the translation key was displayed.

This PR adds the auto-guessing for `.mo` files.