### PR TITLE
Improve the way C# methods are identified

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1358,7 +1358,7 @@ func _thing_has_method(thing, method: String, args: Array) -> bool:
 	if thing.has_method(method):
 		return true
 
-	if method.to_snake_case() != method and DMSettings.check_for_dotnet_solution():
+	if thing.get_script().resource_path.ends_with(".cs"):
 		# If we get this far then the method might be a C# method with a Task return type
 		return _get_dotnet_dialogue_manager().ThingHasMethod(thing, method, args)
 


### PR DESCRIPTION
This changes how C# Task methods are found so that it actually checks the file extension of the state script.

Fixes #823 