### PR TITLE
Remove Include All Responses from docs

### DIFF
--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -30,10 +30,6 @@ Dialogue Manager settings are found in Project Settings at the bottom of the Gen
 
   The balloon scene to instantiate when using `DialogueManager.show_dialogue_balloon`.
 
-- **Include All Responses**
-
-  Responses in dialogue that have failed their condition check will still be present in the `responses` list on the relevant `DialogueLine`.
-
 - **Ignore Missing State Values** (Advanced)
 
   Suppress errors when properties or mutations are missing from state.


### PR DESCRIPTION
_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

Updated the docs to reflect the recent removal of `Include All Responses` from the plugin settings.
Fixes #792 