### PR TITLE
Change TestScene to use relative script path

### DIFF
--- a/addons/dialogue_manager/test_scene.tscn
+++ b/addons/dialogue_manager/test_scene.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://ugd552efvil0"]
 
-[ext_resource type="Script" uid="uid://c8e16qdgu40wo" path="res://addons/dialogue_manager/test_scene.gd" id="1_yupoh"]
+[ext_resource type="Script" uid="uid://c8e16qdgu40wo" path="./test_scene.gd" id="1_yupoh"]
 
 [node name="TestScene" type="Node2D"]
 script = ExtResource("1_yupoh")


### PR DESCRIPTION
Hi! 

This is just a very minor thing.
I'm using this plugin as a [sub-plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html#using-sub-plugins) to my own plugin. I found that when putting it in my plugin's addon directory, it produces an error because `TestScene` cannot find the script that is attached to it (`test_scene.gd`). It expects it to be inside `res://addons/dialogue_manager`. This is a fix to the scene file to use a relative path instead.

I understand if you would not like this because its an edit to the `.tscn` file, which is kind of uncommon I think.
Thanks for considering!

===
To reproduce the error: (I used Godot Version 4.3, Dialogue Manger version 3.3.3)
- create new project
- add new plugin (Project -> Project Settings -> Plugins -> Create New Plugin)
- add `dialogue manager` as [sub-plugin](https://docs.godotengine.org/en/stable/tutorials/plugins/editor/making_plugins.html#using-sub-plugins) to newly created plugin

Produces:
```
  Attempt to open script 'res://addons/my_addon/dialogue_manager/test_scene.gd' resulted in error 'File not found'.
  Failed loading resource: res://addons/my_addon/dialogue_manager/test_scene.gd. Make sure resources have been imported by opening the project in the editor at least once.
```