### PR TITLE
Assorted documentation changes/fixes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -36,15 +36,15 @@ Returns a `DialogueLine` that looks something like this:
 - `character: String` - the name of the character speaking (or `""`).
 - `text: String` - the text that the character is saying.
 - `tags: PackedStringArray` - a list of tags.
-- `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the line)
+- `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the line).
 - `responses: Array[DialogueResponse]` - the list of responses to this line (or `[]` if none are available).
   - `id: String` - the ID of the response.
   - `next_id: String` - the ID of the next line if this response is chosen.
-  - `is_allowed: bool` - whether this line passed its condition check (useful if you have "include all responses" enabled)
+  - `is_allowed: bool` - whether this line passed its condition check (useful if you have "include all responses" enabled).
   - `character: String` - the character name (if one was provided).
   - `text: String` - the text for this response.
   - `tags: PackedStringArray` - a list of tags.
-  - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the response)
+  - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the response).
 
 If there is no next line of dialogue found, it will return an empty dictionary (`{}`).
 
@@ -69,7 +69,7 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 - `seconds_per_step: float = 0.02` - the speed at which the text types out.
 - `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
 - `skip_pause_at_character_if_followed_by: String = ")\""` - ignore automatic pausing if the pause character is followed by one of these.
-- `skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"]` - Don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).
+- `skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"]` - don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).
 - `seconds_per_pause_step: float = 0.3` - the amount of time to pause when exposing a character present in pause_at_characters.
 
 ### Signals

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,17 +46,17 @@ Returns a `DialogueLine` that looks something like this:
   - `tags: PackedStringArray` - a list of tags.
   - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the response)
 
-If there is no next line of dialogue found then it will return an empty dictionary (`{}`).
+If there is no next line of dialogue found, it will return an empty dictionary (`{}`).
 
 Pass an array of nodes as `extra_game_states` in order to temporarily add to the game state shortcuts that are available to conditions and mutations.
 
-You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases you should leave this as the default. _The example balloon only supports `Wait`_.
+You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases, you should leave this as the default. _The example balloon only supports `Wait`_.
 
 #### `func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer`
 
 Opens the example balloon.
 
-If your game viewport is less than 400 it will open the low res balloon. Otherwise it will open the usual balloon.
+If your game viewport is less than 400, it will open the low res balloon. Otherwise, it will open the usual balloon.
 
 It will close once dialogue runs out.
 
@@ -66,10 +66,10 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 
 ### Exports
 
-- `seconds_per_step: float = 0.02` - the speed with which the text types out.
+- `seconds_per_step: float = 0.02` - the speed at which the text types out.
 - `pause_at_characters: String = ".?!"` - automatically have a brief pause when these characters are encountered.
 - `skip_pause_at_character_if_followed_by: String = ")\""` - ignore automatic pausing if the pause character is followed by one of these.
-- `skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"] - Don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).
+- `skip_pause_at_abbreviations: Array = ["Mr", "Mrs", "Ms", "Dr", "etc", "ex"]` - Don't auto pause after these abbreviations (only if "." is in `pause_at_characters`).
 - `seconds_per_pause_step: float = 0.3` - the amount of time to pause when exposing a character present in pause_at_characters.
 
 ### Signals

--- a/docs/CSharp.md
+++ b/docs/CSharp.md
@@ -1,6 +1,6 @@
 # C# wrapper
 
-If you are using C# for your project then there is a small convenience wrapper around the Dialogue Manager.
+If you are using C# for your project, there is a small convenience wrapper around the Dialogue Manager.
 
 First, add the namespace:
 
@@ -32,7 +32,7 @@ The returned line is a `DialogueLine` and will have mostly the same properties t
 
 ## State
 
-When looking for state, the Dialogue Manager will search in the current scene (ie. the scene returned from `GetTree().CurrentScene`), any autoloads, as well as anything passed in to the `extraGameStates` array in `GetNextDialogueLine(resource, key, extraGameStates)`. In order for a property to be visible to the Dialogue Manager it needs to have the `[Export]` decorator applied.
+When looking for state, the Dialogue Manager will search in the current scene (i.e. the scene returned from `GetTree().CurrentScene`), any autoloads, as well as anything passed in to the `extraGameStates` array in `GetNextDialogueLine(resource, key, extraGameStates)`. In order for a property to be visible to the Dialogue Manager, it needs to have the `[Export]` decorator applied.
 
 ## Mutations
 
@@ -92,7 +92,7 @@ DialogueManager.Mutated += (Godot.Collections.Dictionary mutation) =>
 };
 ```
 
-If you are using the built-in responses menu node then you'll have to use the `Connect` approach.
+If you are using the built-in responses menu node, you'll have to use the `Connect` approach.
 
 ```csharp
 responsesMenu.Connect("response_selected", Callable.From((DialogueResponse response) =>
@@ -103,4 +103,4 @@ responsesMenu.Connect("response_selected", Callable.From((DialogueResponse respo
 
 ## Example
 
-There is a balloon implemented in C# in the **examples** folder of the repository. If you want to have a closer look at it you'll have to clone the repository down because the automatic download ZIP removes the docs and examples folder.
+There is a balloon implemented in C# in the **examples** folder of the repository. If you want to have a closer look at it, you'll have to clone the repository down because the automatic download ZIP removes the docs and examples folder.

--- a/docs/CSharp.md
+++ b/docs/CSharp.md
@@ -92,7 +92,7 @@ DialogueManager.Mutated += (Godot.Collections.Dictionary mutation) =>
 };
 ```
 
-If you are using the built-in responses menu node, you'll have to use the `Connect` approach.
+If you are using the built-in responses menu node, you'll have to use the `Connect` approach:
 
 ```csharp
 responsesMenu.Connect("response_selected", Callable.From((DialogueResponse response) =>

--- a/docs/Example_Balloons.md
+++ b/docs/Example_Balloons.md
@@ -6,11 +6,11 @@ You can find them in the [/examples](../examples) directory. If you want to try 
 
 Example scenes include:
 
-- A portrait balloon showing character potraits and typing noises. This also shows using a low res balloon if the viewport is set to lower than 400px.
+- A portrait balloon showing character portraits and typing noises. This also shows using a low res balloon if the viewport is set to lower than 400px.
 - Using a mutation to ask the player for their name.
 - A Point n Click Adventure style interaction that includes voice acting in multiple languages.
 - A Visual Novel style balloon with various character slots and mutations for adding/removing characters in the conversation.
-- A C# Balloon that show how you might write a custom balloon in C#.
+- A C# Balloon that shows how you might write a custom balloon in C#.
 
 To see an example in action, open the scenes in [/examples/test_scenes](../examples/test_scenes/) and run them.
 

--- a/docs/Example_Balloons.md
+++ b/docs/Example_Balloons.md
@@ -1,6 +1,6 @@
 # Example Balloons
 
-It's up to you to implement the actual dialogue rendering and input control but there are a few example balloons included in the repository to get you started.
+It's up to you to implement the actual dialogue rendering and input control, however, there are a few example balloons included in the repository to get you started.
 
 You can find them in the [/examples](../examples) directory. If you want to try out these examples yourself, you'll need to clone the repository, not just download it.
 
@@ -14,13 +14,13 @@ Example scenes include:
 
 To see an example in action, open the scenes in [/examples/test_scenes](../examples/test_scenes/) and run them.
 
-If you want to run the Point n Click example in German then you will need to open Project Settings and change _Internationalization/Locale/Test_ to be `"de"` (you might need to enable Advanced Settings to see this).
+If you want to run the Point n Click example in German, you will need to open Project Settings and change _Internationalization/Locale/Test_ to be `"de"` (you might need to enable Advanced Settings to see this).
 
 ## Copying the example balloon
 
-There is a "Create copy of example dialogue balloon..." item in the _Project > Tools_ menu. When you click it you will be prompted to choose a directory to save the copied files into. From there, you can edit the new balloon to make it your own.
+There is a "Create copy of example dialogue balloon..." item in the _Project > Tools_ menu. When you click it, you will be prompted to choose a directory to save the copied files into. From there, you can edit the new balloon to make it your own.
 
-The most common thing you might want to do is adjust the font and margin sizes and the simplest way to do that is to edit the `theme` that is attached to the `Balloon` panel in your new copy of the example balloon.
+The most common thing you might want to do is adjust the font and margin sizes. The simplest way to do that is to edit the `theme` that is attached to the `Balloon` panel in your new copy of the example balloon.
 
 ## My balloon
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,19 +4,19 @@
 
 You can [ask on my Discord](https://nathanhoad.net/discord), [ask me on Mastodon](https://mastodon.social/@nathanhoad), or [open a discussion on GitHub](https://github.com/nathanhoad/godot_dialogue_manager/discussions).
 
-If you run into something that you think might be a bug then you can [open an issue](https://github.com/nathanhoad/godot_dialogue_manager/issues) (make sure to include your Godot version and Dialogue Manager version).
+If you run into something that you think might be a bug, you can [open an issue](https://github.com/nathanhoad/godot_dialogue_manager/issues) (make sure to include your Godot version and Dialogue Manager version).
 
 ## How can I support this project?
 
 There are a few ways you can support the development of Dialogue Manager. You can [become a patron on Patreon](https://patreon.com/nathanhoad) or [sponser me on GitHub](https://github.com/sponsors/nathanhoad).
 
-If you're not in a position to do either of those things then you can just [give me a sub or like on YouTube](https://youtube.com/@nathan_hoad).
+If you're not in a position to do either of those things, you can just [give me a sub or like on YouTube](https://youtube.com/@nathan_hoad).
 
 ## How do I stop my player from moving while dialogue is showing?
 
 One of the most common causes is that you've implemented player movement inside `_process` instead of in `_unhandled_input`.
 
-For more of a guide then check out the code for my [beginner dialogue example project](https://github.com/nathanhoad/beginner_godot4_dialogue/blob/finished/characters/coco/coco.gd#L17) and [the video that goes with it](https://youtu.be/UhPFk8FSbd8).
+For more of a guide, check out the code for my [beginner dialogue example project](https://github.com/nathanhoad/beginner_godot4_dialogue/blob/finished/characters/coco/coco.gd#L17) and [the video that goes with it](https://youtu.be/UhPFk8FSbd8).
 
 ## How do I detect when dialogue has finished?
 
@@ -32,10 +32,10 @@ The most common changes will be to the `theme` that is attached to the `Balloon`
 
 ## How do I credit Dialogue Manager in my game?
 
-To comply with the license you just need to include the license text (or a link to it) somewhere in your game, usually at the end of the credits.
+To comply with the license, you just need to include the license text (or a link to it) somewhere in your game. This is usually at the end of the credits.
 
-If you want to also credit it specifically then you can include something like "Dialogue System by Nathan Hoad" or whatever (I'm not fussy).
+If you want to also credit it specifically, you can include something like "Dialogue System by Nathan Hoad" or whatever (I'm not fussy).
 
 ## Why isn't something like Dialogue Manager built into Godot?
 
-The short answer is that not all games need to have any kind of dialogue, let alone branching dialogue trees so it would just be introducing bloat into the engine for little benefit. Another good reason to have it as an addon means I can iterate on it much faster than having to wait for engine releases.
+The short answer is that not all games need to have any kind of dialogue, let alone branching dialogue trees, so it would just be introducing bloat into the engine for little benefit. Another good reason to have it as an addon means I can iterate on it much faster than having to wait for engine releases.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,7 +8,7 @@ If you run into something that you think might be a bug, you can [open an issue]
 
 ## How can I support this project?
 
-There are a few ways you can support the development of Dialogue Manager. You can [become a patron on Patreon](https://patreon.com/nathanhoad) or [sponser me on GitHub](https://github.com/sponsors/nathanhoad).
+There are a few ways you can support the development of Dialogue Manager. You can [become a patron on Patreon](https://patreon.com/nathanhoad) or [sponsor me on GitHub](https://github.com/sponsors/nathanhoad).
 
 If you're not in a position to do either of those things, you can just [give me a sub or like on YouTube](https://youtube.com/@nathan_hoad).
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -18,21 +18,21 @@ You can configure a default balloon to show when calling [`DialogueManager.show_
 
 ### Globals shortcuts
 
-The dialogue runtime itself is stateless, meaning it looks to your game to provide values for variables and for methods to run. At run time, the dialogue manager will check the current scene first and then check any globals.
+The dialogue runtime itself is stateless, meaning it looks to your game to provide values for variables and methods to run. At run time, the dialogue manager will check the current scene first and then check any globals.
 
-If you don't want to type out a globals' name all of the time you can add it to the globals shortcut list.
+If you don't want to type out a globals' name all of the time, you can add it to the globals shortcut list.
 
-For example, instead of having to type out `GameState.some_variable`, you could enable `GameState` and then you would just need to type out `some_variable`.
+For example, instead of having to type out `GameState.some_variable`, you can enable `GameState`. This will allow you to simply type out `some_variable`.
 
 ![GameState and SessionState are used by dialogue](states.jpg)
 
 ## Advanced
 
 - `Include character names in translation exports` - will include a `_character` column in CSV exports.
-- `Include notes (## comments) in translation exports` - will include a `_notes` column in CSV exports populated from doc-style comments (eg. `## This is a comment`) above translatable lines.
+- `Include notes (## comments) in translation exports` - will include a `_notes` column in CSV exports populated from doc-style comments (e.g. `## This is a comment`) above translatable lines.
 - `Custom Test Scene` can be used to override the default test scene that gets run when you click the "Test dialogue" button in the dialogue editor.
 
 Changing any of the following values will result in a recompile of all dialogue files in your project.
 
 - `Treat missing translations as errors` can be enabled if you are using static translation keys and are adding them manually (there is an automatic static key button but you might be writing specific keys).
-- `Create child dialogue line for responses with character names in them` can be disabled if you don't want to automatically create a dialogue line after responses that define a character
+- `Create child dialogue line for responses with character names in them` can be disabled if you don't want to automatically create a dialogue line after responses that define a character.

--- a/docs/Translations.md
+++ b/docs/Translations.md
@@ -4,7 +4,7 @@ By default, all dialogue and response prompts will be run through Godot's `tr` f
 
 Translations in dialogue work slightly differently depending on whether you're using CSV files or PO files to define your translated phrases.
 
-By default Dialogue Manager will try to guess which one you're using based on the files that you have set up in the locale project settings. If a PO file is found it will assume you're using PO files and if not it will fall back to assuming CSV.
+By default, Dialogue Manager will try to guess which one you're using based on the files that you have set up in the locale project settings. If a PO file is found, it will assume you're using PO files. If not, it will fall back to assuming CSV.
 
 You can override this behaviour by setting `DialogueManager.translation_source` to be one of the values provided by `DialogueManager.TranslationSource`. `None` will turn off translations altogether, meaning you'll have to handle them yourself. `CSV` tells Dialogue Manager that you're using CSVs for translations. `PO` tells it that you're using PO files for translations. `Guess` is the default behaviour and will attempt to guess either CSV or PO.
 
@@ -24,18 +24,18 @@ All `.dialogue` files are automatically added to the POT Generation list in **Pr
 
 You can export translations as CSV from the "Translations" menu in the dialogue editor. 
 
-This will find any unique dialogue lines or response prompts and add them to a list. If an ID is specified for the line (eg. `[ID:SOME_KEY]`) then that will be used as the translation key, otherwise the dialogue/prompt itself will be.
+This will find any unique dialogue lines or response prompts and add them to a list. If an ID is specified for the line (e.g. `[ID:SOME_KEY]`) then that will be used as the translation key, otherwise the dialogue/prompt itself will be.
 
 If the target CSV file already exists, it will be merged with.
 
 ## Importing changes to translations CSV
 
-If you've made changes in the exported CSV to the original lines then you can reimport them from the translations menu.
+If you've made changes in the exported CSV to the original lines, you can reimport them from the translations menu.
 
 This will match lines using static keys and replace the dialogue/response content with the text found in the CSV.
 
 ## Translating character names
 
-Characters' names generally show up in more than just dialogue so it is assumed that they are translated by your game. There is an option to export all character names in a dialogue file to CSV from the Translations menu.
+Characters' names generally show up in more than just dialogue, so it is assumed that they are translated by your game. There is an option to export all character names in a dialogue file to CSV from the Translations menu.
 
 Character names will also be added to the POT Generation list with a context of "dialogue".

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -2,9 +2,9 @@
 
 The simplest way to show dialogue in your game is to call [`DialogueManager.show_dialogue_balloon(resource, title)`](./API.md#func-show_dialogue_balloonresource-dialogueresource-title-string--0-extra_game_states-array-----node) with a dialogue resource and a title to start from. This will show the example balloon by default but you can configure it in [Settings](./Settings.md) to show your custom balloon.
 
-It's up to you to implement/customise any dialogue rendering and input control to match your game but there are [a few example balloons](Example_Balloons.md) included to get you started with some of the more common things.
+It's up to you to implement/customise any dialogue rendering and input control to match your game, however, there are [a few example balloons](Example_Balloons.md) included to get you started with some of the more common things.
 
-Once you get to the stage of building your own balloon you'll need to know how to get a line of dialogue and how to use the dialogue label node.
+Once you get to the stage of building your own balloon, you'll need to know how to get a line of dialogue and how to use the dialogue label node.
 
 ## Getting a line of dialogue
 
@@ -37,7 +37,7 @@ var dialogue_line = await resource.get_next_dialogue_line("start")
 
 Then `dialogue_line` would now hold a `DialogueLine` containing information for the line `Nathan: Hi! I'm Nathan`.
 
-To get the next line of dialogue you can call `get_next_dialogue_line` again with `dialogue_line.next_id` as the title:
+To get the next line of dialogue, you can call `get_next_dialogue_line` again with `dialogue_line.next_id` as the title:
 
 ```
 dialogue_line = await DialogueManager.get_next_dialogue_line(resource, dialogue_line.next_id)
@@ -49,13 +49,13 @@ Now `dialogue_line` holds a `DialogueLine` containing the information for the li
 
 Each option also contains a `next_id` property that can be used to continue along that branch.
 
-For more information about `DialogueLine`s see the [API documentation](API.md).
+For more information about `DialogueLine`s, see the [API documentation](API.md).
 
 ## DialogueLabel node
 
 The addon provides a `DialogueLabel` node (an extension of the RichTextLabel node) which helps with rendering a line of dialogue text.
 
-This node is given a `dialogue_line` (mentioned above) and uses its properties to work out how to handling typing out the dialogue. It will automatically handle any `bb_code`, `wait`, `speed`, and `inline_mutation` references.
+This node is given a `dialogue_line` (mentioned above) and uses its properties to work out how to handle typing out the dialogue. It will automatically handle any `bb_code`, `wait`, `speed`, and `inline_mutation` references.
 
 Use `type_out()` to start typing out the text. The label will emit a `finished_typing` signal when it has finished typing.
 
@@ -65,11 +65,11 @@ The `DialogueLabel` typing speed can be configured in your balloon by changing t
 
 ## Using a custom `current_scene` implementation
 
-If your game has its own method of managing what the "current scene" is then you might want to pass an overridden `Callable` to `DialogueManager.get_current_scene`. The built-in implementation looks at `get_tree().current_scene` before assuming the last child of `get_tree().root` is the current scene. If that doesn't work for you game then you can pass in a `Callable` that returns a `Node` that represents what the current scene is.
+If your game has its own method of managing what the "current scene" is, you might want to pass an overridden `Callable` to `DialogueManager.get_current_scene`. The built-in implementation looks at `get_tree().current_scene` before assuming the last child of `get_tree().root` is the current scene. If that doesn't work for your game, you can pass in a `Callable` that returns a `Node` that represents what the current scene is.
 
 ## Generating Dialogue Resources at runtime
 
-If you need to construct a dialogue resource at runtime you can use `create_resource_from_text(string)`:
+If you need to construct a dialogue resource at runtime, you can use `create_resource_from_text(string)`:
 
 ```gdscript
 var resource = DialogueManager.create_resource_from_text("~ title\nCharacter: Hello!")
@@ -77,9 +77,9 @@ var resource = DialogueManager.create_resource_from_text("~ title\nCharacter: He
 
 This will run the given text through the parser.
 
-If there were syntax errors the method will fail.
+If there were syntax errors, the method will fail.
 
-If there were no errors then you can use this ephemeral resource like normal:
+If there were no errors, you can use this ephemeral resource like normal:
 
 ```gdscript
 var dialogue_line = await DialogueManager.get_next_dialogue_line(resource, "title")

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -103,7 +103,7 @@ To weight lines, use a `%` followed by a number to weight by. For example, a `%2
 
 ```
 %3 Nathan: This line has a 60% chance of being picked
-%2 Nathan: This line has an 40% chance of being picked
+%2 Nathan: This line has a 40% chance of being picked
 ```
 
 ## Comments

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -48,7 +48,7 @@ and
 Coco: This is the first line.\nThis line would show up below it in the same balloon.\nAnd even this line.
 ```
 
-_Note: When using indented line breaks and [line IDs for translations](./Translations.md) you can only specify a line ID on the first (unindented) line of each group._
+_Note: When using indented line breaks and [line IDs for translations](./Translations.md), you can only specify a line ID on the first (unindented) line of each group._
 
 ### Escaping characters
 
@@ -64,15 +64,15 @@ Character : This is how\: you escape a colon.
 
 Dialogue lines can also contain **bb_code** for RichTextEffects (if you end up using a `RichTextLabel` or the `DialogueLabel` provided by this addon).
 
-If you use the `DialogueLabel` node then you can also make use of the `[wait=N]` and `[speed=N]` codes. `wait` will pause the typing of the dialogue for `N` seconds (eg. `[wait=1.5]` will pause for 1.5 seconds). `speed` will change the typing speed of the current line of dialogue by that factor (eg `[speed=10]` will change the typing speed to be 10 times faster than normal).
+If you use the `DialogueLabel` node, you can also make use of the `[wait=N]` and `[speed=N]` codes. `wait` will pause the typing of the dialogue for `N` seconds (e.g. `[wait=1.5]` will pause for 1.5 seconds). `speed` will change the typing speed of the current line of dialogue by that factor (e.g. `[speed=10]` will change the typing speed to be 10 times faster than normal).
 
-There is also a `[next]` code that you can use to signify that a line should be auto advanced. If given no arguments it will auto advance immediately after the text has typed out. If given something like `[next=0.5]` it will wait for 0.5s after typing has finished before moving to the next line. If given `[next=auto]` it will wait for an automatic amount of time based on the length of the line.
+There is also a `[next]` code that you can use to signify that a line should be auto advanced. If given no arguments, it will auto advance immediately after the text has typed out. If given something like `[next=0.5]`, it will wait for 0.5s after typing has finished before moving to the next line. If given `[next=auto]`, it will wait for an automatic amount of time based on the length of the line.
 
-If you need to use `[` or `]` in general dialogue without markup then you can escape them like `\[` and `\]`.
+If you need to use `[` or `]` in general dialogue without markup, you can escape them like `\[` and `\]`.
 
 ### Tags
 
-If you need to annotate your lines with tags then you can wrap them in `[#` and `]`, separated by commas. So to specify "happy" and "surprised" tags for a line you would do something like:
+If you need to annotate your lines with tags, you can wrap them in `[#` and `]`, separated by commas. So to specify "happy" and "surprised" tags for a line, you would do something like:
 
 ```
 Nathan: [#happy, #surprised] Oh, Hello!
@@ -88,7 +88,7 @@ For this line of dialogue, the `tags` array would be `["mood=happy"]`, and `line
 
 ### Randomising lines of dialogue
 
-If you want to pick one from a few lines of dialogue you can mark the line with a `%` at the start like this:
+If you want to pick one from a few lines of dialogue, you can mark the line with a `%` at the start like this:
 
 ```
 Nathan: I will say this.
@@ -99,10 +99,10 @@ Nathan: I will say this.
 
 Each line will have an equal chance of being said.
 
-To weight lines use a `%` followed by a number to weight by. For example a `%2` will mean that line has twice the chance of being picked as a normal line.
+To weight lines, use a `%` followed by a number to weight by. For example, a `%2` will mean that line has twice the chance of being picked as a normal line.
 
 ```
-%3 Nathan: This line as a 60% chance of being picked
+%3 Nathan: This line has a 60% chance of being picked
 %2 Nathan: This line has an 40% chance of being picked
 ```
 
@@ -112,13 +112,13 @@ Any line starting with a `#` will be ignored by the compiler so you can use thos
 
 ## Jumps
 
-If you want to redirect flow to another title then you can use a jump line. Assuming the target title is "another_title" your jump line would be
+If you want to redirect flow to another title, you can use a jump line. Assuming the target title is "another_title", your jump line would be:
 
 ```
 => another_title
 ```
 
-If you wanted the dialogue manager to jump to that title but then return to this line when it is finished then you can write the goto line as:
+If you wanted the dialogue manager to jump to that title but then return to this line when it is finished, you can write the goto line as:
 
 ```
 =>< another_title
@@ -132,9 +132,9 @@ You can also import titles from other files. Specify your imports at the top of 
 import "res://snippets.dialogue" as snippets
 ```
 
-And then you can jump to titles by prefixing them with `snippets/`. For example, say there was a "talk_to_nathan" title in the snippets file then in the current file I could use `=> snippets/talk_to_nathan`.
+And then you can jump to titles by prefixing them with `snippets/`. For example, say there was a "talk_to_nathan" title in the snippets file, in the current file I could use `=> snippets/talk_to_nathan`.
 
-The `%` syntax also applies to jumps. So to jump to one of a random set of titles you might have something like this:
+The `%` syntax also applies to jumps. So to jump to one of a random set of titles, you might have something like this:
 
 ```
 Nathan: Let's go somewhere random.
@@ -145,7 +145,7 @@ Nathan: Let's go somewhere random.
 
 ## Responses
 
-To give the player branching options you can start a line with "- " and then a prompt. Like dialogue, prompts can also contain variables wrapped in `{{}}`.
+To give the player branching options, you can start a line with "- " and then a prompt. Like dialogue, prompts can also contain variables wrapped in `{{}}`.
 
 ```
 Nathan: What would you like?
@@ -166,7 +166,7 @@ Nathan: What would you like?
 - Nothing => END
 ```
 
-If a response prompt contains a character name then it will be treated as an actual line of dialogue when the player selects it.
+If a response prompt contains a character name, it will be treated as an actual line of dialogue when the player selects it.
 
 For example:
 
@@ -198,7 +198,7 @@ if SomeGlobal.some_property >= 10
 elif SomeGlobal.some_other_property == "some value"
     Nathan: Or we might be in here.
 else
-    Nathan: If neither are true I'll say this.
+    Nathan: If neither are true, I'll say this.
 ```
 
 You can also start a conditional block with "while". These blocks will loop as long as the condition is true.
@@ -210,7 +210,7 @@ while SomeGlobal.some_property < 10
 Nathan: Now, we can move on.
 ```
 
-To escape a condition line (ie. if you wanted to start a dialogue line with "if") then you can prefix the condition keyword with a "\".
+To escape a condition line (i.e. if you wanted to start a dialogue line with "if"), you can prefix the condition keyword with a "\".
 
 Responses can also have "if" conditions. Wrap these in "[" and "]".
 
@@ -222,7 +222,7 @@ Nathan: What would you like?
 - Nothing => END
 ```
 
-If using a condition and a goto on a response line then make sure the goto is provided last.
+If using a condition and a goto on a response line, make sure the goto is provided last.
 
 Conditions can also be used inline in a dialogue line when wrapped with "[if predicate]" and "[/if]".
 
@@ -230,7 +230,7 @@ Conditions can also be used inline in a dialogue line when wrapped with "[if pre
 Nathan: I have done this [if already_done]once again[/if]
 ```
 
-For simple this-or-that conditions you can write them like this:
+For simple this-or-that conditions, you can write them like this:
 
 ```
 Nathan: You have {{num_apples}} [if num_apples == 1]apple[else]apples[/if], nice!
@@ -279,7 +279,7 @@ Inline mutations that use `await` in their implementation will pause typing of d
 
 Signals can be emitted similarly to how they are emitted in GDScript - by calling `emit` on them.
 
-For example, if `SomeGlobal` has a signal called `some_signal` that has a single string parameter then you can emit it from dialogue like this:
+For example, if `SomeGlobal` has a signal called `some_signal` that has a single string parameter, you can emit it from dialogue like this:
 
 ```
 do SomeGlobal.some_signal.emit("some argument")
@@ -287,24 +287,24 @@ do SomeGlobal.some_signal.emit("some argument")
 
 ### State shortcuts
 
-If you want to shorten your references to state from something like `SomeGlobal.some_property` to just `some_property` then there are two ways you can do this.
+If you want to shorten your references to state from something like `SomeGlobal.some_property` to just `some_property`, there are two ways you can do this.
 
-1. If you use the same state in all of your dialogue then you can set up global state shortcuts in [Settings](./Settings.md).
-2. Or, if you want different shortcuts per dialogue file you can add a `using SomeGlobal` clause (for whatever autoload you're using) at the top of your dialogue file.
+1. If you use the same state in all of your dialogue, you can set up global state shortcuts in [Settings](./Settings.md).
+2. Or, if you want different shortcuts per dialogue file, you can add a `using SomeGlobal` clause (for whatever autoload you're using) at the top of your dialogue file.
 
 ## Error checking
 
 Your dialogue will be periodically checked for syntax or referential integrity issues.
 
-If any are found they will be highlighted and must be fixed before you can run your game.
+If any are found, they will be highlighted and must be fixed before you can run your game.
 
 ## Running a test scene
 
-For dialogue that doesn't rely too heavily on game state conditions you can do a quick test of it by clicking the "Run the test scene" button in the main toolbar.
+For dialogue that doesn't rely too heavily on game state conditions, you can do a quick test of it by clicking the "Run the test scene" button in the main toolbar.
 
 This will boot up a test scene and run from the nearest title marker above the cursor position. Use your mouse and/or `ui_up`, `ui_down`, and `ui_accept` to navigate the dialogue and responses.
 
-Once the conversation is over the scene will close.
+Once the conversation is over, the scene will close.
 
 ### Custom test scene
 
@@ -326,6 +326,6 @@ func _ready() -> void:
 
 You can export translations as CSV from the "Translations" menu in the dialogue editor.
 
-This will find any unique dialogue lines or response prompts and add them to a list. If an ID is specified for the line (eg. `[ID:SOME_KEY]`) then that will be used as the translation key, otherwise the dialogue/prompt itself will be.
+This will find any unique dialogue lines or response prompts and add them to a list. If an ID is specified for the line (e.g. `[ID:SOME_KEY]`), that will be used as the translation key, otherwise the dialogue/prompt itself will be.
 
 If the target CSV file already exists, it will be merged with.

--- a/docs/Writing_Dialogue.md
+++ b/docs/Writing_Dialogue.md
@@ -88,7 +88,7 @@ For this line of dialogue, the `tags` array would be `["mood=happy"]`, and `line
 
 ### Randomising lines of dialogue
 
-If you want to pick one from a few lines of dialogue, you can mark the line with a `%` at the start like this:
+If you want to pick a random line out of multiple, you can mark the lines with a `%` at the start like this:
 
 ```
 Nathan: I will say this.
@@ -154,9 +154,9 @@ Nathan: What would you like?
 - Nothing
 ```
 
-By default responses will just continue on to the lines below the list when one is chosen.
+By default, responses will just continue on to the lines below the list when one is chosen.
 
-To branch, you can provide and indented body under a given prompt or add a `=> another_title` where "another_title" is the title of another node. If you want to end the conversation right away you can `=> END`.
+To branch, you can provide an indented body under a given prompt or add a `=> another_title` where "another_title" is the title of another node. If you want to end the conversation right away you can use `=> END`.
 
 ```
 Nathan: What would you like?
@@ -181,7 +181,7 @@ Someone: Here is a thing you can do.
 ...is the same as writing:
 
 ```
-Someone: Here is a thing you can do
+Someone: Here is a thing you can do.
 - Nathan: That's good to hear!
 - Nathan: That's definitely news
 ```
@@ -273,7 +273,7 @@ Nathan: I'm not sure we've met before [do wave()]I'm Nathan.
 Nathan: I can also emit signals[do SomeGlobal.some_signal.emit()] inline.
 ```
 
-Inline mutations that use `await` in their implementation will pause typing of dialogue until they resolve. To ignore awaiting, add a "!" after the "do" keyword - eg. `[do! something()]`.
+Inline mutations that use `await` in their implementation will pause typing of dialogue until they resolve. To ignore awaiting, add a "!" after the "do" keyword - e.g. `[do! something()]`.
 
 ### Signals
 


### PR DESCRIPTION
Updated the documentation with improved punctuation for better readability and fixed missing backtick/fullstop and occasional incorrectly used words such as, _"with" instead of "at"_, _"handling" instead of "handle"_, _"as" instead of "has"_, and _"you" instead of "your"_.