### PR TITLE
Added signal to DialogueManager for when dialogue starts

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -12,6 +12,9 @@ const DialogueManagerParseResult = preload("./components/parse_result.gd")
 const ResolvedLineData = preload("./components/resolved_line_data.gd")
 
 
+## Emitted when a dialogue balloon is created and dialogue starts
+signal dialogue_started(resource: DialogueResource)
+
 ## Emitted when a title is encountered while traversing dialogue, usually when jumping from a
 ## goto line
 signal passed_title(title: String)
@@ -269,6 +272,7 @@ func show_example_dialogue_balloon(resource: DialogueResource, title: String = "
 	var balloon: Node = load(_get_example_balloon_path()).instantiate()
 	get_current_scene.call().add_child(balloon)
 	balloon.start(resource, title, extra_game_states)
+	dialogue_started.emit(resource)
 
 	return balloon
 
@@ -278,6 +282,7 @@ func show_dialogue_balloon(resource: DialogueResource, title: String = "", extra
 	var balloon_path: String = DialogueSettings.get_setting(&"balloon_path", _get_example_balloon_path())
 	if not ResourceLoader.exists(balloon_path):
 		balloon_path = _get_example_balloon_path()
+	dialogue_started.emit(resource)
 	return show_dialogue_balloon_scene(balloon_path, resource, title, extra_game_states)
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,7 @@
 
 ### Signals
 
+- `dialogue_started(resource: DialogueResource)` - emitted when a dialogue balloon is created and dialogue begins.
 - `passed_title(title)` - emitted when a title marker is passed through.
 - `got_dialogue(line: DialogueLine)` - emitted when a dialogue line is found.
 - `mutated(mutation: Dictionary)` - emitted when a mutation line is about to be run (not including `set` lines).


### PR DESCRIPTION
I've added a signal called `dialogue_started(resource: DialogueResource)`

The signal emits when either the example balloon or a custom balloon is created, and dialogue starts.

This signal is more specific and useful to mark when dialogue starts than the existing `title_passed(title)` because it is only emitted once when the dialogue first begins, and includes a reference to the dialogue resource file. This signal pairs very nicely with the existing `dialogue_ended(resource: DialogueResource)` signal.

I have also updated the documentation to include this signal and what it does.