### PR TITLE
Simplify showing balloons

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -415,10 +415,7 @@ func create_resource_from_text(text: String) -> Resource:
 ## Show the example balloon
 func show_example_dialogue_balloon(resource: DialogueResource, title: String = "", extra_game_states: Array = []) -> CanvasLayer:
 	var balloon: Node = load(_get_example_balloon_path()).instantiate()
-	get_current_scene.call().add_child(balloon)
-	balloon.start(resource, title, extra_game_states)
-	dialogue_started.emit(resource)
-
+	_start_balloon.call_deferred(balloon, resource, title, extra_game_states)
 	return balloon
 
 
@@ -438,7 +435,14 @@ func show_dialogue_balloon_scene(balloon_scene, resource: DialogueResource, titl
 		balloon_scene = balloon_scene.instantiate()
 
 	var balloon: Node = balloon_scene
-	get_current_scene.call().add_child.call_deferred(balloon)
+	_start_balloon.call_deferred(balloon, resource, title, extra_game_states)
+	return balloon
+
+
+# Call "start" on the given balloon.
+func _start_balloon(balloon: Node, resource: DialogueResource, title: String, extra_game_states: Array) -> void:
+	get_current_scene.call().add_child(balloon)
+
 	if balloon.has_method(&"start"):
 		balloon.start(resource, title, extra_game_states)
 	elif balloon.has_method(&"Start"):
@@ -447,7 +451,6 @@ func show_dialogue_balloon_scene(balloon_scene, resource: DialogueResource, titl
 		assert(false, DMConstants.translate(&"runtime.dialogue_balloon_missing_start_method"))
 
 	dialogue_started.emit(resource)
-	return balloon
 
 
 # Get the path to the example balloon

--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -132,11 +132,6 @@ namespace DialogueManagerRuntime
 
     public async void Start(Resource dialogueResource, string title, Array<Variant> extraGameStates = null)
     {
-      if (!IsNodeReady())
-      {
-        await ToSignal(this, SignalName.Ready);
-      }
-
       temporaryGameStates = new Array<Variant> { this } + (extraGameStates ?? new Array<Variant>());
       isWaitingForInput = false;
       resource = dialogueResource;
@@ -156,11 +151,6 @@ namespace DialogueManagerRuntime
 
     private async void ApplyDialogueLine()
     {
-      if (!IsNodeReady())
-      {
-        await ToSignal(this, SignalName.Ready);
-      }
-
       MutationCooldown.Stop();
 
       isWaitingForInput = false;

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -81,8 +81,6 @@ func _notification(what: int) -> void:
 
 ## Start some dialogue
 func start(dialogue_resource: DialogueResource, title: String, extra_game_states: Array = []) -> void:
-	if not is_node_ready():
-		await ready
 	temporary_game_states = [self] + extra_game_states
 	is_waiting_for_input = false
 	resource = dialogue_resource
@@ -91,10 +89,6 @@ func start(dialogue_resource: DialogueResource, title: String, extra_game_states
 
 ## Apply any changes to the balloon given a new [DialogueLine].
 func apply_dialogue_line() -> void:
-	# If the node isn't ready yet then none of the labels will be ready yet either
-	if not is_node_ready():
-		await ready
-
 	mutation_cooldown.stop()
 
 	is_waiting_for_input = false

--- a/addons/dialogue_manager/example_balloon/example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/example_balloon.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://d1wt4ma6055l8" path="res://addons/dialogue_manager/example_balloon/example_balloon.gd" id="1_36de5"]
 [ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="2_a8ve6"]
-[ext_resource type="Script" uid="uid://bb52rsfwhkxbn" path="res://addons/dialogue_manager/dialogue_responses_menu.gd" id="3_72ixx"]
+[ext_resource type="Script" path="res://addons/dialogue_manager/dialogue_responses_menu.gd" id="3_72ixx"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_spyqn"]
 bg_color = Color(0, 0, 0, 1)


### PR DESCRIPTION
This simplifies how `show_dialogue_balloon` works to eliminate the need for awaiting `ready` in the balloon itself.