### PR TITLE
Add doc comments to POT export

### DIFF
--- a/Dialogue Manager.csproj
+++ b/Dialogue Manager.csproj
@@ -1,8 +1,6 @@
-<Project Sdk="Godot.NET.Sdk/4.3.0">
+<Project Sdk="Godot.NET.Sdk/4.4.0-beta.2">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net7.0</TargetFramework>
-    <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>DialogueManager</RootNamespace>
   </PropertyGroup>

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -1,37 +1,60 @@
 class_name DMTranslationParserPlugin extends EditorTranslationParserPlugin
 
 
+## Cached result of parsing a dialogue file.
+var data: DMCompilerResult
+## List of characters that were added.
+var translated_character_names: PackedStringArray = []
+var translated_lines: Array[Dictionary] = []
+
+
 func _parse_file(path: String, msgids: Array, msgids_context_plural: Array) -> void:
 	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
 	var text: String = file.get_as_text()
 
-	var data: DMCompilerResult = DMCompiler.compile_string(text, path)
+	data = DMCompiler.compile_string(text, path)
+
 	var known_keys: PackedStringArray = PackedStringArray([])
 
 	# Add all character names if settings ask for it
 	if DMSettings.get_setting(DMSettings.INCLUDE_CHARACTERS_IN_TRANSLATABLE_STRINGS_LIST, true):
-		var character_names: PackedStringArray = data.character_names
-		for character_name in character_names:
+		translated_character_names = [] as Array[DialogueLine]
+		for character_name: String in data.character_names:
 			if character_name in known_keys: continue
 
 			known_keys.append(character_name)
 
+			translated_character_names.append(character_name)
 			msgids_context_plural.append([character_name.replace('"', '\"'), "dialogue", ""])
 
 	# Add all dialogue lines and responses
 	var dialogue: Dictionary = data.lines
-	for key in dialogue.keys():
+	for key: String in dialogue.keys():
 		var line: Dictionary = dialogue.get(key)
 
 		if not line.type in [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE]: continue
-		if line.translation_key in known_keys: continue
 
-		known_keys.append(line.translation_key)
+		var translation_key: String = line.get(&"translation_key", line.text)
 
-		if line.translation_key == "" or line.translation_key == line.text:
+		if translation_key in known_keys: continue
+
+		known_keys.append(translation_key)
+		translated_lines.append(line)
+		if translation_key == line.text:
 			msgids_context_plural.append([line.text.replace('"', '\"'), "", ""])
 		else:
 			msgids_context_plural.append([line.text.replace('"', '\"'), line.translation_key.replace('"', '\"'), ""])
+
+
+func _get_comments(msgids_comment: Array[String], msgids_context_plural_comment: Array[String]) -> void:
+	# Add all character names if settings ask for it
+	if DMSettings.get_setting(DMSettings.INCLUDE_CHARACTERS_IN_TRANSLATABLE_STRINGS_LIST, true):
+		for character_name in translated_character_names:
+			msgids_context_plural_comment.append(DMConstants.translate("translation_plugin.character_name"))
+
+	# Add all dialogue lines and responses
+	for line: Dictionary in translated_lines:
+		msgids_context_plural_comment.append(line.get("notes", ""))
 
 
 func _get_recognized_extensions() -> PackedStringArray:

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -419,3 +419,6 @@ msgstr "Your dialogue balloon is missing a \"start\" or \"Start\" method."
 
 msgid "runtime.top_level_states_share_name"
 msgstr "Multiple top-level states ({states}) share method/property/signal name \"{key}\". Only the first occurance is accessible to dialogue."
+
+msgid "translation_plugin.character_name"
+msgstr "Character name"

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -409,3 +409,6 @@ msgstr ""
 
 msgid "runtime.top_level_states_share_name"
 msgstr ""
+
+msgid "translation_plugin.character_name"
+msgstr ""

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Dialogue Manager"
 run/main_scene="res://tests/tests.tscn"
-config/features=PackedStringArray("4.3", "C#")
+config/features=PackedStringArray("4.4", "C#")
 config/icon="res://icon.svg"
 
 [autoload]

--- a/tests/test_simultaneous_dialogue.gd.uid
+++ b/tests/test_simultaneous_dialogue.gd.uid
@@ -1,0 +1,1 @@
+uid://sdwflnlw3gql


### PR DESCRIPTION
This uses a new hook in Godot 4.4 to add doc (`##`) comments from dialogue to the POT exports against the relevant line.