### PR TITLE
Add explicit class references

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -7,6 +7,7 @@ signal error_clicked(line_number: int)
 signal external_file_requested(path: String, title: String)
 
 
+const DialogueManagerParser = preload("./parser.gd")
 const DialogueSyntaxHighlighter = preload("./code_edit_syntax_highlighter.gd")
 
 

--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -2,6 +2,9 @@
 extends SyntaxHighlighter
 
 
+const DialogueManagerParser = preload("./parser.gd")
+
+
 enum ExpressionType {DO, SET, IF}
 
 

--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -72,7 +72,7 @@ var while_loopbacks: Array[String] = []
 
 ## Parse some raw dialogue text. Returns a dictionary containing parse results
 static func parse_string(string: String, path: String) -> DialogueManagerParseResult:
-	var parser: DialogueManagerParser = DialogueManagerParser.new()
+	var parser = new()
 	var error: Error = parser.parse(string, path)
 	var data: DialogueManagerParseResult = parser.get_data()
 	parser.free()
@@ -85,7 +85,7 @@ static func parse_string(string: String, path: String) -> DialogueManagerParseRe
 
 ## Extract bbcode and other markers from a string
 static func extract_markers_from_string(string: String) -> ResolvedLineData:
-	var parser: DialogueManagerParser = DialogueManagerParser.new()
+	var parser = new()
 	var markers: ResolvedLineData = parser.extract_markers(string)
 	parser.free()
 

--- a/addons/dialogue_manager/dialogue_resource.gd
+++ b/addons/dialogue_manager/dialogue_resource.gd
@@ -6,6 +6,7 @@ class_name DialogueResource extends Resource
 
 
 const _DialogueManager = preload("./dialogue_manager.gd")
+const DialogueLine = preload("./dialogue_line.gd")
 
 ## A list of state shortcuts
 @export var using_states: PackedStringArray = []

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -3,6 +3,7 @@ extends EditorTranslationParserPlugin
 
 const DialogueConstants = preload("./constants.gd")
 const DialogueSettings = preload("./settings.gd")
+const DialogueManagerParser = preload("./components/parser.gd")
 const DialogueManagerParseResult = preload("./components/parse_result.gd")
 
 

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -6,6 +6,7 @@ signal compiled_resource(resource: Resource)
 
 
 const DialogueResource = preload("./dialogue_resource.gd")
+const DialogueManagerParser = preload("./components/parser.gd")
 const DialogueManagerParseResult = preload("./components/parse_result.gd")
 
 const compiler_version = 12

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -8,6 +8,7 @@ const DialogueTranslationParserPlugin = preload("./editor_translation_parser_plu
 const DialogueSettings = preload("./settings.gd")
 const DialogueCache = preload("./components/dialogue_cache.gd")
 const MainView = preload("./views/main_view.tscn")
+const DialogueResource = preload("./dialogue_resource.gd")
 
 
 var import_plugin: DialogueImportPlugin

--- a/addons/dialogue_manager/test_scene.gd
+++ b/addons/dialogue_manager/test_scene.gd
@@ -2,6 +2,7 @@ class_name BaseDialogueTestScene extends Node2D
 
 
 const DialogueSettings = preload("./settings.gd")
+const DialogueResource = preload("./dialogue_resource.gd")
 
 
 @onready var title: String = DialogueSettings.get_user_value("run_title")

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -4,6 +4,8 @@ extends Control
 
 const DialogueConstants = preload("../constants.gd")
 const DialogueSettings = preload("../settings.gd")
+const DialogueResource = preload("../dialogue_resource.gd")
+const DialogueManagerParser = preload("../components/parser.gd")
 
 const OPEN_OPEN = 100
 const OPEN_CLEAR = 101
@@ -166,8 +168,6 @@ func _ready() -> void:
 
 	close_confirmation_dialog.ok_button_text = DialogueConstants.translate(&"confirm_close.save")
 	close_confirmation_dialog.add_button(DialogueConstants.translate(&"confirm_close.discard"), true, "discard")
-
-	settings_view.editor_plugin = editor_plugin
 
 	errors_dialog.dialog_text = DialogueConstants.translate(&"errors_in_script")
 

--- a/addons/dialogue_manager/views/settings_view.gd
+++ b/addons/dialogue_manager/views/settings_view.gd
@@ -7,6 +7,7 @@ signal script_button_pressed(path: String)
 
 const DialogueConstants = preload("../constants.gd")
 const DialogueSettings = preload("../settings.gd")
+const BaseDialogueTestScene = preload("../test_scene.gd")
 
 
 enum PathTarget {
@@ -42,7 +43,6 @@ enum PathTarget {
 @onready var create_lines_for_response_characters: CheckBox = $Advanced/CreateLinesForResponseCharacters
 @onready var missing_translations_button: CheckBox = $Advanced/MissingTranslationsButton
 
-var editor_plugin: EditorPlugin
 var all_globals: Dictionary = {}
 var enabled_globals: Array = []
 var path_target: PathTarget = PathTarget.CustomTestScene
@@ -98,7 +98,7 @@ func prepare() -> void:
 	revert_balloon_button.tooltip_text = DialogueConstants.translate(&"settings.revert_to_default_balloon")
 	load_balloon_button.icon = get_theme_icon("Load", "EditorIcons")
 
-	var scale: float = editor_plugin.get_editor_interface().get_editor_scale()
+	var scale: float = Engine.get_meta("DialogueManagerPlugin").get_editor_interface().get_editor_scale()
 	custom_test_scene_file_dialog.min_size = Vector2(600, 500) * scale
 
 	states_title.add_theme_font_override("font", get_theme_font("bold", "EditorFonts"))
@@ -118,7 +118,7 @@ func prepare() -> void:
 	include_notes_in_translations.set_pressed_no_signal(DialogueSettings.get_setting("include_notes_in_translation_exports", false))
 	open_in_external_editor_button.set_pressed_no_signal(DialogueSettings.get_user_value("open_in_external_editor", false))
 
-	var editor_settings: EditorSettings = editor_plugin.get_editor_interface().get_editor_settings()
+	var editor_settings: EditorSettings = Engine.get_meta("DialogueManagerPlugin").get_editor_interface().get_editor_settings()
 	var external_editor: String = editor_settings.get_setting("text_editor/external/exec_path")
 	var use_external_editor: bool = editor_settings.get_setting("text_editor/external/use_external_editor") and external_editor != ""
 	if not use_external_editor:


### PR DESCRIPTION
This adds explicit loading of class references to hopefully get around the initial loading order in Godot 4.x.