### PR TITLE
Add shortcut to delete current line

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -78,6 +78,9 @@ func _gui_input(event: InputEvent) -> void:
 			"toggle_comment":
 				toggle_comment()
 				get_viewport().set_input_as_handled()
+			"delete_line":
+				delete_current_line()
+				get_viewport().set_input_as_handled()
 			"move_up":
 				move_line(-1)
 				get_viewport().set_input_as_handled()
@@ -349,6 +352,16 @@ func toggle_comment() -> void:
 	end_complex_operation()
 
 	text_set.emit()
+	text_changed.emit()
+
+
+# Remove the current line
+func delete_current_line() -> void:
+	var cursor = get_cursor()
+	var lines: PackedStringArray = text.split("\n")
+	lines.remove_at(cursor.y)
+	text = "\n".join(lines)
+	set_cursor(cursor)
 	text_changed.emit()
 
 

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -148,6 +148,9 @@ func get_editor_shortcuts() -> Dictionary:
 			_create_event("Ctrl+K"),
 			_create_event("Ctrl+Slash")
 		],
+		delete_line = [
+			_create_event("Ctrl+Shift+K")
+		],
 		move_up = [
 			_create_event("Alt+Up")
 		],
@@ -179,9 +182,13 @@ func get_editor_shortcuts() -> Dictionary:
 	}
 
 	var paths = get_editor_interface().get_editor_paths()
-	var settings = load(paths.get_config_dir() + "/editor_settings-4.tres")
-
-	if not settings: return shortcuts
+	var settings
+	if FileAccess.file_exists(paths.get_config_dir() + "/editor_settings-4.3.tres"):
+		settings = load(paths.get_config_dir() + "/editor_settings-4.3.tres")
+	elif FileAccess.file_exists(paths.get_config_dir() + "/editor_settings-4.tres"):
+		settings = load(paths.get_config_dir() + "/editor_settings-4.tres")
+	else:
+		return shortcuts
 
 	for s in settings.get("shortcuts"):
 		for key in shortcuts:
@@ -210,7 +217,7 @@ func get_editor_shortcut(event: InputEventKey) -> String:
 	var shortcuts: Dictionary = get_editor_shortcuts()
 	for key in shortcuts:
 		for shortcut in shortcuts.get(key, []):
-			if event.is_match(shortcut):
+			if event.as_text().split(" ")[0] == shortcut.as_text().split(" ")[0]:
 				return key
 	return ""
 


### PR DESCRIPTION
This adds a shortcut for deleting the current line. The shortcut itself is taken from Godot's code editor settings.

Closes #605 