### PR TITLE
Fix incorrectly failing match cases

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -703,8 +703,12 @@ func _check_case_value(match_value: Variant, data: Dictionary, extra_game_states
 			already_compared = true
 
 		var resolved_value = await _resolve(expression_to_check, extra_game_states)
-		if (already_compared and resolved_value) or match_value == resolved_value:
-			return true
+		if already_compared:
+			if resolved_value:
+				return true
+		else:
+			if match_value == resolved_value:
+				return true
 
 	return false
 

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -230,6 +230,22 @@ After")
 	resource = create_resource("
 ~ start
 Before
+match StateForTests.some_property
+	when < 2
+		Less than 2.
+	when 2
+		Exactly 2.
+After")
+
+	StateForTests.some_property = 2
+	line = await resource.get_next_dialogue_line("start")
+	assert(line.text == "Before", "Should be before match.")
+	line = await resource.get_next_dialogue_line(line.next_id)
+	assert(line.text == "Exactly 2.", "Should match comparison.")
+
+	resource = create_resource("
+~ start
+Before
 match StateForTests.some_property + 1
 	when 0
 		It's zero.


### PR DESCRIPTION
Looks like there was some confusion in the compound conditional.

This fix applies to dialogue like this, for the example integer 2,

```
match SomeClass.AnIntegerEqualToTwo
    when < 2
        Bob: hello
    when 2
        Bob: hello again
```