### PR TITLE
Update the Dialogue Label when the locale changes

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -206,6 +206,13 @@ namespace DialogueManagerRuntime
 
     public partial class DialogueLine : RefCounted
     {
+        private string id = "";
+        public string Id
+        {
+            get => id;
+            set => id = value;
+        }
+
         private string type = "dialogue";
         public string Type
         {

--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -110,8 +110,12 @@ namespace DialogueManagerRuntime
       // Detect a change of locale and update the current dialogue line to show the new language
       if (what == NotificationTranslationChanged)
       {
+        float visibleRatio = dialogueLabel.VisibleRatio;
         DialogueLine = await DialogueManager.GetNextDialogueLine(resource, DialogueLine.Id, temporaryGameStates);
-        dialogueLabel.Call("skip_typing");
+        if (visibleRatio < 1.0f)
+        {
+          dialogueLabel.Call("skip_typing");
+        }
       }
     }
 

--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -105,6 +105,17 @@ namespace DialogueManagerRuntime
     }
 
 
+    public override async void _Notification(int what)
+    {
+      // Detect a change of locale and update the current dialogue line to show the new language
+      if (what == NotificationTranslationChanged)
+      {
+        DialogueLine = await DialogueManager.GetNextDialogueLine(resource, DialogueLine.Id, temporaryGameStates);
+        dialogueLabel.Call("skip_typing");
+      }
+    }
+
+
     public async void Start(Resource dialogueResource, string title, Array<Variant> extraGameStates = null)
     {
       temporaryGameStates = extraGameStates ?? new Array<Variant>();

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -92,8 +92,10 @@ func _unhandled_input(_event: InputEvent) -> void:
 func _notification(what: int) -> void:
 	# Detect a change of locale and update the current dialogue line to show the new language
 	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		var visible_ratio = dialogue_label.visible_ratio
 		self.dialogue_line = await resource.get_next_dialogue_line(dialogue_line.id)
-		dialogue_label.skip_typing()
+		if visible_ratio < 1:
+			dialogue_label.skip_typing()
 
 
 ## Start some dialogue

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -89,6 +89,13 @@ func _unhandled_input(_event: InputEvent) -> void:
 	get_viewport().set_input_as_handled()
 
 
+func _notification(what: int) -> void:
+	# Detect a change of locale and update the current dialogue line to show the new language
+	if what == NOTIFICATION_TRANSLATION_CHANGED:
+		self.dialogue_line = await resource.get_next_dialogue_line(dialogue_line.id)
+		dialogue_label.skip_typing()
+
+
 ## Start some dialogue
 func start(dialogue_resource: DialogueResource, title: String, extra_game_states: Array = []) -> void:
 	temporary_game_states =  [self] + extra_game_states
@@ -102,7 +109,7 @@ func next(next_id: String) -> void:
 	self.dialogue_line = await resource.get_next_dialogue_line(next_id, temporary_game_states)
 
 
-### Signals
+#region Signals
 
 
 func _on_mutated(_mutation: Dictionary) -> void:
@@ -139,3 +146,6 @@ func _on_balloon_gui_input(event: InputEvent) -> void:
 
 func _on_responses_menu_response_selected(response: DialogueResponse) -> void:
 	next(response.next_id)
+
+
+#endregion

--- a/examples/csharp_balloon/Balloon.cs
+++ b/examples/csharp_balloon/Balloon.cs
@@ -103,8 +103,12 @@ public partial class Balloon : CanvasLayer
     // Detect a change of locale and update the current dialogue line to show the new language
     if (what == NotificationTranslationChanged)
     {
+      float visibleRatio = dialogueLabel.VisibleRatio;
       DialogueLine = await DialogueManager.GetNextDialogueLine(resource, DialogueLine.Id, temporaryGameStates);
-      dialogueLabel.Call("skip_typing");
+      if (visibleRatio < 1.0f)
+      {
+        dialogueLabel.Call("skip_typing");
+      }
     }
   }
 

--- a/examples/csharp_balloon/Balloon.cs
+++ b/examples/csharp_balloon/Balloon.cs
@@ -21,6 +21,8 @@ public partial class Balloon : CanvasLayer
     set
     {
       isWaitingForInput = false;
+      balloon.FocusMode = Control.FocusModeEnum.All;
+      balloon.GrabFocus();
 
       if (value == null)
       {
@@ -43,10 +45,10 @@ public partial class Balloon : CanvasLayer
 
     balloon.Hide();
 
-    balloon.GuiInput += (inputEvent) =>
+    balloon.GuiInput += (@event) =>
     {
       // Finish typing out the dialogue if we click the mouse
-      if ((bool)dialogueLabel.Get("is_typing") && inputEvent is InputEventMouseButton && (inputEvent as InputEventMouseButton).ButtonIndex == MouseButton.Left && inputEvent.IsPressed())
+      if ((bool)dialogueLabel.Get("is_typing") && @event is InputEventMouseButton && (@event as InputEventMouseButton).ButtonIndex == MouseButton.Left && @event.IsPressed())
       {
         GetViewport().SetInputAsHandled();
         dialogueLabel.Call("skip_typing");
@@ -58,11 +60,11 @@ public partial class Balloon : CanvasLayer
 
       GetViewport().SetInputAsHandled();
 
-      if (inputEvent is InputEventMouseButton && inputEvent.IsPressed() && (inputEvent as InputEventMouseButton).ButtonIndex == MouseButton.Left)
+      if (@event is InputEventMouseButton && @event.IsPressed() && (@event as InputEventMouseButton).ButtonIndex == MouseButton.Left)
       {
         Next(dialogueLine.NextId);
       }
-      else if (inputEvent.IsActionPressed("ui_accept") && GetViewport().GuiGetFocusOwner() == balloon)
+      else if (@event.IsActionPressed("ui_accept") && GetViewport().GuiGetFocusOwner() == balloon)
       {
         Next(dialogueLine.NextId);
       }
@@ -89,10 +91,21 @@ public partial class Balloon : CanvasLayer
   }
 
 
-  public override void _UnhandledInput(InputEvent inputEvent)
+  public override void _UnhandledInput(InputEvent @event)
   {
     // Only the balloon is allowed to handle input while it's showing
     GetViewport().SetInputAsHandled();
+  }
+
+
+  public override async void _Notification(int what)
+  {
+    // Detect a change of locale and update the current dialogue line to show the new language
+    if (what == NotificationTranslationChanged)
+    {
+      DialogueLine = await DialogueManager.GetNextDialogueLine(resource, DialogueLine.Id, temporaryGameStates);
+      dialogueLabel.Call("skip_typing");
+    }
   }
 
 


### PR DESCRIPTION
This changes the example balloon so that when it detects a locale change it will update the dialogue label to show the text in the new language. 

⚠ _This comes with the caveat that inline mutations will possibly be run twice if the locale is swapped mid-typing as there is no way of knowing if the new language has the mutations at the same indices._

Closes #565 