### PR TITLE
Keep previous get_current_scene data in C# bridge

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -453,7 +453,9 @@ func _get_dotnet_dialogue_manager() -> Node:
 
 
 func _bridge_get_new_instance() -> Node:
-	return new()
+	var instance = new()
+	instance.get_current_scene = get_current_scene
+	return instance
 
 
 func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:


### PR DESCRIPTION
updated _bridge_get_new_instance() to pass through the previous get_current_scene value into the temporary C# bridge instance. this fixes an issue where modifying DialogueManager.GetCurrentScene in a C# script would only update the get_current_scene variable in the main instance, and not from the temporary instance created by _bridge_get_new_instance().