### PR TITLE
Add started_typing signal to DialogueLabel

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -59,6 +59,8 @@ var is_typing: bool = false:
 	set(value):
 		var is_finished: bool = is_typing != value and value == false
 		is_typing = value
+		if is_typing:
+			started_typing.emit(dialogue_line.character)
 		if is_finished:
 			finished_typing.emit()
 	get:
@@ -109,9 +111,6 @@ func type_out() -> void:
 
 	# Allow typing listeners a chance to connect
 	await get_tree().process_frame
-	
-	# Emit the started_typing signal with the character name
-	started_typing.emit(dialogue_line.character)
 
 	if get_total_character_count() == 0:
 		self.is_typing = false

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -15,11 +15,11 @@ signal paused_typing(duration: float)
 ## Emitted when the player skips the typing of dialogue.
 signal skipped_typing()
 
+## Emitted when typing starts
+signal started_typing()
+
 ## Emitted when typing finishes.
 signal finished_typing()
-
-## Emitted when typing starts
-signal started_typing(character:String)
 
 # The action to press to skip typing.
 @export var skip_action: StringName = &"ui_cancel"
@@ -59,8 +59,6 @@ var is_typing: bool = false:
 	set(value):
 		var is_finished: bool = is_typing != value and value == false
 		is_typing = value
-		if is_typing:
-			started_typing.emit(dialogue_line.character)
 		if is_finished:
 			finished_typing.emit()
 	get:
@@ -108,6 +106,7 @@ func type_out() -> void:
 	_already_mutated_indices.clear()
 
 	self.is_typing = true
+	started_typing.emit()
 
 	# Allow typing listeners a chance to connect
 	await get_tree().process_frame

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -18,6 +18,8 @@ signal skipped_typing()
 ## Emitted when typing finishes.
 signal finished_typing()
 
+## Emitted when typing starts
+signal started_typing(character:String)
 
 # The action to press to skip typing.
 @export var skip_action: StringName = &"ui_cancel"
@@ -107,6 +109,9 @@ func type_out() -> void:
 
 	# Allow typing listeners a chance to connect
 	await get_tree().process_frame
+	
+	# Emit the started_typing signal with the character name
+	started_typing.emit(dialogue_line.character)
 
 	if get_total_character_count() == 0:
 		self.is_typing = false

--- a/docs/API.md
+++ b/docs/API.md
@@ -80,6 +80,7 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 - `spoke(letter: String, letter_index: int, speed: float)` - emitted each step while typing out.
 - `paused_typing(duration: float)` - emitted when the label pauses typing.
 - `skipped_typing()` - emitted when the player skips the label typing out.
+- `started_typing(character:String)` - emitted when the label starts typing with the character name 
 - `finished_typing()` - emitted when the label finishes typing.
 
 ### Methods

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,8 +79,8 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 
 - `spoke(letter: String, letter_index: int, speed: float)` - emitted each step while typing out.
 - `paused_typing(duration: float)` - emitted when the label pauses typing.
+- `started_typing()` - emitted when the label starts typing.
 - `skipped_typing()` - emitted when the player skips the label typing out.
-- `started_typing(character:String)` - emitted when the label starts typing with the character name 
 - `finished_typing()` - emitted when the label finishes typing.
 
 ### Methods

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -57,7 +57,7 @@ The addon provides a `DialogueLabel` node (an extension of the RichTextLabel nod
 
 This node is given a `dialogue_line` (mentioned above) and uses its properties to work out how to handle typing out the dialogue. It will automatically handle any `bb_code`, `wait`, `speed`, and `inline_mutation` references.
 
-Use `type_out()` to start typing out the text. The label will emit a `finished_typing` signal when it has finished typing.
+Use `type_out()` to start typing out the text. The label will emit a `started_typeing` signal as the text begins typing , and a `finished_typing` signal when it has finished typing.
 
 The label will emit a `paused_typing` signal (along with the duration of the pause) when there is a pause in the typing and a `spoke` signal (along with the letter typed and the current speed) when a letter was just typed.
 

--- a/docs/Using_Dialogue.md
+++ b/docs/Using_Dialogue.md
@@ -57,7 +57,7 @@ The addon provides a `DialogueLabel` node (an extension of the RichTextLabel nod
 
 This node is given a `dialogue_line` (mentioned above) and uses its properties to work out how to handle typing out the dialogue. It will automatically handle any `bb_code`, `wait`, `speed`, and `inline_mutation` references.
 
-Use `type_out()` to start typing out the text. The label will emit a `started_typeing` signal as the text begins typing , and a `finished_typing` signal when it has finished typing.
+Use `type_out()` to start typing out the text. The label will emit a `started_typing` signal as the text begins typing, and a `finished_typing` signal when it has finished typing.
 
 The label will emit a `paused_typing` signal (along with the duration of the pause) when there is a pause in the typing and a `spoke` signal (along with the letter typed and the current speed) when a letter was just typed.
 


### PR DESCRIPTION
This adds a `started_typing` signal into the `DialogueLabel` class to mirror the `finished_typing` signal and help with making animations for character portraits easier without workarounds.

Docs have been updated to show the change in the API as well.