### PR TITLE
Make dotnet detection more forgiving

### DIFF
--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -176,9 +176,5 @@ static func has_dotnet_solution() -> bool:
 		var has_dotnet_solution: bool = FileAccess.file_exists("res://%s/%s.sln" % [directory, file_name])
 		set_user_value("has_dotnet_solution", has_dotnet_solution)
 		return has_dotnet_solution
-	else:
-		var plugin_path: String = new().get_script().resource_path.get_base_dir()
-		if not ResourceLoader.exists(plugin_path + "/DialogueManager.cs"): return false
-		if load(plugin_path + "/DialogueManager.cs") == null: return false
 
-	return true
+	return false


### PR DESCRIPTION
This should make the dotnet detection a bit more forgiving for when people are using the mono build of Godot but not using C#.