### PR TITLE
Added public ExtraGameStates property to DialogueLine

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -301,6 +301,10 @@ namespace DialogueManagerRuntime
         }
 
         private Array<Variant> extra_game_states = new Array<Variant>();
+        public Array<Variant> ExtraGameStates
+        {
+            get => extra_game_states;
+        }
 
         private Array<string> tags = new Array<string>();
         public Array<string> Tags


### PR DESCRIPTION
The field `extra_game_states` was not exposed through a public property on the `DialogueLine` C# class. Added this to make it easier for running dialogue in custom ways from C#.