### PR TITLE
Stop dialogue editor scrolling to top when generating line IDs

### DIFF
--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -521,6 +521,7 @@ func generate_translations_keys() -> void:
 	rng.randomize()
 
 	var cursor: Vector2 = code_edit.get_cursor()
+	var scroll_vertical = code_edit.scroll_vertical
 	var lines: PackedStringArray = code_edit.text.split("\n")
 
 	var key_regex = RegEx.new()
@@ -592,6 +593,7 @@ func generate_translations_keys() -> void:
 
 	code_edit.text = "\n".join(lines)
 	code_edit.set_cursor(cursor)
+	code_edit.scroll_vertical = scroll_vertical
 	_on_code_edit_text_changed()
 
 


### PR DESCRIPTION
_Please describe what it is that you've fixed or changed and link to any relevant issues. Include any screenshots that you think might be needed to help explain the change._

When Generating line IDs in the dialogue editor the view scrolls to the very top instead of staying at the current position.
This has been fixed by restoring scroll_vertical after generating the line IDs

_If this is a change to the compiler then make sure to add/update any tests that may be affected._

no change to compiler

_If this change needs updates to the documentation then make sure you've made those changes too._

no need to update docs