### PR TITLE
Fix find and replace index reset

### DIFF
--- a/addons/dialogue_manager/components/find_in_files.gd
+++ b/addons/dialogue_manager/components/find_in_files.gd
@@ -99,7 +99,7 @@ func update_results_view() -> void:
 				var matched_word: String = "[bgcolor=" + colors.critical_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + path_result.matched_text + "[/color][/bgcolor]"
 				highlight = "[s]" + matched_word + "[/s][bgcolor=" + colors.notice_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + replace_input.text + "[/color][/bgcolor]"
 			else:
-				highlight = "[bgcolor=" + colors.symbols_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + path_result.matched_text + "[/color][/bgcolor]"
+				highlight = "[bgcolor=" + colors.notice_color.to_html() + "][color=" + colors.text_color.to_html() + "]" + path_result.matched_text + "[/color][/bgcolor]"
 			var text: String = path_result.text.substr(0, path_result.index) + highlight + path_result.text.substr(path_result.index + path_result.query.length())
 			result_label.text = "%s: %s" % [str(path_result.line).lpad(4), text]
 			result_label.gui_input.connect(func(event):

--- a/addons/dialogue_manager/components/search_and_replace.gd
+++ b/addons/dialogue_manager/components/search_and_replace.gd
@@ -114,7 +114,7 @@ func find_in_line(line: String, text: String, from_index: int = 0) -> int:
 		return line.findn(text, from_index)
 
 
-### Signals
+#region Signals
 
 
 func _on_text_edit_gui_input(event: InputEvent) -> void:
@@ -177,13 +177,16 @@ func _on_replace_button_pressed() -> void:
 
 	# Replace the selection at result index
 	var r: Array = results[result_index]
+	code_edit.begin_complex_operation()
 	var lines: PackedStringArray = code_edit.text.split("\n")
 	var line: String = lines[r[0]]
 	line = line.substr(0, r[1]) + replace_input.text + line.substr(r[1] + r[2])
 	lines[r[0]] = line
 	code_edit.text = "\n".join(lines)
-	search(input.text, result_index)
+	code_edit.end_complex_operation()
 	code_edit.text_changed.emit()
+
+	search(input.text, result_index)
 
 
 func _on_replace_all_button_pressed() -> void:
@@ -210,3 +213,6 @@ func _on_input_focus_entered() -> void:
 
 func _on_match_case_check_box_toggled(button_pressed: bool) -> void:
 	search()
+
+
+#endregion


### PR DESCRIPTION
This fixes an issue where after replacing a find-and-replace result the results list would be reset.

Fixes #834