### PR TITLE
Make dialogue label use _update_text() when setting text in type_out()

### DIFF
--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -94,7 +94,7 @@ func _update_text() -> void:
 
 ## Start typing out the text
 func type_out() -> void:
-	text = dialogue_line.text
+	_update_text()
 	visible_characters = 0
 	visible_ratio = 0
 	_waiting_seconds = 0


### PR DESCRIPTION
Recently, it was made possible to override how the text is set in the dialogue label so that you can modify it before display, so that you can add BBCodes and the like if you want. (#933) This failed to update the location where the text is *actually* set for typing out, meaning that the effects wouldn't be seen. This pull request makes the relevant location use `_update_text()` instead, updating the text appropriately. 