### PR TITLE
Fix nestled inline mutations being clobbered

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -187,11 +187,12 @@ func _mutate_inline_mutations(index: int) -> void:
 		if inline_mutation[0] > index:
 			return
 		if inline_mutation[0] == index and not _already_mutated_indices.has(index):
-			_already_mutated_indices.append(index)
 			_is_awaiting_mutation = true
 			# The DialogueManager can't be referenced directly here so we need to get it by its path
 			await Engine.get_singleton("DialogueManager")._mutate(inline_mutation[1], dialogue_line.extra_game_states, true)
 			_is_awaiting_mutation = false
+
+	_already_mutated_indices.append(index)
 
 
 # Determine if the current autopause character at the cursor should qualify to pause typing.

--- a/addons/dialogue_manager/utilities/builtins.gd
+++ b/addons/dialogue_manager/utilities/builtins.gd
@@ -406,7 +406,7 @@ static func resolve_vector2_property(vector: Vector2, property: String):
 			return Vector2.UP
 		"DOWN":
 			return Vector2.DOWN
-		
+
 		"DOWN_LEFT":
 			return Vector2(-1, 1)
 		"DOWN_RIGHT":

--- a/tests/test_dialogue_label.gd
+++ b/tests/test_dialogue_label.gd
@@ -34,3 +34,24 @@ func test_type_out() -> void:
 	await label.finished_typing
 
 	assert(label.visible_characters == label.get_parsed_text().length(), "Should be finished typing.")
+
+
+func test_inline_mutations() -> void:
+	var data: Dictionary = {
+		counter = 0
+	}
+
+	var resource = create_resource("
+~ start
+Nathan: This line has[set counter += 1][set counter += 10] two mutations.
+=> END")
+
+	var dialogue_line: DialogueLine = await resource.get_next_dialogue_line("start", [data])
+	label.dialogue_line = dialogue_line
+
+	assert(data.counter == 0, "Counter should initially be zero.")
+
+	label.type_out()
+	await label.finished_typing
+
+	assert(data.counter == 11, "Both mutations should have run.")


### PR DESCRIPTION
This stops mutations that exist within the same index of a line from clobbering each other.

Fixes #754 