### PR TITLE
Remove example balloon class on copy

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -334,6 +334,8 @@ func _copy_dialogue_balloon() -> void:
 		file_contents = file.get_as_text()
 		if is_dotnet:
 			file_contents = file_contents.replace("class ExampleBalloon", "class DialogueBalloon")
+		else:
+			file_contents = file_contents.replace("class_name DialogueManagerExampleBalloon ", "")
 		file = FileAccess.open(balloon_script_path, FileAccess.WRITE)
 		file.store_string(file_contents)
 		file.close()


### PR DESCRIPTION
This removes the `DialogueManagerExampleBalloon` class name when using the "copy example balloon" tool.