### PR TITLE
Add missing export plugin name

### DIFF
--- a/addons/dialogue_manager/export_plugin.gd
+++ b/addons/dialogue_manager/export_plugin.gd
@@ -4,8 +4,15 @@ const IGNORED_PATHS = [
 	"/assets",
 	"/components",
 	"/l10n",
-	"/views"
+	"/views",
+	"inspector_plugin",
+	"test_scene"
 ]
+
+
+func _get_name() -> String:
+	return "Dialogue Manager Export Plugin"
+
 
 func _export_file(path: String, type: String, features: PackedStringArray) -> void:
 	var plugin_path: String = Engine.get_meta("DialogueManagerPlugin").get_plugin_path()


### PR DESCRIPTION
This adds the missing `_get_name` hook for the new export plugin.