### PR TITLE
Add a couple of things missing from docs

### DIFF
--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -22,6 +22,7 @@ Nathan: This is me talking.
 
 You can add some spice to your dialogue with [BBCode](https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html#reference). Along with everything available to Godot's `RichTextLabel` you can also use a few extra ones provided by Dialogue Manager:
 
+- `[[This|Or this|Or even this]]` to pick one option at random in the middle of dialogue (note the double "[[").
 - `[wait=N]` where N is the number of seconds to pause typing of dialogue.
 - `[speed=N]` where N is a number to multiply the default typing speed by.
 - `[next=N]` where N is a number of seconds to wait before automatically continuing to the next line of dialogue. You can also use `[next=auto]` to have the label determine a length of time to wait based on the length of the text.

--- a/docs/CSharp.md
+++ b/docs/CSharp.md
@@ -84,6 +84,11 @@ There are two ways you can connect to the Dialogue Manager signals - using `Conn
 Using event handlers is the simpler method (but only works on the Dialogue Manager itself):
 
 ```csharp
+DialogueManager.DialogueStarted += (Resource dialogueResource) =>
+{
+  // ...
+};
+
 DialogueManager.DialogueEnded += (Resource dialogueResource) =>
 {
   // ...


### PR DESCRIPTION
This adds docs for random inline dialogue and the `DialogueStarted` signal in C#.