### PR TITLE
Add support for conditions on randomised lines

### DIFF
--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -236,6 +236,14 @@ For simple this-or-that conditions you can write them like this:
 Nathan: You have {{num_apples}} [if num_apples == 1]apple[else]apples[/if], nice!
 ```
 
+Randomised lines and randomised jump lines can also have conditions. Conditions for randomised lines go in square brackets after the `%` and before the line's content:
+
+```
+% => some_title
+%2 => some_other_title
+% [if SomeGlobal.some_condition] => another_title
+```
+
 ## Mutations
 
 You can affect state with either a "set" or a "do" line.

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -190,6 +190,33 @@ Nathan: Jump 3.")
 	assert(output.lines["5"].siblings[2].weight == 3, "Weight of 3 should be 3.")
 
 
+func test_can_parse_random_conditional_lines() -> void:
+	var output = parse("
+% Nathan: Random 1.
+%2 [if false] Nathan: Random 2.
+% Nathan: Random 3.
+% [if false] => jump_1
+% [if true] => jump_2
+%3 => jump_3
+~ jump_1
+Nathan: Jump 1.
+~ jump_2
+Nathan: Jump 2.
+~ jump_3
+Nathan: Jump 3.")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.lines["2"].siblings.size() == 3, "Should have 3 random siblings.")
+	assert(output.lines["2"].siblings[0].weight == 1, "Undefined weight should be 1.")
+	assert(output.lines["2"].siblings[1].weight == 2, "Weight of 2 should be 2.")
+	assert(output.lines["2"].siblings[1].condition.expression[0].value == "false", "Should parse expression.")
+
+	assert(output.lines["5"].siblings.size() == 3, "Should have 3 random siblings.")
+	assert(output.lines["5"].siblings[0].weight == 1, "Undefined weight should be 1.")
+	assert(output.lines["5"].siblings[1].condition.expression[0].value == "true", "Should parse expression.")
+	assert(output.lines["5"].siblings[2].weight == 3, "Weight of 3 should be 3.")
+
+
 class TestClass:
 	var string: String = ""
 	var number: int = -1


### PR DESCRIPTION
This adds support for conditional randomised jumps and randomised lines:

Conditions for randomised lines go in square brackets after the `%` and before the line's content:

```
% => some_title
%2 => some_other_title
% [if SomeGlobal.some_condition] => another_title
```

Closes #659 