### PR TITLE
Fix scrolling issue in code edit

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -383,6 +383,7 @@ func delete_current_line() -> void:
 func move_line(offset: int) -> void:
 	offset = clamp(offset, -1, 1)
 
+	var starting_scroll := scroll_vertical
 	var cursor = get_cursor()
 	var reselect: bool = false
 	var from: int = cursor.y
@@ -413,6 +414,7 @@ func move_line(offset: int) -> void:
 		select(from, 0, to, get_line_width(to))
 
 	text_changed.emit()
+	scroll_vertical = starting_scroll + offset
 
 
 ### Signals


### PR DESCRIPTION
In Godot 4.2.2 the dialogue editor would scroll back up to the top of the file when moving a line. This fixes it by simply returning the scroll value back to its initial value (+offset) from the start of the function.

_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

_If this is a change to the compiler then make sure to add/update any tests that may be affected._

_If this change needs updates to the documentation then make sure you've made those changes too._