### PR TITLE
Moving add and remove autoload to enable and disable plugin functions

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -13,9 +13,15 @@ var main_view
 var dialogue_cache: DMCache
 
 
-func _enter_tree() -> void:
+func _enable_plugin() -> void:
 	add_autoload_singleton("DialogueManager", get_plugin_path() + "/dialogue_manager.gd")
 
+
+func _disable_plugin() -> void:
+	remove_autoload_singleton("DialogueManager")
+
+
+func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		Engine.set_meta("DialogueManagerPlugin", self)
 
@@ -105,8 +111,6 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	remove_autoload_singleton("DialogueManager")
-
 	remove_import_plugin(import_plugin)
 	import_plugin = null
 


### PR DESCRIPTION
Small QoL change to address the plugin unnecessarily modifying the current scene each time Godot is opened.

Godot updated their docs a few months ago to specify Autoloads should be added and removed in the `_enable_plugin` and `_disable_plugin` functions respectively.

https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html#registering-autoloads-singletons-in-plugins

The related PR/comment that addressed this: https://github.com/godotengine/godot/issues/68285#issuecomment-2362438548