### PR TITLE
Add a check for top-level state name collisions

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -721,6 +721,9 @@ func _get_state_value(property: String, extra_game_states: Array):
 	if expression.parse(property) != OK:
 		assert(false, DMConstants.translate(&"runtime.invalid_expression").format({ expression = property, error = expression.get_error_text() }))
 
+	# Warn about possible name collisions
+	_warn_about_state_name_collisions(property, extra_game_states)
+
 	for state in _get_game_states(extra_game_states):
 		if typeof(state) == TYPE_DICTIONARY:
 			if state.has(property):
@@ -739,6 +742,50 @@ func _get_state_value(property: String, extra_game_states: Array):
 				return load(class_data.path).new()
 
 	show_error_for_missing_state_value(DMConstants.translate(&"runtime.property_not_found").format({ property = property, states = _get_state_shortcut_names(extra_game_states) }))
+
+
+# Print warnings for top-level state name collisions.
+func _warn_about_state_name_collisions(target_key: String, extra_game_states: Array) -> void:
+	# Don't run the check if this is a release build
+	if not OS.is_debug_build(): return
+	# Also don't run if the setting is off
+	if not DMSettings.get_setting(DMSettings.WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS, false): return
+
+	# Get the list of state shortcuts.
+	var state_shortcuts: Array = []
+	for node_name in DMSettings.get_setting(DMSettings.STATE_AUTOLOAD_SHORTCUTS, ""):
+		var state: Node = Engine.get_main_loop().root.get_node_or_null(node_name)
+		if state:
+			state_shortcuts.append(state)
+
+	# Check any top level names for a collision
+	var states_with_key: Array = []
+	for state in extra_game_states + [get_current_scene.call()] + state_shortcuts:
+		if state is Dictionary:
+			if state.keys().has(target_key):
+				states_with_key.append("Dictionary")
+		else:
+			var script: Script = (state as Object).get_script()
+			if script == null:
+				continue
+
+			for method in script.get_script_method_list():
+				if method.name == target_key and not states_with_key.has(state.name):
+					states_with_key.append(state.name)
+					break
+
+			for property in script.get_script_property_list():
+				if property.name == target_key and not states_with_key.has(state.name):
+					states_with_key.append(state.name)
+					break
+
+			for signal_info in script.get_script_signal_list():
+				if signal_info.name == target_key and not states_with_key.has(state.name):
+					states_with_key.append(state.name)
+					break
+
+	if states_with_key.size() > 1:
+		push_warning(DMConstants.translate(&"runtime.top_level_states_share_name").format({ states = ", ".join(states_with_key), key = target_key }))
 
 
 # Set a value on the current scene or game state
@@ -869,6 +916,9 @@ func _resolve(tokens: Array, extra_game_states: Array):
 						token.value = randi_range(1, args[0])
 						found = true
 					_:
+						# Check for top level name conflicts
+						_warn_about_state_name_collisions(function_name, extra_game_states)
+
 						for state in _get_game_states(extra_game_states):
 							if _thing_has_method(state, function_name, args):
 								token.type = DMConstants.TOKEN_VALUE

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -410,3 +410,6 @@ msgstr "Array[{type}] isn't supported in mutations. Use Array as a type instead.
 
 msgid "runtime.dialogue_balloon_missing_start_method"
 msgstr "Your dialogue balloon is missing a \"start\" or \"Start\" method."
+
+msgid "runtime.top_level_states_share_name"
+msgstr "Multiple top-level states ({states}) share method/property/signal name \"{key}\". Only the first occurance is accessible to dialogue."

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -400,3 +400,6 @@ msgstr ""
 
 msgid "runtime.dialogue_balloon_missing_start_method"
 msgstr ""
+
+msgid "runtime.top_level_states_share_name"
+msgstr ""

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -31,6 +31,8 @@ const CUSTOM_TEST_SCENE_PATH = "editor/advanced/custom_test_scene_path"
 const BALLOON_PATH = "runtime/balloon_path"
 ## The names of any autoloads to shortcut into all dialogue files (so you don't have to write `using SomeGlobal` in each file).
 const STATE_AUTOLOAD_SHORTCUTS = "runtime/state_autoload_shortcuts"
+## Check for possible naming conflicts in state shortcuts.
+const WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS = "runtime/warn_about_method_property_or_signal_name_conflicts"
 
 ## Bypass any missing state when running dialogue.
 const IGNORE_MISSING_STATE_VALUES = "runtime/advanced/ignore_missing_state_values"
@@ -94,6 +96,11 @@ const SETTINGS_CONFIGURATION = {
 	STATE_AUTOLOAD_SHORTCUTS: {
 		value = [],
 		type = TYPE_PACKED_STRING_ARRAY,
+	},
+	WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS: {
+		value = false,
+		type = TYPE_BOOL,
+		is_advanced = true
 	},
 
 	IGNORE_MISSING_STATE_VALUES: {

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -20,6 +20,12 @@ Dialogue Manager settings are found in Project Settings at the bottom of the Gen
     Nathan: There are {{some_property}} of them!
   ```
 
+- **Warn about method property or signal name conflicts**
+
+  If enabled, when there is more than one property, method, or signal sharing the same name at the top-level (ie. extra game states, current scene, or autoload shortcut) a warning will be shown in the Debugger panel.
+
+  _NOTE: Even when enabled, this does nothing when running in a non-debug build._
+
 - **Balloon Path**
 
   The balloon scene to instantiate when using `DialogueManager.show_dialogue_balloon`.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -20,7 +20,7 @@ Dialogue Manager settings are found in Project Settings at the bottom of the Gen
     Nathan: There are {{some_property}} of them!
   ```
 
-- **Warn about method property or signal name conflicts**
+- **Warn about method property or signal name conflicts** (Advanced)
 
   If enabled, when there is more than one property, method, or signal sharing the same name at the top-level (ie. extra game states, current scene, or autoload shortcut) a warning will be shown in the Debugger panel.
 

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -402,3 +402,16 @@ Nathan: The number is {{Callable(StateForTests, \"some_method\").bind(\"blah\").
 
 	var line = await resource.get_next_dialogue_line("start")
 	assert(line.text == "The number is 40.", "Should resolve callable.")
+
+
+func test_can_warn_about_conflicts() -> void:
+	var resource = create_resource("
+using StateForTests
+~ start
+set some_property = 1
+Value is {{some_property}}")
+
+	ProjectSettings.set_setting("dialogue_manager/runtime/warn_about_method_property_or_signal_name_conflicts", true)
+
+	var line = await resource.get_next_dialogue_line("start", [{ some_property = 1000 }])
+	assert(line.text == "Value is 1", "Should process first occurance of property.")


### PR DESCRIPTION
This adds a new advanced runtime setting to check for top-level state (ie. extra game states, current scene, autoload shortcuts) naming collisions. When referring to a property/method/signal in dialogue that has multiple possible references a warning will show in the Debugger panel:

![image](https://github.com/user-attachments/assets/dfed5d6c-ac67-445e-a91e-5d46c6488b76)

Closes #746 