### PR TITLE
Add support for simultaneous lines

### DIFF
--- a/addons/dialogue_manager/compiler/compiled_line.gd
+++ b/addons/dialogue_manager/compiler/compiled_line.gd
@@ -20,6 +20,8 @@ var text_replacements: Array[Dictionary] = []
 var responses: PackedStringArray = []
 ## Any randomise or case siblings for this line.
 var siblings: Array[Dictionary] = []
+## Any lines said simultaneously.
+var concurrent_lines: PackedStringArray = []
 ## Any tags on this line.
 var tags: PackedStringArray = []
 ## The condition or mutation expression for this line.
@@ -146,6 +148,8 @@ func to_data() -> Dictionary:
 				d.notes = notes
 			if not siblings.is_empty():
 				d.siblings = siblings
+			if not concurrent_lines.is_empty():
+				d.concurrent_lines = concurrent_lines
 
 	return d
 

--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -116,6 +116,8 @@ const ERR_UNKNOWN_USING = 135
 const ERR_EXPECTED_WHEN_OR_ELSE = 136
 const ERR_ONLY_ONE_ELSE_ALLOWED = 137
 const ERR_WHEN_MUST_BELONG_TO_MATCH = 138
+const ERR_CONCURRENT_LINE_WITHOUT_ORIGIN = 139
+const ERR_GOTO_NOT_ALLOWED_ON_CONCURRECT_LINES = 140
 
 
 ## Get the error message
@@ -197,6 +199,10 @@ static func get_error_message(error: int) -> String:
 			return translate(&"errors.only_one_else_allowed")
 		ERR_WHEN_MUST_BELONG_TO_MATCH:
 			return translate(&"errors.when_must_belong_to_match")
+		ERR_CONCURRENT_LINE_WITHOUT_ORIGIN:
+			return translate(&"errors.concurrent_line_without_origin")
+		ERR_GOTO_NOT_ALLOWED_ON_CONCURRECT_LINES:
+			return translate(&"errors.goto_not_allowed_on_concurrect_lines")
 
 	return translate(&"errors.unknown")
 

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -38,6 +38,9 @@ var inline_mutations: Array[Array] = []
 ## A list of responses attached to this line of dialogue.
 var responses: Array = []
 
+## A list of lines that are spoken simultaneously with this one.
+var concurrent_lines: Array[DialogueLine] = []
+
 ## A list of any extra game states to check when resolving variables and mutations.
 var extra_game_states: Array = []
 
@@ -73,6 +76,7 @@ func _init(data: Dictionary = {}) -> void:
 				inline_mutations = data.get("inline_mutations", [] as Array[Array])
 				time = data.get("time", "")
 				tags = data.get("tags", [])
+				concurrent_lines = data.get("concurrent_lines", [] as Array[DialogueLine])
 
 			DMConstants.TYPE_MUTATION:
 				mutation = data.mutation

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -315,6 +315,12 @@ msgstr "Only one else case is allowed per match."
 msgid "errors.when_must_belong_to_match"
 msgstr "When statements can only appear as children of match statements."
 
+msgid "errors.concurrent_line_without_origin"
+msgstr "Concurrent lines need an origin line that doesn't start with \"| \"."
+
+msgid "errors.goto_not_allowed_on_concurrect_lines"
+msgstr "Goto references are not allowed on concurrent dialogue lines."
+
 msgid "errors.unknown"
 msgstr "Unknown syntax."
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -305,6 +305,12 @@ msgstr ""
 msgid "errors.when_must_belong_to_match"
 msgstr ""
 
+msgid "errors.concurrent_line_without_origin"
+msgstr ""
+
+msgid "errors.goto_not_allowed_on_concurrect_lines"
+msgstr ""
+
 msgid "errors.unknown"
 msgstr ""
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,6 +46,7 @@ Returns a `DialogueLine` that looks something like this:
   - `text: String` - the text for this response.
   - `tags: PackedStringArray` - a list of tags.
   - `translation_key: String` - the key used to translate the text (or the whole text again if no ID was specified on the response).
+- `concurrent_lines: Array[DialogueLine]` - A list of lines that are to be spoken at the same time as this one.
 
 If there is no next line of dialogue found, it will return an empty dictionary (`{}`).
 

--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -107,3 +107,18 @@ You can also have whole blocks be random:
 ```
 
 If the first random item is chosen it will play through both nested lines.
+
+
+## Simultaneous dialogue
+
+If you would like multiple characters to speak at once the you can use the concurrent lines syntax. After a regular line of dialogue any lines that are to be spoken at the same time as it can be prefixed with "| ".
+
+```
+Nathan: This is a regular line of dialogue.
+| Coco: And I'll say this line at the same time!
+| Lilly: And I'll say this too!
+```
+
+To use concurrent line, access the `concurrent_lines` property on a `DialogueLine`.
+
+_NOTE: In an effort to keeps things simple, the built-in example balloon does not contain an implementation for concurrent lines._

--- a/tests/test_simultaneous_dialogue.gd
+++ b/tests/test_simultaneous_dialogue.gd
@@ -1,0 +1,59 @@
+extends AbstractTest
+
+
+func test_can_parse_simultaneous_dialogue() -> void:
+	var output = compile("
+~ start
+Nathan: I'm saying this.
+| Coco: While I'm saying this.
+| Lilly: And I'm saying this simultaneously too.
+Nathan: Then I say this.
+=> END")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.lines["2"].text == "I'm saying this.", "Should have the correct text.")
+	assert(output.lines["2"].next_id == "5", "Should point to the next line after the concurrent lines.")
+	assert(output.lines["2"].has("concurrent_lines"), "Should have concurrent lines.")
+	assert(output.lines[output.lines["2"].concurrent_lines[0]].text == "While I'm saying this.", "Should be the correct line.")
+	assert(output.lines[output.lines["2"].concurrent_lines[1]].text == "And I'm saying this simultaneously too.", "Should be the correct line.")
+	assert(not output.lines["5"].has("concurrent_lines"))
+
+	output = compile("
+~ start
+| Nathan: This line has no origin!
+=> END")
+
+	assert(output.errors[0].error == DMConstants.ERR_CONCURRENT_LINE_WITHOUT_ORIGIN, "Should have concurrent line error.")
+
+	output = compile("
+~ start
+Nathan: First I'll say this.
+if true
+	Nathan: Then I'm saying this.
+	| Coco: While I'm saying this.
+	| Lilly: And I'm saying this simultaneously too.
+Nathan: Lastly, I say this.
+=> END")
+
+	assert(output.errors.is_empty(), "Should have no errors.")
+	assert(output.lines["4"].next_id == "7", "Concurrent origin line should point to line after concurrency.")
+
+
+func test_can_run_simultaneous_dialogue() -> void:
+	var resource = create_resource("
+~ start
+Nathan: I'm saying this.
+| Coco: While I'm saying this.
+| Lilly: And I'm saying this simultaneously too.
+Nathan: Then I say this.
+=> END")
+
+	var line = await resource.get_next_dialogue_line("start")
+	assert(line.text == "I'm saying this.", "Should have the correct text.")
+	assert(line.concurrent_lines.size() == 2, "Should have two concurrent lines.")
+	assert(line.concurrent_lines[0].text == "While I'm saying this.", "Should have concurrent line.")
+	assert(line.concurrent_lines[1].text == "And I'm saying this simultaneously too.", "Should have concurrent line.")
+
+	line = await resource.get_next_dialogue_line(line.next_id)
+	assert(line.text == "Then I say this.", "Should have correct text.")
+	assert(line.concurrent_lines.size() == 0, "Should have no concurrent lines.")


### PR DESCRIPTION
This adds support for concurrent dialogue.

To write lines that are meant to be spoken at the same time as a regular dialogue line you can prefix them with "| ".

```
Nathan: I'll say this.
| Coco: And I'll say this at the same time!
| Lilly: And I'll say this too!
```