### PR TITLE
Skip random group if none pass their conditions

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -203,6 +203,10 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 	if data.has(&"siblings"):
 		# Only count siblings that pass their condition (if they have one).
 		var successful_siblings: Array = data.siblings.filter(func(sibling): return not sibling.has("condition") or await _check_condition(sibling, extra_game_states))
+		# If there are no siblings that pass their conditions then just skip over them all.
+		if successful_siblings.size() == 0:
+			return await get_line(resource, data.next_id + id_trail, extra_game_states)
+		# Otherwise, pick a random one.
 		var target_weight: float = randf_range(0, successful_siblings.reduce(func(total, sibling): return total + sibling.weight, 0))
 		var cummulative_weight: float = 0
 		for sibling in successful_siblings:

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -224,6 +224,20 @@ Nathan: Jump 3.")
 	assert(output.lines["5"].siblings[2].weight == 3, "Weight of 3 should be 3.")
 
 
+func test_will_skip_random_condition_lines_if_none_pass() -> void:
+	var resource = create_resource("
+~ start
+Nathan: Hello.
+% [if false] Nathan: Fail 1
+% [if false] Nathan: Fail 2
+Nathan: After.")
+
+	var line = await resource.get_next_dialogue_line("start")
+	assert(line.text == "Hello.", "Should be first line.")
+	line = await resource.get_next_dialogue_line(line.next_id)
+	assert(line.text == "After.", "Should skip failed lines.")
+
+
 class TestClass:
 	var string: String = ""
 	var number: int = -1


### PR DESCRIPTION
This fixes an issue where random line groups would stall if none passed their condition.