### PR TITLE
Add setting for extra auto-complete sources

### DIFF
--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -26,6 +26,8 @@ const INCLUDE_NOTES_IN_TRANSLATION_EXPORTS = "editor/translations/include_notes_
 
 ## A custom test scene to use when testing dialogue.
 const CUSTOM_TEST_SCENE_PATH = "editor/advanced/custom_test_scene_path"
+## Extra script files to include in the auto-complete-able list
+const EXTRA_AUTO_COMPLETE_SCRIPT_SOURCES = "editor/advanced/extra_auto_complete_script_sources"
 
 ## The custom balloon for this game.
 const BALLOON_PATH = "runtime/balloon_path"
@@ -40,7 +42,7 @@ const IGNORE_MISSING_STATE_VALUES = "runtime/advanced/ignore_missing_state_value
 const USES_DOTNET = "runtime/advanced/uses_dotnet"
 
 
-const SETTINGS_CONFIGURATION = {
+static var SETTINGS_CONFIGURATION = {
 	WRAP_LONG_LINES: {
 		value = false,
 		type = TYPE_BOOL,
@@ -68,6 +70,8 @@ const SETTINGS_CONFIGURATION = {
 	EXTRA_CSV_LOCALES: {
 		value = [],
 		type = TYPE_PACKED_STRING_ARRAY,
+		hint = PROPERTY_HINT_TYPE_STRING,
+		hint_string = "%d:" % [TYPE_STRING],
 		is_advanced = true
 	},
 	INCLUDE_CHARACTER_IN_TRANSLATION_EXPORTS: {
@@ -87,6 +91,13 @@ const SETTINGS_CONFIGURATION = {
 		hint = PROPERTY_HINT_FILE,
 		is_advanced = true
 	},
+	EXTRA_AUTO_COMPLETE_SCRIPT_SOURCES: {
+		value = [],
+		type = TYPE_PACKED_STRING_ARRAY,
+		hint = PROPERTY_HINT_TYPE_STRING,
+		hint_string = "%d/%d:*.*" % [TYPE_STRING, PROPERTY_HINT_FILE],
+		is_advanced = true
+	},
 
 	BALLOON_PATH: {
 		value = "",
@@ -96,6 +107,8 @@ const SETTINGS_CONFIGURATION = {
 	STATE_AUTOLOAD_SHORTCUTS: {
 		value = [],
 		type = TYPE_PACKED_STRING_ARRAY,
+		hint = PROPERTY_HINT_TYPE_STRING,
+		hint_string = "%d:" % [TYPE_STRING],
 	},
 	WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS: {
 		value = false,

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1,3 +1,4 @@
+
 # Settings
 
 Dialogue Manager settings are found in Project Settings at the bottom of the General tab.
@@ -67,3 +68,9 @@ Dialogue Manager settings are found in Project Settings at the bottom of the Gen
 - **Custom Test Scene Path** (advanced)
 
   Use a custom test scene when running "Test" from the dialogue editor. The scene must extend `BaseDialogueTestScene`.
+
+- **Extra Auto Complete Script Sources** (advanced)
+
+  Add script files to check for top level auto-complete members.
+
+  Any scripts added in here are assumed to be available in all dialogue files (eg. your balloon inserts itself into the `extra_game_states` at runtime).


### PR DESCRIPTION
This adds an advanced setting for providing extra sources for auto-complete in the dialogue editor.

The main use case is for when your dialogue balloon inserts itself into the `extra_game_states` at runtime. In that scenario, it is impossible for the dialogue editor to know about the balloon's members ahead of time so you can add it to the sources list in order to get some auto-complete options.