### PR TITLE
Fix initial example balloon attached script

### DIFF
--- a/addons/dialogue_manager/components/download_update_panel.gd
+++ b/addons/dialogue_manager/components/download_update_panel.gd
@@ -34,7 +34,7 @@ func _ready() -> void:
 
 func _on_download_button_pressed() -> void:
 	# Safeguard the actual dialogue manager repo from accidentally updating itself
-	if FileAccess.file_exists("res://examples/test_scenes/test_scene.gd"):
+	if FileAccess.file_exists("res://tests/test_basic_dialogue.gd"):
 		prints("You can't update the addon from within itself.")
 		failed.emit()
 		return


### PR DESCRIPTION
This detects the presence of dotnet when enabling the plugin to determine which script should be attached to the example balloon.

Fixes #796 