### PR TITLE
Ensure label is ready before locale change

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -91,7 +91,7 @@ func _unhandled_input(_event: InputEvent) -> void:
 
 func _notification(what: int) -> void:
 	# Detect a change of locale and update the current dialogue line to show the new language
-	if what == NOTIFICATION_TRANSLATION_CHANGED:
+	if what == NOTIFICATION_TRANSLATION_CHANGED and is_instance_valid(dialogue_label):
 		var visible_ratio = dialogue_label.visible_ratio
 		self.dialogue_line = await resource.get_next_dialogue_line(dialogue_line.id)
 		if visible_ratio < 1:

--- a/project.godot
+++ b/project.godot
@@ -25,6 +25,7 @@ DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 [dialogue_manager]
 
 general/states=["State", "Events"]
+general/uses_dotnet=true
 
 [display]
 


### PR DESCRIPTION
This makes sure the label reference in the example balloon is ready before handling locale changes (it appears Godot 4.3 has an earlier notification than Godot 4.2).