### PR TITLE
Fix issue with if grouping with wrong else

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -406,10 +406,18 @@ func parse_goto_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: Arra
 func parse_condition_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: Array[DMTreeLine], sibling_index: int, parent: DMCompiledLine) -> Error:
 	# Work out the next IDs before parsing the condition line itself so that the last
 	# child can inherit from the chain.
-	line.next_sibling_id = get_next_matching_sibling_id(siblings, sibling_index, parent, func(s: DMTreeLine):
-		# The next conditional that isn't starting a new conditional group
-		return s.type == DMConstants.TYPE_CONDITION and not s.text.begins_with("if ")
-	)
+
+	# Find the next conditional sibling that is part of this grouping (if there is one).
+	for next_sibling: DMTreeLine in siblings.slice(sibling_index + 1):
+		if not next_sibling.type in [DMConstants.TYPE_UNKNOWN, DMConstants.TYPE_CONDITION]:
+			break
+		elif next_sibling.type == DMConstants.TYPE_CONDITION:
+			if next_sibling.text.begins_with("el"):
+				line.next_sibling_id = next_sibling.id
+				break
+			else:
+				break
+
 	line.next_id_after = get_next_matching_sibling_id(siblings, sibling_index, parent, func(s: DMTreeLine):
 		# The next line that isn't a conditional or is a new "if"
 		return s.type != DMConstants.TYPE_CONDITION or s.text.begins_with("if ")

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -55,6 +55,23 @@ Nathan: After")
 	assert(output.lines["1"].has("next_sibling_id") == false, "Condition should have no sibling.")
 
 
+func test_can_group_conditions() -> void:
+	var output = compile("
+~ start
+if false
+	Nathan: False
+if true
+	Nathan: True
+else
+	Nathan: Else
+=> END")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(not output.lines["2"].has("next_sibling_id"), "Should not have a sibling.")
+	assert(output.lines["4"].has("next_sibling_id"), "Should have no sibling.")
+	assert(output.lines["4"].next_sibling_id == "6", "Should have else as sibling.")
+
+
 func test_ignore_escaped_conditions() -> void:
 	var output = compile("
 \\if this is dialogue.


### PR DESCRIPTION
This fixes an issue where peerless `if` statements where incorrectly grouping to another group's `else` statement.

Fixes #752 