### PR TITLE
Set Id in DialogueLine

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -344,6 +344,7 @@ namespace DialogueManagerRuntime
 
         public DialogueLine(RefCounted data)
         {
+            id = (string)data.Get("id");
             type = (string)data.Get("type");
             next_id = (string)data.Get("next_id");
             character = (string)data.Get("character");


### PR DESCRIPTION
This should fix the issue with the ID not being set for DialogueLines in C#

see https://github.com/nathanhoad/godot_dialogue_manager/issues/818