### PR TITLE
Add missing "this" to C# Example Balloon states

### DIFF
--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -137,7 +137,7 @@ namespace DialogueManagerRuntime
         await ToSignal(this, SignalName.Ready);
       }
 
-      temporaryGameStates = extraGameStates ?? new Array<Variant>();
+      temporaryGameStates = new Array<Variant> { this } + (extraGameStates ?? new Array<Variant>());
       isWaitingForInput = false;
       resource = dialogueResource;
 


### PR DESCRIPTION
 This adds the Example Balloon itself to the list of extra game states in the C# Example Balloon (the GDScript balloon was already doing this).

Related to #759 