### PR TITLE
Account for character but no dialogue

### DIFF
--- a/addons/dialogue_manager/components/parser.gd
+++ b/addons/dialogue_manager/components/parser.gd
@@ -216,7 +216,7 @@ func parse(text: String, path: String) -> Error:
 			# If this response has a character name in it then it will automatically be
 			# injected as a line of dialogue if the player selects it
 			var response_text: String = line.text.replace("\\:", "!ESCAPED_COLON!")
-			if ": " in response_text:
+			if ":" in response_text:
 				if DialogueSettings.get_setting("create_lines_for_responses_with_characters", true):
 					var first_child: Dictionary = {
 						type = DialogueConstants.TYPE_DIALOGUE,
@@ -362,8 +362,9 @@ func parse(text: String, path: String) -> Error:
 			raw_line = tag_data.line_without_tags
 
 			var l = raw_line.replace("\\:", "!ESCAPED_COLON!")
-			if ": " in l:
-				var bits = Array(l.strip_edges().split(": "))
+
+			if ":" in l:
+				var bits = Array(l.strip_edges().split(":"))
 				line["character"] = bits.pop_front().strip_edges()
 				if not line["character"] in character_names:
 					character_names.append(line["character"])
@@ -372,7 +373,7 @@ func parse(text: String, path: String) -> Error:
 				for replacement in line.character_replacements:
 					if replacement.has("error"):
 						add_error(id, replacement.index, replacement.error)
-				line["text"] = ": ".join(bits).replace("!ESCAPED_COLON!", ":")
+				line["text"] = ":".join(bits).replace("!ESCAPED_COLON!", ":")
 			else:
 				line["character"] = ""
 				line["character_replacements"] = [] as Array[Dictionary]
@@ -1079,7 +1080,7 @@ func parse_response_character_and_text(id: int, text: String, line: Dictionary, 
 	if not line["character"] in character_names:
 		character_names.append(line["character"])
 
-	line["text"] = ": ".join(bits).replace("!ESCAPED_COLON!", ":").strip_edges()
+	line["text"] = ":".join(bits).replace("!ESCAPED_COLON!", ":").strip_edges()
 
 	if line.get("translation_key", null) == null:
 		line["translation_key"] = line.text

--- a/docs/Translations.md
+++ b/docs/Translations.md
@@ -1,6 +1,6 @@
 # Translations
 
-By default, all dialogue and response prompts will be run through Godot's `tr` function to provide translations. 
+By default, all dialogue and response prompts will be run through Godot's `tr` function to provide translations.
 
 Translations in dialogue work slightly differently depending on whether you're using CSV files or PO files to define your translated phrases.
 
@@ -12,7 +12,16 @@ You can override this behaviour by setting `DialogueManager.translation_source` 
 
 Dialogue lines and response lines can specify a unique ID per line in the form of `[ID:SOME_KEY]` where "SOME_KEY" is a unique string identifying that line/response.
 
+For example:
+
+```
+Nathan: Hi! I'm Nathan. [ID:HI_IM_NATHAN]
+Coco: Meow. [ID:MEOW]
+```
+
 Static line keys are useful if you need to match up lines with voice acted dialogue.
+
+_NOTE: Tags (eg. `[next=auto]`, `[#happy]`, `[wave]`, etc) are part of the dialogue line so they should be included in any translations._
 
 ## Generating POT files for gettext (PO) translation
 
@@ -22,7 +31,7 @@ All `.dialogue` files are automatically added to the POT Generation list in **Pr
 
 ## Exporting lines as CSV
 
-You can export translations as CSV from the "Translations" menu in the dialogue editor. 
+You can export translations as CSV from the "Translations" menu in the dialogue editor.
 
 This will find any unique dialogue lines or response prompts and add them to a list. If an ID is specified for the line (e.g. `[ID:SOME_KEY]`) then that will be used as the translation key, otherwise the dialogue/prompt itself will be.
 


### PR DESCRIPTION
This makes a slight adjustment to differentiating between character and dialogue in dialogue lines for when the line is basically blank (ie. only contains a static line ID).