### PR TITLE
Set handled when using shortcut to avoid unwanted input

### DIFF
--- a/addons/dialogue_manager/components/search_and_replace.gd
+++ b/addons/dialogue_manager/components/search_and_replace.gd
@@ -122,9 +122,11 @@ func _on_text_edit_gui_input(event: InputEvent) -> void:
 		match event.as_text():
 			"Ctrl+F", "Command+F":
 				open_requested.emit()
+				get_viewport().set_input_as_handled()
 			"Ctrl+Shift+R", "Command+Shift+R":
 				replace_check_button.set_pressed(true)
 				open_requested.emit()
+				get_viewport().set_input_as_handled()
 
 
 func _on_text_edit_text_changed() -> void:


### PR DESCRIPTION
When doing a search while editing dialogue by pressing `Ctrl+f` and typing `potato` results in `fpotato`, at least when using Linux (gnome). Adding `set_input_as_handled` has fixed it for me (and hopefully hasn't broken anything else).