### PR TITLE
Add support for String methods in mutations

### DIFF
--- a/addons/dialogue_manager/utilities/builtins.gd
+++ b/addons/dialogue_manager/utilities/builtins.gd
@@ -4,6 +4,8 @@ extends Object
 const DialogueConstants = preload("../constants.gd")
 
 const SUPPORTED_BUILTIN_TYPES = [
+	TYPE_STRING,
+	TYPE_STRING_NAME,
 	TYPE_ARRAY,
 	TYPE_VECTOR2,
 	TYPE_VECTOR3,
@@ -25,7 +27,7 @@ static func is_supported(thing) -> bool:
 
 static func resolve_property(builtin, property: String):
 	match typeof(builtin):
-		TYPE_ARRAY, TYPE_DICTIONARY, TYPE_QUATERNION:
+		TYPE_ARRAY, TYPE_DICTIONARY, TYPE_QUATERNION, TYPE_STRING, TYPE_STRING_NAME:
 			return builtin[property]
 
 		# Some types have constants that we need to manually resolve


### PR DESCRIPTION
This adds support for using `String` methods in variable substitution and mutations.