### PR TITLE
for multiline lines, remove extra whitespace in front of static ID

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -703,7 +703,10 @@ func parse_dialogue_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: 
 				add_error(child.line_number, child.indent, DMConstants.ERR_NESTED_DIALOGUE_INVALID_JUMP)
 			if i == 0 and " =>" in tree_line.text:
 				add_error(tree_line.line_number, tree_line.indent, DMConstants.ERR_NESTED_DIALOGUE_INVALID_JUMP)
-
+			# before concatenating child text, remove extra whitespace in front of ID from parent text
+			if i == 0 and tree_line.text.contains(" [ID:"):
+				tree_line.text = RegEx.create_from_string(" +\\[ID:").sub(tree_line.text, "[ID:")
+			
 			tree_line.text += "\n" + child.text
 		else:
 			result = add_error(child.line_number, child.indent, DMConstants.ERR_INVALID_INDENTATION)


### PR DESCRIPTION
_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

fixed the issue with extra whitespace before the unique ID ` [ID:...]` as described here in my comment on this issue #852
I made sure to only remove space characters, as those are added by the ID generation and other characters might be intentional.

_If this is a change to the compiler then make sure to add/update any tests that may be affected._

don't think there are tests for this

_If this change needs updates to the documentation then make sure you've made those changes too._

no changes needed