### PR TITLE
Add _Notification event workacround to C# file

### DIFF
--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -108,7 +108,7 @@ namespace DialogueManagerRuntime
     public override async void _Notification(int what)
     {
       // Detect a change of locale and update the current dialogue line to show the new language
-      if (what == NotificationTranslationChanged)
+      if (what == NotificationTranslationChanged && IsInstanceValid(dialogueLabel))
       {
         float visibleRatio = dialogueLabel.VisibleRatio;
         DialogueLine = await DialogueManager.GetNextDialogueLine(resource, DialogueLine.Id, temporaryGameStates);


### PR DESCRIPTION
As explained in https://github.com/nathanhoad/godot_dialogue_manager/issues/589, a workaround is needed because Godot calls a translation notification before the object is loaded. @nathanhoad already did it for GDScript but it doesn't seem to have made it into the C# version
