### PR TITLE
Fix search not updating on file change

### DIFF
--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -112,6 +112,9 @@ var current_file_path: String = "":
 
 			errors_panel.errors = []
 			code_edit.errors = []
+
+			if search_and_replace.visible:
+				search_and_replace.search()
 	get:
 		return current_file_path
 


### PR DESCRIPTION
Fixes #879

## Test cases

1. Search should re-trigger when a file is selected in the file list

https://github.com/user-attachments/assets/88c2b7eb-5e7b-406c-9264-3a5703788f03

2. Search should re-trigger when a new file is opened


https://github.com/user-attachments/assets/6e629f08-53a1-45f9-a956-f0e3d35849a6

