### PR TITLE
Stop invalidating resources with errors

### DIFF
--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -5,12 +5,15 @@ class_name DMImportPlugin extends EditorImportPlugin
 signal compiled_resource(resource: Resource)
 
 
-const COMPILER_VERSION = 14
+const COMPILER_VERSION = 15
 
 
 func _get_importer_name() -> String:
-	# NOTE: A change to this forces a re-import of all dialogue
-	return "dialogue_manager_compiler_%s" % COMPILER_VERSION
+	return "dialogue_manager"
+
+
+func _get_format_version() -> int:
+	return COMPILER_VERSION
 
 
 func _get_visible_name() -> String:
@@ -74,7 +77,7 @@ func _import(source_file: String, save_path: String, options: Dictionary, platfo
 	if result.errors.size() > 0:
 		printerr("%d errors found in %s" % [result.errors.size(), source_file])
 		cache.add_errors_to_file(source_file, result.errors)
-		return ERR_PARSE_ERROR
+		return OK
 
 	# Get the current addon version
 	var config: ConfigFile = ConfigFile.new()


### PR DESCRIPTION
Previously, dialogue files that contained errors would be flagged in the importer as a parsing error. While technically correct the real world experience was that invalid dialogue files were then sometimes impossible to open in the dialogue editor until they were fixed externally.

This changes the dialogue importer to now let files that contain errors to pass the import process. Errors are still reported and if there are known files containing errors the game build step will still fail so any errors can be seen there.

Closes #863 