### PR TITLE
Allow titles in nested lines

### DIFF
--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -64,7 +64,6 @@ const ERR_FILE_ALREADY_IMPORTED = 101
 const ERR_DUPLICATE_IMPORT_NAME = 102
 const ERR_EMPTY_TITLE = 103
 const ERR_DUPLICATE_TITLE = 104
-const ERR_NESTED_TITLE = 105
 const ERR_TITLE_INVALID_CHARACTERS = 106
 const ERR_UNKNOWN_TITLE = 107
 const ERR_INVALID_TITLE_REFERENCE = 108
@@ -110,8 +109,6 @@ static func get_error_message(error: int) -> String:
 			return translate(&"errors.empty_title")
 		ERR_DUPLICATE_TITLE:
 			return translate(&"errors.duplicate_title")
-		ERR_NESTED_TITLE:
-			return translate(&"errors.nested_title")
 		ERR_TITLE_INVALID_CHARACTERS:
 			return translate(&"errors.invalid_title_string")
 		ERR_TITLE_BEGINS_WITH_NUMBER:

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -297,9 +297,6 @@ msgstr "Titles cannot be empty."
 msgid "errors.duplicate_title"
 msgstr "There is already a title with that name."
 
-msgid "errors.nested_title"
-msgstr "Titles cannot be indented."
-
 msgid "errors.invalid_title_string"
 msgstr "Titles can only contain alphanumeric characters and numbers."
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -287,9 +287,6 @@ msgstr ""
 msgid "errors.duplicate_title"
 msgstr ""
 
-msgid "errors.nested_title"
-msgstr ""
-
 msgid "errors.invalid_title_string"
 msgstr ""
 

--- a/addons/dialogue_manager/l10n/uk.po
+++ b/addons/dialogue_manager/l10n/uk.po
@@ -293,9 +293,6 @@ msgstr "Заголовки не можуть бути порожніми."
 msgid "errors.duplicate_title"
 msgstr "З такою назвою уже є заголовок."
 
-msgid "errors.nested_title"
-msgstr "Заголовки не повинні мати відступів."
-
 msgid "errors.invalid_title_string"
 msgstr "Заголовки можуть містити лише алфавітно-цифрові символи та цифри."
 

--- a/addons/dialogue_manager/l10n/zh.po
+++ b/addons/dialogue_manager/l10n/zh.po
@@ -272,9 +272,6 @@ msgstr "标题名不能为空。"
 msgid "errors.duplicate_title"
 msgstr "标题名不能重复。"
 
-msgid "errors.nested_title"
-msgstr "标题不能嵌套。"
-
 msgid "errors.invalid_title_string"
 msgstr "标题名无效。"
 

--- a/addons/dialogue_manager/l10n/zh_TW.po
+++ b/addons/dialogue_manager/l10n/zh_TW.po
@@ -272,9 +272,6 @@ msgstr "標題名不能爲空。"
 msgid "errors.duplicate_title"
 msgstr "標題名不能重複。"
 
-msgid "errors.nested_title"
-msgstr "標題不能嵌套。"
-
 msgid "errors.invalid_title_string"
 msgstr "標題名無效。"
 

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -12,12 +12,6 @@ func test_can_parse_titles() -> void:
 	assert(output.titles.has("some_title"), "Should have known title.")
 	assert(output.titles["some_title"] == "2", "Should point to the next line.")
 
-	output = parse(" ~ indented_title\nNathan: Oh no!")
-
-	assert(output.errors.size() > 0, "Should have an error.")
-	assert(output.errors[0].line_number == 0, "Should be an indentation error.")
-	assert(output.errors[0].error == DialogueConstants.ERR_NESTED_TITLE, "Should be an indentation error.")
-
 
 func test_can_parse_basic_dialogue() -> void:
 	var output = parse("Nathan: This is dialogue with a name.\nThis is dialogue without a name")


### PR DESCRIPTION
This adds support for having titles in nested lines. For example:

```
~ top_level_title
Nathan: Hello.
if SomeGlobal.some_property
  Nathan: This is nested.
  ~ nested_title
  Nathan: Nested titles are now supported.
```

Closes #690 
Also fixes #691 