### PR TITLE
Restore missing exported internal translations

### DIFF
--- a/addons/dialogue_manager/export_plugin.gd
+++ b/addons/dialogue_manager/export_plugin.gd
@@ -3,7 +3,6 @@ class_name DMExportPlugin extends EditorExportPlugin
 const IGNORED_PATHS = [
 	"/assets",
 	"/components",
-	"/l10n",
 	"/views",
 	"inspector_plugin",
 	"test_scene"


### PR DESCRIPTION
This restores the internal translations file when exporting projects.

Fixes #835