### PR TITLE
Fix line ID highlighting when there's no character

### DIFF
--- a/Dialogue Manager.csproj
+++ b/Dialogue Manager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.4.0">
+<Project Sdk="Godot.NET.Sdk/4.4.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -85,9 +85,10 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 
 			var dialogue_text: String = text.substr(index, text.find("=>"))
 
-			# Highlight character name
+			# Highlight character name (but ignore ":" within line ID reference)
 			var split_index: int = dialogue_text.replace("\\:", "??").find(":")
-			colors[index + split_index + 1] = { color = theme.text_color }
+			if text.substr(split_index - 3, 3) != "[ID":
+				colors[index + split_index + 1] = { color = theme.text_color }
 
 			# Interpolation
 			var replacements: Array[RegExMatch] = regex.REPLACEMENTS_REGEX.search_all(dialogue_text)


### PR DESCRIPTION
This fixes the syntax highlighting for when a line has a line ID defined but no character.

Fixes #843 