### PR TITLE
Allow parallel C# next line requests

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -78,12 +78,17 @@ namespace DialogueManagerRuntime
         }
 
 
+        public static void Prepare(GodotObject instance)
+        {
+            instance.Connect("passed_title", Callable.From((string title) => PassedTitle?.Invoke(title)));
+            instance.Connect("got_dialogue", Callable.From((RefCounted line) => GotDialogue?.Invoke(new DialogueLine(line))));
+            instance.Connect("mutated", Callable.From((Dictionary mutation) => Mutated?.Invoke(mutation)));
+            instance.Connect("dialogue_ended", Callable.From((Resource dialogueResource) => DialogueEnded?.Invoke(dialogueResource)));
+        }
+
         public void Prepare()
         {
-            Instance.Connect("passed_title", Callable.From((string title) => PassedTitle?.Invoke(title)));
-            Instance.Connect("got_dialogue", Callable.From((RefCounted line) => GotDialogue?.Invoke(new DialogueLine(line))));
-            Instance.Connect("mutated", Callable.From((Dictionary mutation) => Mutated?.Invoke(mutation)));
-            Instance.Connect("dialogue_ended", Callable.From((Resource dialogueResource) => DialogueEnded?.Invoke(dialogueResource)));
+            Prepare(Instance);
         }
 
 
@@ -113,8 +118,11 @@ namespace DialogueManagerRuntime
 
         public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
         {
-            Instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
-            var result = await Instance.ToSignal(Instance, "bridge_get_next_dialogue_line_completed");
+            var instance = (Node)Instance.Call("_bridge_get_new_instance");
+            Prepare(instance);
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+            var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
+            instance.QueueFree();
 
             if ((RefCounted)result[0] == null) return null;
 
@@ -164,64 +172,64 @@ namespace DialogueManagerRuntime
         }
 
 
-    public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
-    {
-        MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
+        public async void ResolveThingMethod(GodotObject thing, string method, Array<Variant> args)
+        {
+            MethodInfo? info = thing.GetType().GetMethod(method, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
-        if (info == null) return;
+            if (info == null) return;
 
 #nullable disable
-        // Convert the method args to something reflection can handle
-        ParameterInfo[] argTypes = info.GetParameters();
-        object[] _args = new object[argTypes.Length];
-        for (int i = 0; i < argTypes.Length; i++)
-        {
-            // check if args is assignable from derived type
-            if (i < args.Count && args[i].Obj != null)
+            // Convert the method args to something reflection can handle
+            ParameterInfo[] argTypes = info.GetParameters();
+            object[] _args = new object[argTypes.Length];
+            for (int i = 0; i < argTypes.Length; i++)
             {
-                if (argTypes[i].ParameterType.IsAssignableFrom(args[i].Obj.GetType()))
+                // check if args is assignable from derived type
+                if (i < args.Count && args[i].Obj != null)
                 {
-                    _args[i] = args[i].Obj;
+                    if (argTypes[i].ParameterType.IsAssignableFrom(args[i].Obj.GetType()))
+                    {
+                        _args[i] = args[i].Obj;
+                    }
+                    // fallback to assigning primitive types
+                    else
+                    {
+                        _args[i] = Convert.ChangeType(args[i].Obj, argTypes[i].ParameterType);
+                    }
                 }
-                // fallback to assigning primitive types
+                else if (argTypes[i].DefaultValue != null)
+                {
+                    _args[i] = argTypes[i].DefaultValue;
+                }
+            }
+
+            // Add a single frame wait in case the method returns before signals can listen
+            await ToSignal(Engine.GetMainLoop(), SceneTree.SignalName.ProcessFrame);
+
+            // invoke method and handle the result based on return type
+            object result = info.Invoke(thing, _args);
+
+            if (result is Task taskResult)
+            {
+                // await Tasks and handle result if it is a Task<T>
+                await taskResult;
+                var taskType = taskResult.GetType();
+                if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>))
+                {
+                    var resultProperty = taskType.GetProperty("Result");
+                    var taskResultValue = resultProperty.GetValue(taskResult);
+                    EmitSignal(SignalName.Resolved, (Variant)taskResultValue);
+                }
                 else
                 {
-                    _args[i] = Convert.ChangeType(args[i].Obj, argTypes[i].ParameterType);
+                    EmitSignal(SignalName.Resolved, null);
                 }
-            }
-            else if (argTypes[i].DefaultValue != null)
-            {
-                _args[i] = argTypes[i].DefaultValue;
-            }
-        }
-
-        // Add a single frame wait in case the method returns before signals can listen
-        await ToSignal(Engine.GetMainLoop(), SceneTree.SignalName.ProcessFrame);
-
-        // invoke method and handle the result based on return type
-        object result = info.Invoke(thing, _args);
-
-        if (result is Task taskResult)
-        {
-            // await Tasks and handle result if it is a Task<T>
-            await taskResult;
-            var taskType = taskResult.GetType();
-            if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>))
-            {
-                var resultProperty = taskType.GetProperty("Result");
-                var taskResultValue = resultProperty.GetValue(taskResult);
-                EmitSignal(SignalName.Resolved, (Variant)taskResultValue);
             }
             else
             {
-                EmitSignal(SignalName.Resolved, null);
+                EmitSignal(SignalName.Resolved, (Variant)result);
             }
         }
-        else
-        {
-            EmitSignal(SignalName.Resolved, (Variant)result);
-        }
-    }
 #nullable enable
     }
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -309,6 +309,10 @@ func _get_dotnet_dialogue_manager() -> Node:
 	return load(get_script().resource_path.get_base_dir() + "/DialogueManager.cs").new()
 
 
+func _bridge_get_new_instance() -> Node:
+	return new()
+
+
 func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:
 	# dotnet needs at least one await tick of the signal gets called too quickly
 	await get_tree().process_frame

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -315,7 +315,7 @@ func _bridge_get_new_instance() -> Node:
 
 func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:
 	# dotnet needs at least one await tick of the signal gets called too quickly
-	await get_tree().process_frame
+	await Engine.get_main_loop().process_frame
 
 	var line = await get_next_dialogue_line(resource, key, extra_game_states)
 	bridge_get_next_dialogue_line_completed.emit(line)

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -555,7 +555,7 @@ func get_game_states(extra_game_states: Array) -> Array:
 		game_states = [_autoloads]
 		# Add any other state shortcuts from settings
 		for node_name in DialogueSettings.get_setting(&"states", []):
-			var state: Node = get_node_or_null("/root/" + node_name)
+			var state: Node = Engine.get_main_loop().root.get_node_or_null(node_name)
 			if state:
 				game_states.append(state)
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -60,9 +60,9 @@ var translation_source: TranslationSource = TranslationSource.Guess
 
 ## Used to resolve the current scene. Override if your game manages the current scene itself.
 var get_current_scene: Callable = func():
-	var current_scene: Node = get_tree().current_scene
+	var current_scene: Node = Engine.get_main_loop().current_scene
 	if current_scene == null:
-		current_scene = get_tree().root.get_child(get_tree().root.get_child_count() - 1)
+		current_scene = Engine.get_main_loop().root.get_child(Engine.get_main_loop().root.get_child_count() - 1)
 	return current_scene
 
 var _has_loaded_autoloads: bool = false
@@ -100,7 +100,7 @@ func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_
 
 	# Inject any "using" states into the game_states
 	for state_name in resource.using_states:
-		var autoload = get_tree().root.get_node_or_null(state_name)
+		var autoload = Engine.get_main_loop().root.get_node_or_null(state_name)
 		if autoload == null:
 			printerr(DialogueConstants.translate(&"runtime.unknown_autoload").format({ autoload = state_name }))
 		else:
@@ -545,11 +545,11 @@ func get_game_states(extra_game_states: Array) -> Array:
 	if not _has_loaded_autoloads:
 		_has_loaded_autoloads = true
 		# Add any autoloads to a generic state so we can refer to them by name
-		for child in get_tree().root.get_children():
+		for child in Engine.get_main_loop().root.get_children():
 			# Ignore the dialogue manager
 			if child.name == &"DialogueManager": continue
 			# Ignore the current main scene
-			if get_tree().current_scene and child.name == get_tree().current_scene.name: continue
+			if Engine.get_main_loop().current_scene and child.name == Engine.get_main_loop().current_scene.name: continue
 			# Add the node to our known autoloads
 			_autoloads[child.name] = child
 		game_states = [_autoloads]
@@ -585,12 +585,12 @@ func mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation: 
 		match expression[0].function:
 			&"wait":
 				mutated.emit(mutation)
-				await get_tree().create_timer(float(args[0])).timeout
+				await Engine.get_main_loop().create_timer(float(args[0])).timeout
 				return
 
 			&"debug":
 				prints("Debug:", args)
-				await get_tree().process_frame
+				await Engine.get_main_loop().process_frame
 
 	# Or pass through to the resolver
 	else:
@@ -604,7 +604,7 @@ func mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation: 
 			resolve(mutation.expression.duplicate(true), extra_game_states)
 
 	# Wait one frame to give the dialogue handler a chance to yield
-	await get_tree().process_frame
+	await Engine.get_main_loop().process_frame
 
 
 func mutation_contains_assignment(mutation: Array) -> bool:


### PR DESCRIPTION
This addresses an issue where calls to `DialogueManager.GetNextDialogueLine` within the same tick would all return the value from the first request.