### PR TITLE
Free orphan nodes created in constants.gd

### DIFF
--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -177,7 +177,9 @@ static func get_error_message(error: int) -> String:
 
 
 static func translate(string: String) -> String:
-	var base_path = new().get_script().resource_path.get_base_dir()
+	var temp_node = new()
+	var base_path = temp_node.get_script().resource_path.get_base_dir()
+	temp_node.free()
 
 	var language: String = TranslationServer.get_tool_locale()
 	var translations_path: String = "%s/l10n/%s.po" % [base_path, language]


### PR DESCRIPTION
Fixes #642. 

New orphaned nodes were being created in `constants.gd`, specifically the `translate()` function, in order to assemble the `base_path` string. 

This PR creates a temp_node uses it in the creation of `base_path` then frees it. 