### PR TITLE
Fix C# mutation handling derived types in args

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -164,42 +164,64 @@ namespace DialogueManagerRuntime
         }
 
 
-        public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
-        {
-            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+    public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
+    {
+        MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
-            if (info == null) return;
+        if (info == null) return;
 
 #nullable disable
-            // Convert the method args to something reflection can handle
-            ParameterInfo[] argTypes = info.GetParameters();
-            object[] _args = new object[argTypes.Length];
-            for (int i = 0; i < argTypes.Length; i++)
+        // Convert the method args to something reflection can handle
+        ParameterInfo[] argTypes = info.GetParameters();
+        object[] _args = new object[argTypes.Length];
+        for (int i = 0; i < argTypes.Length; i++)
+        {
+            // check if args is assignable from derived type
+            if (i < args.Count && args[i].Obj != null)
             {
-                if (i < args.Count && args[i].Obj != null)
+                if (argTypes[i].ParameterType.IsAssignableFrom(args[i].Obj.GetType()))
+                {
+                    _args[i] = args[i].Obj;
+                }
+                // fallback to assigning primitive types
+                else
                 {
                     _args[i] = Convert.ChangeType(args[i].Obj, argTypes[i].ParameterType);
                 }
-                else if (argTypes[i].DefaultValue != null)
-                {
-                    _args[i] = argTypes[i].DefaultValue;
-                }
             }
-
-            // Add a single frame wait in case the method returns before signals can listen
-            await ToSignal(Engine.GetMainLoop(), SceneTree.SignalName.ProcessFrame);
-
-            if (info.ReturnType == typeof(Task))
+            else if (argTypes[i].DefaultValue != null)
             {
-                await (Task)info.Invoke(thing, _args);
-                EmitSignal(SignalName.Resolved, null);
+                _args[i] = argTypes[i].DefaultValue;
+            }
+        }
+
+        // Add a single frame wait in case the method returns before signals can listen
+        await ToSignal(Engine.GetMainLoop(), SceneTree.SignalName.ProcessFrame);
+
+        // invoke method and handle the result based on return type
+        object result = info.Invoke(thing, _args);
+
+        if (result is Task taskResult)
+        {
+            // await Tasks and handle result if it is a Task<T>
+            await taskResult;
+            var taskType = taskResult.GetType();
+            if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>))
+            {
+                var resultProperty = taskType.GetProperty("Result");
+                var taskResultValue = resultProperty.GetValue(taskResult);
+                EmitSignal(SignalName.Resolved, (Variant)taskResultValue);
             }
             else
             {
-                var value = (Variant)info.Invoke(thing, _args);
-                EmitSignal(SignalName.Resolved, value);
+                EmitSignal(SignalName.Resolved, null);
             }
         }
+        else
+        {
+            EmitSignal(SignalName.Resolved, (Variant)result);
+        }
+    }
 #nullable enable
     }
 


### PR DESCRIPTION
updated ResolveThingMethod() to check if the args is assignable from a derived type. This should allow passing through any custom type as a parameter into a mutation in the dialogue. (this mainly aims at fixing methods that return a Task)

Fixes this issue:
`E 0:00:02:0901   object System.Convert.ChangeType(object, System.Type, System.IFormatProvider): System.InvalidCastException: Object must implement IConvertible.
  <C++ Error>    System.InvalidCastException
  <C++ Source>   :0 @ object System.Convert.ChangeType(object, System.Type, System.IFormatProvider)
  <Stack Trace>  :0 @ object System.Convert.ChangeType(object, System.Type, System.IFormatProvider)
                 DialogueManager.cs:181 @ void DialogueManagerRuntime.DialogueManager+<ResolveThingMethod>d__36.MoveNext()
                 :0 @ void System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
                 :0 @ void System.Threading.Tasks.Task+<>c.<ThrowAsync>b__128_0(object)
                 GodotSynchronizationContext.cs:51 @ void Godot.GodotSynchronizationContext.ExecutePendingContinuations()
                 GodotTaskScheduler.cs:76 @ void Godot.GodotTaskScheduler.Activate()
                 ScriptManagerBridge.cs:82 @ void Godot.Bridge.ScriptManagerBridge.FrameCallback()`