### PR TITLE
Fix "else" being incorrectly required

### DIFF
--- a/addons/dialogue_manager/compiler/compiled_line.gd
+++ b/addons/dialogue_manager/compiler/compiled_line.gd
@@ -82,7 +82,8 @@ func to_data() -> Dictionary:
 	match type:
 		DMConstants.TYPE_CONDITION:
 			d.condition = expression
-			d.next_sibling_id = next_sibling_id
+			if not next_sibling_id.is_empty():
+				d.next_sibling_id = next_sibling_id
 			d.next_id_after = next_id_after
 
 		DMConstants.TYPE_WHILE:

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -219,7 +219,7 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 		# "else" will have no actual condition
 		if await _check_condition(data, extra_game_states):
 			return await get_line(resource, data.next_id + id_trail, extra_game_states)
-		elif data.has("next_sibling_id"):
+		elif data.has("next_sibling_id") and not data.next_sibling_id.is_empty():
 			return await get_line(resource, data.next_sibling_id + id_trail, extra_game_states)
 		else:
 			return await get_line(resource, data.next_id_after + id_trail, extra_game_states)

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -42,8 +42,17 @@ Nathan: After.")
 	condition = output.lines["5"]
 	assert(condition.type == DMConstants.TYPE_CONDITION, "Should be a condition.")
 	assert(condition.next_id == "6", "Should point to next line.")
-	assert(condition.next_sibling_id == "", "Should not reference further conditions.")
+	assert(condition.has("next_sibling_id") == false, "Should not reference further conditions.")
 	assert(condition.next_id_after == "7", "Should reference after conditions.")
+
+	output = compile("
+if StateForTests.some_property == 1
+	Nathan: True
+Nathan: After")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.lines["1"].type == DMConstants.TYPE_CONDITION, "Condition should be condition.")
+	assert(output.lines["1"].has("next_sibling_id") == false, "Condition should have no sibling.")
 
 
 func test_ignore_escaped_conditions() -> void:


### PR DESCRIPTION
This fixes an issue where compiled condition lines were incorrectly reading a blank sibling reference as existing.

Fixes #740 
Fixes #741 