### PR TITLE
Fix incorrect syntax highlighting on 'using' keyword

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -11,7 +11,7 @@ const DialogueManagerParseResult = preload("./parse_result.gd")
 
 
 var IMPORT_REGEX: RegEx = RegEx.create_from_string("import \"(?<path>[^\"]+)\" as (?<prefix>[^\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\-\\=\\+\\{\\}\\[\\]\\;\\:\\\"\\'\\,\\.\\<\\>\\?\\/\\s]+)")
-var USING_REGEX: RegEx = RegEx.create_from_string("using (?<state>.*)")
+var USING_REGEX: RegEx = RegEx.create_from_string("^using (?<state>.*)$")
 var VALID_TITLE_REGEX: RegEx = RegEx.create_from_string("^[^\\!\\@\\#\\$\\%\\^\\&\\*\\(\\)\\-\\=\\+\\{\\}\\[\\]\\;\\:\\\"\\'\\,\\.\\<\\>\\?\\/\\s]+$")
 var BEGINS_WITH_NUMBER_REGEX: RegEx = RegEx.create_from_string("^\\d")
 var TRANSLATION_REGEX: RegEx = RegEx.create_from_string("\\[ID:(?<tr>.*?)\\]")


### PR DESCRIPTION
This PR fixes an issue where the syntax highlighter highlights all istances of the "using" string in the dialogue files. The issue is demonstrated in the screenshot below:

![image](https://github.com/user-attachments/assets/3b164e3e-3b58-4272-a873-1bcd7619864d)
