### PR TITLE
Add GetLine to C#

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -133,6 +133,19 @@ namespace DialogueManagerRuntime
             return new DialogueLine((RefCounted)result[0]);
         }
 
+		public static async Task<DialogueLine?> GetLine(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
+        {
+            var instance = (Node)Instance.Call("_bridge_get_new_instance");
+            Prepare(instance);
+            instance.Call("_bridge_get_line", dialogueResource, key, extraGameStates ?? new Array<Variant>());
+            var result = await instance.ToSignal(instance, "bridge_get_line_completed");
+            instance.QueueFree();
+
+            if ((RefCounted)result[0] == null) return null;
+
+            return new DialogueLine((RefCounted)result[0]);
+        }
+
 
         public static CanvasLayer ShowExampleDialogueBalloon(Resource dialogueResource, string key = "", Array<Variant>? extraGameStates = null)
         {

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -31,6 +31,9 @@ signal dialogue_ended(resource: DialogueResource)
 ## Used internally.
 signal bridge_get_next_dialogue_line_completed(line: DialogueLine)
 
+## Used internally.
+signal bridge_get_line_completed(line: DialogueLine)
+
 ## Used internally
 signal bridge_dialogue_started(resource: DialogueResource)
 
@@ -518,6 +521,13 @@ func _bridge_get_next_dialogue_line(resource: DialogueResource, key: String, ext
 
 	var line = await get_next_dialogue_line(resource, key, extra_game_states)
 	bridge_get_next_dialogue_line_completed.emit(line)
+
+
+func _bridge_get_line(resource: DialogueResource, key: String, extra_game_states: Array = []) -> void:
+	# dotnet needs at least one await tick of the signal gets called too quickly
+	await Engine.get_main_loop().process_frame
+	var line = await get_line(resource, key, extra_game_states)
+	bridge_get_line_completed.emit(line)
 
 
 func _bridge_mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation: bool = false) -> void:


### PR DESCRIPTION
This adds a C# bridge to the getline function, copying most of the logic from the get_next_dialogue_line function.

Let me know if you'd like me to combine my PR's rather than do them separately.