### PR TITLE
Fix import & using syntax highlighting

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -227,12 +227,12 @@ func build_line_tree(raw_lines: PackedStringArray) -> DMTreeLine:
 		tree_line.text = raw_line.strip_edges()
 
 		# Handle any "using" directives.
-		if raw_line.begins_with("using "):
+		if tree_line.type == DMConstants.TYPE_USING:
 			var using_match: RegExMatch = regex.USING_REGEX.search(raw_line)
 			if "state" in using_match.names:
 				var using_state: String = using_match.strings[using_match.names.state].strip_edges()
 				if not using_state in autoload_names:
-					add_error(i, 0, DMConstants.ERR_UNKNOWN_USING)
+					add_error(tree_line.line_number, 0, DMConstants.ERR_UNKNOWN_USING)
 				elif not using_state in using_states:
 					using_states.append(using_state)
 				continue
@@ -915,6 +915,9 @@ func get_line_type(raw_line: String) -> String:
 
 	if text.begins_with("import "):
 		return DMConstants.TYPE_IMPORT
+
+	if text.begins_with("using "):
+		return DMConstants.TYPE_USING
 
 	if text.begins_with("#"):
 		return DMConstants.TYPE_COMMENT

--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -31,6 +31,17 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 	var index: int = 0
 
 	match DMCompiler.get_line_type(text):
+		DMConstants.TYPE_USING:
+			colors[index] = { color = theme.conditions_color }
+			colors[index + "using ".length()] = { color = theme.text_color }
+
+		DMConstants.TYPE_IMPORT:
+			colors[index] = { color = theme.conditions_color }
+			var import: RegExMatch = regex.IMPORT_REGEX.search(text)
+			colors[index + import.get_start("path") - 1] = { color = theme.strings_color }
+			colors[index + import.get_end("path") + 1] = { color = theme.conditions_color }
+			colors[index + import.get_start("prefix")] = { color = theme.text_color }
+
 		DMConstants.TYPE_COMMENT:
 			colors[index] = { color = theme.comments_color }
 

--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -54,6 +54,7 @@ const TOKEN_ERROR = &"error"
 
 const TYPE_UNKNOWN = &""
 const TYPE_IMPORT = &"import"
+const TYPE_USING = &"using"
 const TYPE_COMMENT = &"comment"
 const TYPE_RESPONSE = &"response"
 const TYPE_TITLE = &"title"


### PR DESCRIPTION
This fixes the syntax highlighting for `import` and `using` lines.