### PR TITLE
Fix Cyclical Reference By Making Parent Reference Weak

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -287,7 +287,7 @@ func build_line_tree(raw_lines: PackedStringArray) -> DMTreeLine:
 
 		# Append the current line to the current parent (note: the root is the most basic parent).
 		var parent: DMTreeLine = parent_chain[parent_chain.size() - 1]
-		tree_line.parent = parent
+		tree_line.parent = weakref(parent)
 		parent.children.append(tree_line)
 
 		previous_line = tree_line

--- a/addons/dialogue_manager/compiler/tree_line.gd
+++ b/addons/dialogue_manager/compiler/tree_line.gd
@@ -4,8 +4,10 @@ class_name DMTreeLine extends RefCounted
 
 ## The line number where this dialogue was found (after imported files have had their content imported).
 var line_number: int = 0
-## The parent [DMTreeLine] of this line
-var parent: DMTreeLine
+## The parent [DMTreeLine] of this line.
+## This is stored as a Weak Reference so that this RefCounted can elegantly free itself.
+## Without it being a Weak Reference, this can easily cause a cyclical reference that keeps this resource alive.
+var parent: WeakRef
 ## The ID of this line.
 var id: String
 ## The type of this line (as a [String] defined in [DMConstants].


### PR DESCRIPTION
_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

The Dialogue compilation system had a cyclical reference between parent and child that causes the RefCounted to never clean up the resource. This PR decides to make the parent reference weak, which allows RefCounted to be cleaned up by the garbage collector if that's the only remaining reference to a resource.

https://docs.godotengine.org/en/stable/classes/class_refcounted.html

> RefCounted instances caught in a cyclic reference will not be freed automatically. For example, if a node holds a reference to instance A, which directly or indirectly holds a reference back to A, A's reference count will be 2. Destruction of the node will leave A dangling with a reference count of 1, and there will be a memory leak. To prevent this, one of the references in the cycle can be made weak with @GlobalScope.weakref.

_If this is a change to the compiler then make sure to add/update any tests that may be affected._

Compilation was changed. It did not appear as though there was a necessary change to the tests. Existing tests are all able to run successfully.

_If this change needs updates to the documentation then make sure you've made those changes too._

There appears to be no documentation with regards to accessing the parent. As a `WeakRef`, you need to use `get_ref()` on the reference to get the value. Should this be documented somewhere?