### PR TITLE
Allow multiple values in when clauses

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -486,6 +486,7 @@ func parse_match_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: Arr
 	# Check that all children are when or else.
 	for child in tree_line.children:
 		if child.type == DMConstants.TYPE_WHEN: continue
+		if child.type == DMConstants.TYPE_UNKNOWN: continue
 		if child.type == DMConstants.TYPE_CONDITION and child.text.begins_with("else"): continue
 
 		result = add_error(child.line_number, child.indent, DMConstants.ERR_EXPECTED_WHEN_OR_ELSE)

--- a/addons/dialogue_manager/compiler/expression_parser.gd
+++ b/addons/dialogue_manager/compiler/expression_parser.gd
@@ -364,7 +364,6 @@ func _check_next_token(token: Dictionary, next_tokens: Array[Dictionary], line_t
 
 		DMConstants.TOKEN_COMPARISON, \
 		DMConstants.TOKEN_OPERATOR, \
-		DMConstants.TOKEN_COMMA, \
 		DMConstants.TOKEN_DOT, \
 		DMConstants.TOKEN_NULL_COALESCE, \
 		DMConstants.TOKEN_NOT, \
@@ -375,6 +374,20 @@ func _check_next_token(token: Dictionary, next_tokens: Array[Dictionary], line_t
 				DMConstants.TOKEN_COMMA,
 				DMConstants.TOKEN_COLON,
 				DMConstants.TOKEN_COMPARISON,
+				DMConstants.TOKEN_ASSIGNMENT,
+				DMConstants.TOKEN_OPERATOR,
+				DMConstants.TOKEN_AND_OR,
+				DMConstants.TOKEN_PARENS_CLOSE,
+				DMConstants.TOKEN_BRACE_CLOSE,
+				DMConstants.TOKEN_BRACKET_CLOSE,
+				DMConstants.TOKEN_DOT
+			]
+
+		DMConstants.TOKEN_COMMA:
+			unexpected_token_types = [
+				null,
+				DMConstants.TOKEN_COMMA,
+				DMConstants.TOKEN_COLON,
 				DMConstants.TOKEN_ASSIGNMENT,
 				DMConstants.TOKEN_OPERATOR,
 				DMConstants.TOKEN_AND_OR,
@@ -427,7 +440,8 @@ func _check_next_token(token: Dictionary, next_tokens: Array[Dictionary], line_t
 				DMConstants.TOKEN_BRACKET_OPEN
 			]
 
-	if (expected_token_types.size() > 0 and not next_token.type in expected_token_types or unexpected_token_types.size() > 0 and next_token.type in unexpected_token_types):
+	if (expected_token_types.size() > 0 and not next_token.type in expected_token_types) \
+	or (unexpected_token_types.size() > 0 and next_token.type in unexpected_token_types):
 		match next_token.type:
 			null:
 				return DMConstants.ERR_UNEXPECTED_END_OF_EXPRESSION

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -184,8 +184,8 @@ Before
 match StateForTests.some_property + 1
 	when 0
 		It's zero.
-	when 1 + 1
-		It's two.
+	when 1 + 1, 3
+		It's two or three.
 	when 42
 		It's 42.
 	else
@@ -197,7 +197,7 @@ After")
 	assert(line.text == "Before", "Should be before match.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
-	assert(line.text == "It's two.", "Should match two case.")
+	assert(line.text == "It's two or three.", "Should match two case.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
 	assert(line.text == "After", "Should be after match.")


### PR DESCRIPTION
This adds support for providing multiple values (separated by comma) per `when` clause to match against. For example:

```
match SomeGlobal.some_property
	when 1, 3
		It's one or three.
	when 4, 5, 6
		It's four, five, or six.
	else
		It's none of them.
```