### PR TITLE
Add methods for finding lines by their static IDs

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -161,6 +161,18 @@ namespace DialogueManagerRuntime
         }
 
 
+        public static Array<string> StaticIdToLineIds(Resource dialogueResource, string staticId)
+        {
+            return (Array<string>)Instance.Call("static_id_to_line_ids", dialogueResource, staticId);
+        }
+
+
+        public static string StaticIdToLineId(Resource dialogueResource, string staticId)
+        {
+            return (string)Instance.Call("static_id_to_line_id", dialogueResource, staticId);
+        }
+
+
         public static async void Mutate(Dictionary mutation, Array<Variant>? extraGameStates = null, bool isInlineMutation = false)
         {
             Instance.Call("_bridge_mutate", mutation, extraGameStates ?? new Array<Variant>(), isInlineMutation);

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -439,6 +439,18 @@ func show_dialogue_balloon_scene(balloon_scene, resource: DialogueResource, titl
 	return balloon
 
 
+## Resolve a static line ID to an actual line ID
+func static_id_to_line_id(resource: DialogueResource, static_id: String) -> String:
+	var ids = static_id_to_line_ids(resource, static_id)
+	if ids.size() == 0: return ""
+	return ids[0]
+
+
+## Resolve a static line ID to any actual line IDs that match
+func static_id_to_line_ids(resource: DialogueResource, static_id: String) -> PackedStringArray:
+	return resource.lines.values().filter(func(l): return l.get(&"translation_key", "") == static_id).map(func(l): return l.id)
+
+
 # Call "start" on the given balloon.
 func _start_balloon(balloon: Node, resource: DialogueResource, title: String, extra_game_states: Array) -> void:
 	get_current_scene.call().add_child(balloon)

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -244,3 +244,15 @@ Nathan: Hello.")
 
 	var line = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Hello.", "Should jump to dialogue.")
+
+
+func test_can_resolve_static_line_id() -> void:
+	var resource = create_resource("
+~ start
+Nathan: First line [ID:FIRST]
+Nathan: Second line [ID:SECOND]
+Nathan: Third line [ID:THIRD]")
+
+	var id = DialogueManager.static_id_to_line_id(resource, "SECOND")
+	var line = await resource.get_next_dialogue_line(id)
+	assert(line.text == "Second line", "Should match second line")


### PR DESCRIPTION
This adds the methods `static_id_to_line_id` and `static_id_to_line_ids` for resolving static line IDs to actual line IDs. `static_id_to_line_id` will return the first line found that matches the static ID whereas `static_id_to_line_ids` will return an array of IDs (most often with a length of one but could be more as static line IDs can be used on more than one line if the text is identical).