### PR TITLE
Remove unnecessary backslash in POT file

### DIFF
--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -22,7 +22,7 @@ func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> v
 
 			known_keys.append(character_name)
 
-			msgids_context_plural.append([character_name.replace('"', '\\"'), "dialogue", ""])
+			msgids_context_plural.append([character_name.replace('"', '\"'), "dialogue", ""])
 
 	# Add all dialogue lines and responses
 	var dialogue: Dictionary = data.lines
@@ -35,9 +35,9 @@ func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> v
 		known_keys.append(line.translation_key)
 
 		if line.translation_key == "" or line.translation_key == line.text:
-			msgids_context_plural.append([line.text.replace('"', '\\"'), "", ""])
+			msgids_context_plural.append([line.text.replace('"', '\"'), "", ""])
 		else:
-			msgids_context_plural.append([line.text.replace('"', '\\"'), line.translation_key.replace('"', '\\"'), ""])
+			msgids_context_plural.append([line.text.replace('"', '\"'), line.translation_key.replace('"', '\"'), ""])
 
 
 func _get_recognized_extensions() -> PackedStringArray:


### PR DESCRIPTION
When using this king of dialog line:

`Use the sword with {{InputManager.get_bbcode_for_action_and_current_device("attack", true, 15)}}`

POT generated file contains the following string:
```
#: dialogs/timelines/tutorials/box.dialogue
msgid "To move a box, you must stand in front of it and hold {{InputManager.get_bbcode_for_action_and_current_device(\\\"pull\\\", true, 15)}} while moving"
msgstr ""
```

This prevents godot from loading the po/mo files generated by POEdit

This PR removes the redundant backslashes but there may be side effects