### PR TITLE
Add setting to disable automatic adding of dialogue to POT file

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -329,6 +329,9 @@ func update_import_paths(from_path: String, to_path: String) -> void:
 
 
 func _update_localization() -> void:
+	if not DMSettings.get_setting(DMSettings.UPDATE_POT_FILES_AUTOMATICALLY, true):
+		return
+
 	var dialogue_files = dialogue_cache.get_files()
 
 	# Add any new files to POT generation

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -23,6 +23,8 @@ const EXTRA_CSV_LOCALES = "editor/translations/extra_csv_locales"
 const INCLUDE_CHARACTER_IN_TRANSLATION_EXPORTS = "editor/translations/include_character_in_translation_exports"
 ## Includes a "_notes" column in CSV exports
 const INCLUDE_NOTES_IN_TRANSLATION_EXPORTS = "editor/translations/include_notes_in_translation_exports"
+## Automatically update the project's list of translatable files when dialogue files are added or removed
+const UPDATE_POT_FILES_AUTOMATICALLY = "editor/translations/update_pot_files_automatically"
 
 ## A custom test scene to use when testing dialogue.
 const CUSTOM_TEST_SCENE_PATH = "editor/advanced/custom_test_scene_path"
@@ -81,6 +83,11 @@ static var SETTINGS_CONFIGURATION = {
 	},
 	INCLUDE_NOTES_IN_TRANSLATION_EXPORTS: {
 		value = false,
+		type = TYPE_BOOL,
+		is_advanced = true
+	},
+	UPDATE_POT_FILES_AUTOMATICALLY: {
+		value = true,
 		type = TYPE_BOOL,
 		is_advanced = true
 	},


### PR DESCRIPTION
Previously, translations_pot_files would be updated on save to add new dialogue
files and remove deleted ones.

Some projects may prefer to manage this property manually. In particular,
because the property is serialised by Godot as a single line, parallel branches
which each add dialogue files are guaranteed to cause Git conflicts.

Add a setting to disable this behaviour. Default to the previous behaviour.

Fixes #887
