### PR TITLE
Update example balloons

### DIFF
--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -25,10 +25,6 @@ namespace DialogueManagerRuntime
       get => dialogueLine;
       set
       {
-        isWaitingForInput = false;
-        balloon.FocusMode = Control.FocusModeEnum.All;
-        balloon.GrabFocus();
-
         if (value == null)
         {
           QueueFree();
@@ -36,9 +32,11 @@ namespace DialogueManagerRuntime
         }
 
         dialogueLine = value;
-        UpdateDialogue();
+        ApplyDialogueLine();
       }
     }
+
+    Timer MutationCooldown = new Timer();
 
 
     public override void _Ready()
@@ -87,6 +85,18 @@ namespace DialogueManagerRuntime
       {
         Next(response.NextId);
       }));
+
+
+      // Hide the balloon when a mutation is running
+      MutationCooldown.Timeout += () =>
+      {
+        if (willHideBalloon)
+        {
+          willHideBalloon = false;
+          balloon.Hide();
+        }
+      };
+      AddChild(MutationCooldown);
 
       DialogueManager.Mutated += OnMutated;
     }
@@ -144,12 +154,18 @@ namespace DialogueManagerRuntime
     #region Helpers
 
 
-    private async void UpdateDialogue()
+    private async void ApplyDialogueLine()
     {
       if (!IsNodeReady())
       {
         await ToSignal(this, SignalName.Ready);
       }
+
+      MutationCooldown.Stop();
+
+      isWaitingForInput = false;
+      balloon.FocusMode = Control.FocusModeEnum.All;
+      balloon.GrabFocus();
 
       // Set up the character name
       characterLabel.Visible = !string.IsNullOrEmpty(dialogueLine.Character);
@@ -208,14 +224,7 @@ namespace DialogueManagerRuntime
     {
       isWaitingForInput = false;
       willHideBalloon = true;
-      GetTree().CreateTimer(0.1f).Timeout += () =>
-      {
-        if (willHideBalloon)
-        {
-          willHideBalloon = false;
-          balloon.Hide();
-        }
-      };
+      MutationCooldown.Start(0.1f);
     }
 
 

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -29,12 +29,15 @@ var dialogue_line: DialogueLine:
 	set(value):
 		if value:
 			dialogue_line = value
-			apply_dialogue_line(value)
+			apply_dialogue_line()
 		else:
 			# The dialogue has finished so close the balloon
 			queue_free()
 	get:
 		return dialogue_line
+
+## A cooldown timer for delaying the balloon hide when encountering a mutation.
+var mutation_cooldown: Timer = Timer.new()
 
 ## The base balloon anchor
 @onready var balloon: Control = %Balloon
@@ -56,6 +59,9 @@ func _ready() -> void:
 	# If the responses menu doesn't have a next action set, use this one
 	if responses_menu.next_action.is_empty():
 		responses_menu.next_action = next_action
+
+	mutation_cooldown.timeout.connect(_on_mutation_cooldown_timeout)
+	add_child(mutation_cooldown)
 
 
 func _unhandled_input(_event: InputEvent) -> void:
@@ -84,14 +90,16 @@ func start(dialogue_resource: DialogueResource, title: String, extra_game_states
 
 
 ## Apply any changes to the balloon given a new [DialogueLine].
-func apply_dialogue_line(next_dialogue_line: DialogueLine) -> void:
-	is_waiting_for_input = false
-	balloon.focus_mode = Control.FOCUS_ALL
-	balloon.grab_focus()
-
+func apply_dialogue_line() -> void:
 	# If the node isn't ready yet then none of the labels will be ready yet either
 	if not is_node_ready():
 		await ready
+
+	mutation_cooldown.stop()
+
+	is_waiting_for_input = false
+	balloon.focus_mode = Control.FOCUS_ALL
+	balloon.grab_focus()
 
 	character_label.visible = not dialogue_line.character.is_empty()
 	character_label.text = tr(dialogue_line.character, "dialogue")
@@ -133,14 +141,16 @@ func next(next_id: String) -> void:
 #region Signals
 
 
+func _on_mutation_cooldown_timeout() -> void:
+	if will_hide_balloon:
+		will_hide_balloon = false
+		balloon.hide()
+
+
 func _on_mutated(_mutation: Dictionary) -> void:
 	is_waiting_for_input = false
 	will_hide_balloon = true
-	get_tree().create_timer(0.1).timeout.connect(func():
-		if will_hide_balloon:
-			will_hide_balloon = false
-			balloon.hide()
-	)
+	mutation_cooldown.start(0.1)
 
 
 func _on_balloon_gui_input(event: InputEvent) -> void:


### PR DESCRIPTION
This updates both the GDScript and C# example balloons to better debounce the `mutated` signal handler.