### PR TITLE
Add setting to turn off startup unsaved indicator

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -52,7 +52,7 @@ func _enter_tree() -> void:
 		add_tool_menu_item("Create copy of dialogue example balloon...", _copy_dialogue_balloon)
 
 		# Prevent the project from showing as unsaved even though it was only just opened
-		if Engine.get_physics_frames() == 0:
+		if DialogueSettings.get_setting("try_suppressing_startup_unsaved_indicator", false) and Engine.get_physics_frames() == 0:
 			var timer: Timer = Timer.new()
 			var suppress_unsaved_marker: Callable
 			suppress_unsaved_marker = func():

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -21,7 +21,8 @@ const DEFAULT_SETTINGS = {
 	create_lines_for_responses_with_characters = true,
 	include_character_in_translation_exports = false,
 	include_notes_in_translation_exports = false,
-	uses_dotnet = false
+	uses_dotnet = false,
+	try_suppressing_startup_unsaved_indicator = false
 }
 
 


### PR DESCRIPTION
This adds a project setting to turn off the startup unsaved project indicator suppression.