### PR TITLE
Fix snippet expression jumps

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -186,7 +186,7 @@ func import_content(path: String, prefix: String, imported_line_map: Dictionary,
 					else:
 						content[i] = "%s=>< %s/%s" % [line.split("=>< ")[0], title_hash, bits[1]]
 
-				elif not jump in ["END", "END!"]:
+				elif not jump in ["END", "END!"] and not jump.begins_with("{{"):
 					content[i] = "%s=>< %s/%s" % [line.split("=>< ")[0], str(path.hash()), jump]
 
 			elif "=> " in line:
@@ -199,7 +199,7 @@ func import_content(path: String, prefix: String, imported_line_map: Dictionary,
 					else:
 						content[i] = "%s=> %s/%s" % [line.split("=> ")[0], title_hash, bits[1]]
 
-				elif not jump in ["END", "END!"]:
+				elif not jump in ["END", "END!"] and not jump.begins_with("{{"):
 					content[i] = "%s=> %s/%s" % [line.split("=> ")[0], str(path.hash()), jump]
 
 		imported_paths.append(path)


### PR DESCRIPTION
This fixes a bug where expression jumps in imported dialogue were throwing an "invalid title" error.

Fixes #911 