### PR TITLE
Fix title not found if after dedent

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -268,7 +268,7 @@ func build_line_tree(raw_lines: PackedStringArray) -> DMTreeLine:
 			parent_chain.resize(tree_line.indent + 1)
 
 		# Add any titles to the list of known titles
-		elif tree_line.type == DMConstants.TYPE_TITLE:
+		if tree_line.type == DMConstants.TYPE_TITLE:
 			var title: String = tree_line.text.substr(2)
 			if title == "":
 				add_error(i, 2, DMConstants.ERR_EMPTY_TITLE)

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -9,6 +9,17 @@ func test_can_parse_titles() -> void:
 	assert(output.titles.has("some_title"), "Should have known title.")
 	assert(output.titles["some_title"] == "1", "Should point to the next line.")
 
+	output = compile("
+~ start
+if StateForTests.some_property
+	Nathan: Some unrelated but indented line.
+	=> title_directly_after_dedent
+~ title_directly_after_dedent")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.titles.size() == 2, "Should have two titles.")
+	assert(output.titles.keys()[1] == "title_directly_after_dedent", "Should have second title.")
+
 
 func test_can_parse_basic_dialogue() -> void:
 	var output = compile("Nathan: This is dialogue with a name.\nThis is dialogue without a name")


### PR DESCRIPTION
This fixes an issue where titles that were directly after an indent change were not being added to the known titles list.

Fixes #742