### PR TITLE
Ignore missing "save_all_scenes" in Godot 4.1

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -52,13 +52,15 @@ func _enter_tree() -> void:
 		add_tool_menu_item("Create copy of dialogue example balloon...", _copy_dialogue_balloon)
 
 		# Prevent the project from showing as unsaved even though it was only just opened
-		if DialogueSettings.get_setting("try_suppressing_startup_unsaved_indicator", false) and Engine.get_physics_frames() == 0:
+		if DialogueSettings.get_setting("try_suppressing_startup_unsaved_indicator", false) \
+			and Engine.get_physics_frames() == 0 \
+			and get_editor_interface().has_method("save_all_scenes"):
 			var timer: Timer = Timer.new()
 			var suppress_unsaved_marker: Callable
 			suppress_unsaved_marker = func():
 				if Engine.get_frames_per_second() >= 10:
 					timer.stop()
-					get_editor_interface().save_all_scenes()
+					get_editor_interface().call("save_all_scenes")
 					timer.queue_free()
 			timer.timeout.connect(suppress_unsaved_marker)
 			add_child(timer)


### PR DESCRIPTION
This makes Godot 4.1 ignore the `save_all_scenes` method that was added to `EditorInterface` in Godot 4.2.