### PR TITLE
Stop updating unsaved buffer on external change

### DIFF
--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -811,11 +811,11 @@ func _on_files_moved(old_file: String, new_file: String) -> void:
 func _on_cache_file_content_changed(path: String, new_content: String) -> void:
 	if open_buffers.has(path):
 		var buffer = open_buffers[path]
-		if buffer.text != new_content:
+		if buffer.text == buffer.pristine_text and buffer.text != new_content:
 			buffer.text = new_content
-			buffer.pristine_text = new_content
 			code_edit.text = new_content
 			title_list.titles = code_edit.get_titles()
+		buffer.pristine_text = new_content
 
 
 func _on_editor_settings_changed() -> void:


### PR DESCRIPTION
This stops any unsaved buffers from being clobbered by external file changes. Now only the "pristine text" of the open file will be updated.

Related to #768 