### PR TITLE
Improve nested dialogue compile warnings

### DIFF
--- a/addons/dialogue_manager/compiler/tree_line.gd
+++ b/addons/dialogue_manager/compiler/tree_line.gd
@@ -22,6 +22,8 @@ var text: String = ""
 var children: Array[DMTreeLine] = []
 ## Any doc comments attached to this line.
 var notes: String = ""
+## Is this a dialogue line that is the child of another dialogue line?
+var is_nested_dialogue: bool = false
 
 
 func _init(initial_id: String) -> void:

--- a/addons/dialogue_manager/constants.gd
+++ b/addons/dialogue_manager/constants.gd
@@ -120,6 +120,8 @@ const ERR_ONLY_ONE_ELSE_ALLOWED = 137
 const ERR_WHEN_MUST_BELONG_TO_MATCH = 138
 const ERR_CONCURRENT_LINE_WITHOUT_ORIGIN = 139
 const ERR_GOTO_NOT_ALLOWED_ON_CONCURRECT_LINES = 140
+const ERR_UNEXPECTED_SYNTAX_ON_NESTED_DIALOGUE_LINE = 141
+const ERR_NESTED_DIALOGUE_INVALID_JUMP = 142
 
 
 ## Get the error message
@@ -205,6 +207,10 @@ static func get_error_message(error: int) -> String:
 			return translate(&"errors.concurrent_line_without_origin")
 		ERR_GOTO_NOT_ALLOWED_ON_CONCURRECT_LINES:
 			return translate(&"errors.goto_not_allowed_on_concurrect_lines")
+		ERR_UNEXPECTED_SYNTAX_ON_NESTED_DIALOGUE_LINE:
+			return translate(&"errors.unexpected_syntax_on_nested_dialogue_line")
+		ERR_NESTED_DIALOGUE_INVALID_JUMP:
+			return translate(&"errors.err_nested_dialogue_invalid_jump")
 
 	return translate(&"errors.unknown")
 

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -324,6 +324,12 @@ msgstr "Concurrent lines need an origin line that doesn't start with \"| \"."
 msgid "errors.goto_not_allowed_on_concurrect_lines"
 msgstr "Goto references are not allowed on concurrent dialogue lines."
 
+msgid "errors.unexpected_syntax_on_nested_dialogue_line"
+msgstr "Nested dialogue lines may only contain dialogue."
+
+msgid "errors.err_nested_dialogue_invalid_jump"
+msgstr "Only the last line of nested dialogue is allowed to include a jump."
+
 msgid "errors.unknown"
 msgstr "Unknown syntax."
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -314,6 +314,12 @@ msgstr ""
 msgid "errors.goto_not_allowed_on_concurrect_lines"
 msgstr ""
 
+msgid "errors.unexpected_syntax_on_nested_dialogue_line"
+msgstr ""
+
+msgid "errors.err_nested_dialogue_invalid_jump"
+msgstr ""
+
 msgid "errors.unknown"
 msgstr ""
 

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -508,6 +508,8 @@ func generate_translations_keys() -> void:
 	var key_regex = RegEx.new()
 	key_regex.compile("\\[ID:(?<key>.*?)\\]")
 
+	var compiled_lines: Dictionary = DMCompiler.compile_string(code_edit.text, "").lines
+
 	# Make list of known keys
 	var known_keys = {}
 	for i in range(0, lines.size()):
@@ -530,6 +532,7 @@ func generate_translations_keys() -> void:
 		var l = line.strip_edges()
 
 		if not [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE].has(DMCompiler.get_line_type(l)): continue
+		if not compiled_lines.has(str(i)): continue
 
 		if "[ID:" in line: continue
 


### PR DESCRIPTION
This now flags nested dialogue lines that contain invalid things (eg. static line IDs, extra jumps, etc) as compile errors.

Fixes #852 