### PR TITLE
Fix issue with optional C# mutation parameters

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -229,7 +229,7 @@ namespace DialogueManagerRuntime
             var methodInfos = thing.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly);
             foreach (var methodInfo in methodInfos)
             {
-                if (methodInfo.Name == method && args.Count == methodInfo.GetParameters().Length)
+                if (methodInfo.Name == method && args.Count >= methodInfo.GetParameters().Where(p => !p.HasDefaultValue).Count())
                 {
                     return true;
                 }
@@ -245,7 +245,7 @@ namespace DialogueManagerRuntime
             var methodInfos = thing.GetType().GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly);
             foreach (var methodInfo in methodInfos)
             {
-                if (methodInfo.Name == method && args.Count == methodInfo.GetParameters().Length)
+                if (methodInfo.Name == method && args.Count >= methodInfo.GetParameters().Where(p => !p.HasDefaultValue).Count())
                 {
                     info = methodInfo;
                 }

--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -295,6 +295,8 @@ func get_members_for_autoload(autoload_name: String) -> Array[Dictionary]:
 	if _autoload_member_cache.has(autoload_name) and _autoload_member_cache.get(autoload_name).get("at") > Time.get_ticks_msec() - 5000:
 		return _autoload_member_cache.get(autoload_name).get("members")
 
+	if not _autoloads.has(autoload_name): return []
+
 	var autoload = load(_autoloads.get(autoload_name))
 	var script: Script = autoload if autoload is Script else autoload.get_script()
 


### PR DESCRIPTION
This fixes an issue where a C# mutation was defined with optional parameters and then called without them.