### PR TITLE
Delay reimporting to avoid clashes with editor

### DIFF
--- a/addons/dialogue_manager/components/dialogue_cache.gd
+++ b/addons/dialogue_manager/components/dialogue_cache.gd
@@ -22,6 +22,8 @@ var _cache: Dictionary = {}
 var _update_dependency_timer: Timer = Timer.new()
 var _update_dependency_paths: PackedStringArray = []
 
+var _files_marked_for_reimport: PackedStringArray = []
+
 
 func _ready() -> void:
 	add_child(_update_dependency_timer)
@@ -30,14 +32,24 @@ func _ready() -> void:
 	_build_cache()
 
 
-func reimport_files(files: PackedStringArray = []) -> void:
-	if files.is_empty(): files = get_files()
+func mark_files_for_reimport(files: PackedStringArray) -> void:
+	for file in files:
+		if not _files_marked_for_reimport.has(file):
+			_files_marked_for_reimport.append(file)
+
+
+func reimport_files(and_files: PackedStringArray = []) -> void:
+	for file in and_files:
+		if not _files_marked_for_reimport.has(file):
+			_files_marked_for_reimport.append(file)
+	
+	if _files_marked_for_reimport.is_empty(): return
 
 	var file_system: EditorFileSystem = Engine.get_meta("DialogueManagerPlugin") \
 		.get_editor_interface() \
 		.get_resource_filesystem()
 
-	file_system.reimport_files(files)
+	file_system.reimport_files(_files_marked_for_reimport)
 
 
 ## Add a dialogue file to the cache.

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -156,6 +156,8 @@ func _build() -> bool:
 	if DialogueSettings.get_user_value("is_running_test_scene", true): return true
 
 	if dialogue_cache != null:
+		dialogue_cache.reimport_files()
+		
 		var files_with_errors = dialogue_cache.get_files_with_errors()
 		if files_with_errors.size() > 0:
 			for dialogue_file in files_with_errors:

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -295,7 +295,7 @@ func save_files() -> void:
 		save_file(path, false)
 
 	if saved_files.size() > 0:
-		Engine.get_meta("DialogueCache").reimport_files(saved_files)
+		Engine.get_meta("DialogueCache").mark_files_for_reimport(saved_files)
 
 
 # Save a file
@@ -1054,8 +1054,9 @@ func _on_settings_view_script_button_pressed(path: String) -> void:
 
 
 func _on_test_button_pressed() -> void:
-	save_file(current_file_path)
-
+	save_file(current_file_path, false)
+	Engine.get_meta("DialogueCache").reimport_files([current_file_path])
+	
 	if errors_panel.errors.size() > 0:
 		errors_dialog.popup_centered()
 		return


### PR DESCRIPTION
This moves when resources are actually compiled to hopefully avoid clashing with Godot's automatic import process.

Related to #723 