### PR TITLE
Use cache when checking for state methods

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -68,8 +68,8 @@ var get_current_scene: Callable = func():
 var _has_loaded_autoloads: bool = false
 var _autoloads: Dictionary = {}
 
-
 var _node_properties: Array = []
+var _method_info_cache: Dictionary = {}
 
 
 func _ready() -> void:
@@ -1209,20 +1209,18 @@ func resolve_signal(args: Array, extra_game_states: Array):
 	# The signal hasn't been found anywhere
 	show_error_for_missing_state_value(DialogueConstants.translate(&"runtime.signal_not_found").format({ signal_name = args[0], states = str(get_game_states(extra_game_states)) }))
 
-var cached_thing_method_infos:Dictionary = {}
 
-func get_method_dictionary_for(thing) -> Dictionary:
+func get_method_info_for(thing, method: String) -> Dictionary:
 	# Use the thing instance id as a key for the caching dictionary.
-	var thing_instance_id:int = thing.get_instance_id()
-	# If this thing has already had its method infos cached, return the cached version.
-	if cached_thing_method_infos.has(thing_instance_id):
-		return cached_thing_method_infos[thing_instance_id]
-	# If not, build a new method dictionary and cache it.
-	var dictionary_methods = {}
-	for i in thing.get_method_list():
-		dictionary_methods[i.name] = i
-	cached_thing_method_infos[thing_instance_id] = dictionary_methods
-	return dictionary_methods
+	var thing_instance_id: int = thing.get_instance_id()
+	if not _method_info_cache.has(thing_instance_id):
+		var methods: Dictionary = {}
+		for m in thing.get_method_list():
+			methods[m.name] = m
+		_method_info_cache[thing_instance_id] = methods
+
+	return _method_info_cache.get(thing_instance_id, {}).get(method)
+
 
 func resolve_thing_method(thing, method: String, args: Array):
 	if Builtins.is_supported(thing):
@@ -1232,9 +1230,7 @@ func resolve_thing_method(thing, method: String, args: Array):
 
 	if thing.has_method(method):
 		# Try to convert any literals to the right type
-		var methods_dictionary = get_method_dictionary_for(thing)
-		var method_info: Dictionary = methods_dictionary[method]
-		
+		var method_info: Dictionary = get_method_info_for(thing, method)
 		var method_args: Array = method_info.args
 		if method_info.flags & METHOD_FLAG_VARARG == 0 and method_args.size() < args.size():
 			assert(false, DialogueConstants.translate(&"runtime.expected_n_got_n_args").format({ expected = method_args.size(), method = method, received = args.size()}))


### PR DESCRIPTION
When profiling my game I found a big spike when initializing a dialogue that came from an anonymous lambda being called 500+ times in one frame.

I traced this back to the `resolve_thing_method()` function in DialogueManager. It uses a filter on a get_method_list array to find the method with the correct name. It seems that can get slow when done for a lot of different methods, so I made a new method that caches the needed information to a dictionary the first time it runs, and uses the cached information in subsequent calls if it's already cached or adds to the cache if it isn't.

This change greatly alleviated the big lag spike I was experiencing.

<img width="889" alt="Screenshot 2024-07-17 at 10 49 37 AM" src="https://github.com/user-attachments/assets/c3e87f81-311c-482c-90d9-48768d45f56a">

No tests failed, and no change is needed to the documentation.