### PR TITLE
Add MutationBehavior passthrough to C# get_next_dialogue_line bridge

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -9,6 +9,13 @@ using System.Threading.Tasks;
 
 namespace DialogueManagerRuntime
 {
+
+	public enum MutationBehaviour {
+		Wait,
+		DoNotWait,
+		Skip
+	}
+
     public enum TranslationSource
     {
         None,

--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -131,7 +131,7 @@ namespace DialogueManagerRuntime
         {
             var instance = (Node)Instance.Call("_bridge_get_new_instance");
             Prepare(instance);
-            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), mutation_behaviour.ToString());
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), (int)mutation_behaviour);
             var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
             instance.QueueFree();
 

--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -127,11 +127,11 @@ namespace DialogueManagerRuntime
             return (Resource)Instance.Call("create_resource_from_text", text);
         }
 
-        public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+		public static async Task<DialogueLine?> GetNextDialogueLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null, MutationBehaviour mutation_behaviour = MutationBehaviour.Wait)
         {
             var instance = (Node)Instance.Call("_bridge_get_new_instance");
             Prepare(instance);
-            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+            instance.Call("_bridge_get_next_dialogue_line", dialogueResource, key, extraGameStates ?? new Array<Variant>(), mutation_behaviour.ToString());
             var result = await instance.ToSignal(instance, "bridge_get_next_dialogue_line_completed");
             instance.QueueFree();
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -512,10 +512,10 @@ func _bridge_get_new_instance() -> Node:
 	return instance
 
 
-func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = [], mutation_behaviour: String = str(DMConstants.MutationBehaviour.Wait)) -> void:
+func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = [], mutation_behaviour: int = DMConstants.MutationBehaviour.Wait) -> void:
 	# dotnet needs at least one await tick of the signal gets called too quickly
 	await Engine.get_main_loop().process_frame
-	var line = await get_next_dialogue_line(resource, key, extra_game_states, DMConstants.MutationBehaviour.get(mutation_behaviour))
+	var line = await get_next_dialogue_line(resource, key, extra_game_states, mutation_behaviour)
 	bridge_get_next_dialogue_line_completed.emit(line)
 
 

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -512,11 +512,10 @@ func _bridge_get_new_instance() -> Node:
 	return instance
 
 
-func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:
+func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, extra_game_states: Array = [], mutation_behaviour: String = str(DMConstants.MutationBehaviour.Wait)) -> void:
 	# dotnet needs at least one await tick of the signal gets called too quickly
 	await Engine.get_main_loop().process_frame
-
-	var line = await get_next_dialogue_line(resource, key, extra_game_states)
+	var line = await get_next_dialogue_line(resource, key, extra_game_states, DMConstants.MutationBehaviour.get(mutation_behaviour))
 	bridge_get_next_dialogue_line_completed.emit(line)
 
 


### PR DESCRIPTION
The C# get_next_dialogue_line command was missing the MutationBehavior argument present in its gdscript counterpart. This PR adds it back in.

The bridge dislikes converting between the two langauages' enum types so I worked around it by stringifying them in the bridge. This solution does suffer from having to define MutationBehavior in both C# and gdscript, which could lead to issues if you add an extra value to one but not the other, but overall it does get the job done. Other suggestions and solutions are of course welcome.