### PR TITLE
Allow single step execution on get_next_dialogue_line via flag

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -8,6 +8,12 @@ using System.Threading.Tasks;
 
 namespace DialogueManagerRuntime
 {
+    public enum MutationBehaviour {
+        Wait,
+        DoNotWait,
+        Skip
+    }
+    
     public enum TranslationSource
     {
         None,
@@ -116,11 +122,11 @@ namespace DialogueManagerRuntime
             return instance;
         }
 
-        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null, MutationBehaviour mutationBehaviour = MutationBehaviour.Wait, bool singleStep = false)
         {
             var instance = (Node)Instance.Call("_bridge_get_new_instance");
             Prepare(instance);
-            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), mutationBehaviour.ToString(), singleStep);
             var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
             instance.QueueFree();
 
@@ -432,4 +438,3 @@ namespace DialogueManagerRuntime
         }
     }
 }
-

--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -116,11 +116,11 @@ namespace DialogueManagerRuntime
             return instance;
         }
 
-        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null, bool singleStep = false)
         {
             var instance = (Node)Instance.Call("_bridge_get_new_instance");
             Prepare(instance);
-            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), singleStep);
             var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
             instance.QueueFree();
 

--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -116,11 +116,11 @@ namespace DialogueManagerRuntime
             return instance;
         }
 
-        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null, bool singleStep = false)
+        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
         {
             var instance = (Node)Instance.Call("_bridge_get_new_instance");
             Prepare(instance);
-            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), singleStep);
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
             var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
             instance.QueueFree();
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -941,8 +941,12 @@ func resolve(tokens: Array, extra_game_states: Array):
 				# it until everything after it has been resolved
 				token["type"] = "variable"
 			else:
-				token["type"] = "value"
-				token["value"] = get_state_value(str(token.value), extra_game_states)
+				if token.type == DialogueConstants.TOKEN_NUMBER:
+					token["type"] = "value"
+					token["value"] = token.value
+				else:
+					token["type"] = "value"
+					token["value"] = get_state_value(str(token.value), extra_game_states)
 
 		i += 1
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -941,12 +941,8 @@ func resolve(tokens: Array, extra_game_states: Array):
 				# it until everything after it has been resolved
 				token["type"] = "variable"
 			else:
-				if token.type == DialogueConstants.TOKEN_NUMBER:
-					token["type"] = "value"
-					token["value"] = token.value
-				else:
-					token["type"] = "value"
-					token["value"] = get_state_value(str(token.value), extra_game_states)
+				token["type"] = "value"
+				token["value"] = get_state_value(str(token.value), extra_game_states)
 
 		i += 1
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -316,11 +316,11 @@ func _bridge_get_new_instance() -> Node:
 	return new()
 
 
-func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:
+func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = [], mutation_behaviour: String = "Wait", single_step: bool = false) -> void:
 	# dotnet needs at least one await tick of the signal gets called too quickly
 	await Engine.get_main_loop().process_frame
 
-	var line = await get_next_dialogue_line(resource, key, extra_game_states)
+	var line = await get_next_dialogue_line(resource, key, extra_game_states, MutationBehaviour[mutation_behaviour], single_step)
 	bridge_get_next_dialogue_line_completed.emit(line)
 
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -91,7 +91,7 @@ func _ready() -> void:
 
 
 ## Step through lines and run any mutations until we either hit some dialogue or the end of the conversation
-func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine:
+func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait, single_step: bool = false) -> DialogueLine:
 	# You have to provide a valid dialogue resource
 	if resource == null:
 		assert(false, DialogueConstants.translate(&"runtime.no_resource"))
@@ -129,7 +129,10 @@ func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_
 			(func(): dialogue_ended.emit(resource)).call_deferred()
 			return null
 		else:
-			return await get_next_dialogue_line(resource, dialogue.next_id, extra_game_states, mutation_behaviour)
+			if single_step:
+				return dialogue
+			else:
+				return await get_next_dialogue_line(resource, dialogue.next_id, extra_game_states, mutation_behaviour)
 	else:
 		got_dialogue.emit(dialogue)
 		return dialogue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -649,7 +649,7 @@ func get_state_value(property: String, extra_game_states: Array):
 		return Vector3.ZERO
 	elif property == "Vector4":
 		return Vector4.ZERO
-	elif property == "Quaternian":
+	elif property == "Quaternion":
 		return Quaternion()
 
 	var expression = Expression.new()

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -649,7 +649,7 @@ func get_state_value(property: String, extra_game_states: Array):
 		return Vector3.ZERO
 	elif property == "Vector4":
 		return Vector4.ZERO
-	elif property == "Quaternion":
+	elif property == "Quaternian":
 		return Quaternion()
 
 	var expression = Expression.new()

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,7 +23,7 @@ Opens a dialogue balloon given in `balloon_scene`.
 
 Returns the balloon's base node in case you want to `queue_free()` it yourself.
 
-#### `func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait) -> DialogueLine`
+#### `func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_game_states: Array = [], mutation_behaviour: MutationBehaviour = MutationBehaviour.Wait, single_step: bool = false) -> DialogueLine`
 
 **Must be used with `await`.**
 
@@ -51,6 +51,8 @@ If there is no next line of dialogue found, it will return an empty dictionary (
 Pass an array of nodes as `extra_game_states` in order to temporarily add to the game state shortcuts that are available to conditions and mutations.
 
 You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases, you should leave this as the default. _The example balloon only supports `Wait`_.
+
+If `single_step` is enabled, the function will NOT run until it finds a printable line. Instead, it will run a single line from the dialogue and return a `DialogueLine` even if it is not printable (as in the case of mutations).
 
 #### `func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer`
 


### PR DESCRIPTION
This PR adds a new flag `single_step` on function `get_next_dialogue_line()` (it is disabled by default to maintain compatibility). If enabled, the engine will not run until it finds a printable line, instead it will stop after running one line only. Documentation has been updated accordingly. This has two benefits:
* users can have more control on the execution flow
* engine is more stateless than before, since in executing multiple steps there we keep some state implicitly within the function stack inside `get_next_dialogue_line()`

The PR also fixes two minor issues, a typo and a fix for handling numbers (which the engine was attempting to convert to variables previously).
