### PR TITLE
Fix empty lines breaking response grouping

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -562,14 +562,14 @@ func parse_response_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: 
 	for i in range(sibling_index - 1, 0, -1):
 		if siblings[i].type == DMConstants.TYPE_RESPONSE:
 			original_response = siblings[i]
-		else:
+		elif siblings[i].type != DMConstants.TYPE_UNKNOWN:
 			break
 
 	# If it's the original response then set up an original line.
 	if original_response == tree_line:
 		line.next_id_after = get_next_matching_sibling_id(siblings, sibling_index, parent, (func(s: DMTreeLine):
 			# The next line that isn't a response.
-			return s.type != DMConstants.TYPE_RESPONSE
+			return not s.type in [DMConstants.TYPE_RESPONSE, DMConstants.TYPE_UNKNOWN]
 		), true)
 		line.responses = [line.id]
 		# If this line has children then the next ID is the first child.

--- a/tests/test_responses.gd
+++ b/tests/test_responses.gd
@@ -24,6 +24,23 @@ Nathan: Line after.")
 	assert(responses[3].text == "Condition", "Should match text")
 	assert("expression" in responses[3].condition, "Should match text")
 
+	output = compile("
+~ start
+Nathan: All of these responses should count.
+- First
+- Second
+
+- Third
+	Nathan: Nested
+
+- Fourth
+
+=> END")
+
+	assert(output.errors.is_empty(), "Should be no errors.")
+	assert(output.lines["3"].responses.size() == 4, "Should have four responses in group.")
+	assert(output.lines["3"].next_id == "11", "Should point to END after.")
+
 
 func test_can_have_responses_without_dialogue() -> void:
 	var output = compile("


### PR DESCRIPTION
This fixes an issue where empty lines were breaking the grouping of responses. Empty lines are only supposed to break the grouping of randomised lines.