### PR TITLE
Add support for waiting for input

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -432,12 +432,6 @@ namespace DialogueManagerRuntime
             get => time;
         }
 
-        private Dictionary pauses = new Dictionary();
-        public Dictionary Pauses
-        {
-            get => pauses;
-        }
-
         private Dictionary speeds = new Dictionary();
         public Dictionary Speeds
         {
@@ -476,7 +470,6 @@ namespace DialogueManagerRuntime
             character = (string)data.Get("character");
             text = (string)data.Get("text");
             translation_key = (string)data.Get("translation_key");
-            pauses = (Dictionary)data.Get("pauses");
             speeds = (Dictionary)data.Get("speeds");
             inline_mutations = (Array<Godot.Collections.Array>)data.Get("inline_mutations");
             time = (string)data.Get("time");

--- a/addons/dialogue_manager/compiler/compiler.gd
+++ b/addons/dialogue_manager/compiler/compiler.gd
@@ -44,6 +44,12 @@ static func extract_translatable_string(text: String) -> String:
 	return line.text
 
 
+## Extract a mutation from a string.
+static func extract_mutation(text: String) -> Dictionary:
+	var compilation: DMCompilation = DMCompilation.new()
+	return compilation.extract_mutation(text)
+
+
 ## Get the known titles in a dialogue script.
 static func get_titles_in_text(text: String, path: String) -> Dictionary:
 	var compilation: DMCompilation = DMCompilation.new()

--- a/addons/dialogue_manager/compiler/resolved_line_data.gd
+++ b/addons/dialogue_manager/compiler/resolved_line_data.gd
@@ -3,8 +3,6 @@ class_name DMResolvedLineData extends RefCounted
 
 ## The line's text
 var text: String = ""
-## A map of pauses against where they are found in the text.
-var pauses: Dictionary = {}
 ## A map of speed changes against where they are found in the text.
 var speeds: Dictionary = {}
 ## A list of any mutations to run and where they are found in the text.
@@ -15,7 +13,6 @@ var time: String = ""
 
 func _init(line: String) -> void:
 	text = line
-	pauses = {}
 	speeds = {}
 	mutations = []
 	time = ""
@@ -65,8 +62,7 @@ func _init(line: String) -> void:
 		var raw_args = bbcode.raw_args
 		var args = {}
 		if code in ["do", "do!", "set"]:
-			var compilation: DMCompilation = DMCompilation.new()
-			args["value"] = compilation.extract_mutation("%s %s" % [code, raw_args])
+			args["value"] = DMCompiler.extract_mutation("%s %s" % [code, raw_args])
 		else:
 			# Could be something like:
 			# 	"=1.0"
@@ -80,10 +76,8 @@ func _init(line: String) -> void:
 
 		match code:
 			"wait":
-				if pauses.has(index):
-					pauses[index] += args.get("value").to_float()
-				else:
-					pauses[index] = args.get("value").to_float()
+				var wait: Dictionary = DMCompiler.extract_mutation("do wait(%s)" % [args.get("value")])
+				mutations.append([index, wait])
 			"speed":
 				speeds[index] = args.get("value").to_float()
 			"/speed":

--- a/addons/dialogue_manager/dialogue_label.gd
+++ b/addons/dialogue_manager/dialogue_label.gd
@@ -9,9 +9,6 @@ class_name DialogueLabel extends RichTextLabel
 ## Emitted for each letter typed out.
 signal spoke(letter: String, letter_index: int, speed: float)
 
-## Emitted when typing paused for a `[wait]`
-signal paused_typing(duration: float)
-
 ## Emitted when the player skips the typing of dialogue.
 signal skipped_typing()
 
@@ -20,6 +17,9 @@ signal started_typing()
 
 ## Emitted when typing finishes.
 signal finished_typing()
+
+## [Deprecated] No longer emitted.
+signal paused_typing(duration: float)
 
 
 ## The action to press to skip typing.
@@ -57,12 +57,13 @@ var dialogue_line:
 ## Whether the label is currently typing itself out.
 var is_typing: bool = false:
 	set(value):
-		var is_finished: bool = is_typing != value and value == false
-		is_typing = value
+		var is_finished: bool = is_typing != value and value == false and visible_characters == get_total_character_count()
+		_is_typing = value
 		if is_finished:
 			finished_typing.emit()
 	get:
-		return is_typing
+		return _is_typing and not _is_awaiting_mutation
+var _is_typing: bool = false
 
 var _last_wait_index: int = -1
 var _last_mutation_index: int = -1
@@ -71,7 +72,7 @@ var _is_awaiting_mutation: bool = false
 
 
 func _process(delta: float) -> void:
-	if self.is_typing:
+	if _is_typing:
 		# Type out text
 		if visible_ratio < 1:
 			# See if we are waiting
@@ -83,7 +84,7 @@ func _process(delta: float) -> void:
 		else:
 			# Make sure any mutations at the end of the line get run
 			_mutate_inline_mutations(get_total_character_count())
-			self.is_typing = false
+			is_typing = false
 
 
 ## Sets the label's text from the current dialogue line. Override if you want
@@ -102,25 +103,25 @@ func type_out() -> void:
 	_last_mutation_index = -1
 	_already_mutated_indices.clear()
 
-	self.is_typing = true
+	is_typing = true
 	started_typing.emit()
 
 	# Allow typing listeners a chance to connect
 	await get_tree().process_frame
 
 	if get_total_character_count() == 0:
-		self.is_typing = false
+		is_typing = false
 	elif seconds_per_step == 0:
 		_mutate_remaining_mutations()
 		visible_characters = get_total_character_count()
-		self.is_typing = false
+		is_typing = false
 
 
 ## Stop typing out the text and jump right to the end
 func skip_typing() -> void:
 	_mutate_remaining_mutations()
 	visible_characters = get_total_character_count()
-	self.is_typing = false
+	is_typing = false
 	skipped_typing.emit()
 
 
@@ -136,17 +137,11 @@ func _type_next(delta: float, seconds_needed: float) -> void:
 		_mutate_inline_mutations(visible_characters)
 		if _is_awaiting_mutation: return
 
-	var additional_waiting_seconds: float = _get_pause(visible_characters)
-
 	# Pause on characters like "."
-	if _should_auto_pause():
-		additional_waiting_seconds += seconds_per_pause_step
-
-	# Pause at literal [wait] directives
-	if _last_wait_index != visible_characters and additional_waiting_seconds > 0:
+	var waiting_seconds: float = seconds_per_pause_step if _should_auto_pause() else 0
+	if _last_wait_index != visible_characters and waiting_seconds > 0:
 		_last_wait_index = visible_characters
-		_waiting_seconds += additional_waiting_seconds
-		paused_typing.emit(_get_pause(visible_characters))
+		_waiting_seconds += waiting_seconds
 	else:
 		visible_characters += 1
 		if visible_characters <= get_total_character_count():
@@ -157,11 +152,6 @@ func _type_next(delta: float, seconds_needed: float) -> void:
 			_waiting_seconds += seconds_needed
 		else:
 			_type_next(delta, seconds_needed)
-
-
-# Get the pause for the current typing position if there is one
-func _get_pause(at_index: int) -> float:
-	return dialogue_line.pauses.get(at_index, 0)
 
 
 # Get the speed for the current typing position

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -26,9 +26,6 @@ var text_replacements: Array[Dictionary] = []
 ## The key to use for translating this line.
 var translation_key: String = ""
 
-## A map for when and for how long to pause while typing out the dialogue text.
-var pauses: Dictionary = {}
-
 ## A map for speed changes when typing out the dialogue text.
 var speeds: Dictionary = {}
 
@@ -71,7 +68,6 @@ func _init(data: Dictionary = {}) -> void:
 				text = data.text
 				text_replacements = data.get("text_replacements", [] as Array[Dictionary])
 				translation_key = data.get("translation_key", data.text)
-				pauses = data.get("pauses", {})
 				speeds = data.get("speeds", {})
 				inline_mutations = data.get("inline_mutations", [] as Array[Array])
 				time = data.get("time", "")

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -37,7 +37,7 @@ signal bridge_get_line_completed(line: DialogueLine)
 ## Used internally
 signal bridge_dialogue_started(resource: DialogueResource)
 
-## Used inernally
+## Used internally
 signal bridge_mutated()
 
 
@@ -357,7 +357,7 @@ func get_resolved_line_data(data: Dictionary, extra_game_states: Array = []) -> 
 			resolved_text = resolved_text.substr(0, r.start) + r.body + resolved_text.substr(r.end, 9999)
 			# Move any other markers now that the text has changed
 			var offset: int = r.end - r.start - r.body.length()
-			for key in [&"pauses", &"speeds", &"time"]:
+			for key in [&"speeds", &"time"]:
 				if markers.get(key) == null: continue
 				var marker = markers.get(key)
 				var next_marker: Dictionary = {}
@@ -601,7 +601,6 @@ func create_dialogue_line(data: Dictionary, extra_game_states: Array) -> Dialogu
 				text = resolved_data.text,
 				text_replacements = data.get(&"text_replacements", [] as Array[Dictionary]),
 				translation_key = data.get(&"translation_key", data.text),
-				pauses = resolved_data.pauses,
 				speeds = resolved_data.speeds,
 				inline_mutations = resolved_data.mutations,
 				time = resolved_data.time,
@@ -737,7 +736,11 @@ func _mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation:
 		match expression[0].function:
 			&"wait", &"Wait":
 				mutated.emit(mutation.merged({ is_inline = is_inline_mutation }))
-				await Engine.get_main_loop().create_timer(float(args[0])).timeout
+				if [TYPE_FLOAT, TYPE_INT].has(typeof(args[0])):
+					await Engine.get_main_loop().create_timer(float(args[0])).timeout
+				else:
+					var actions: PackedStringArray = PackedStringArray(args[0] if typeof(args[0]) == TYPE_ARRAY else [args[0]])
+					await _wait_for(actions)
 				return
 
 			&"debug", &"Debug":
@@ -757,6 +760,14 @@ func _mutate(mutation: Dictionary, extra_game_states: Array, is_inline_mutation:
 
 	# Wait one frame to give the dialogue handler a chance to yield
 	await Engine.get_main_loop().process_frame
+
+
+# Wait for a given action
+func _wait_for(actions: PackedStringArray) -> void:
+	var waiter = DMWaiter.new(actions)
+	add_child(waiter)
+	await waiter.waited
+	waiter.queue_free()
 
 
 # Check if a mutation contains an assignment token.

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -51,6 +51,9 @@ var mutation_cooldown: Timer = Timer.new()
 ## The menu of responses
 @onready var responses_menu: DialogueResponsesMenu = %ResponsesMenu
 
+## Indicator to show that player can progress dialogue.
+@onready var progress: Polygon2D = %Progress
+
 
 func _ready() -> void:
 	balloon.hide()
@@ -62,6 +65,10 @@ func _ready() -> void:
 
 	mutation_cooldown.timeout.connect(_on_mutation_cooldown_timeout)
 	add_child(mutation_cooldown)
+
+
+func _process(delta: float) -> void:
+	progress.visible = not dialogue_label.is_typing and dialogue_line.responses.size() == 0
 
 
 func _unhandled_input(_event: InputEvent) -> void:
@@ -91,6 +98,7 @@ func start(dialogue_resource: DialogueResource, title: String, extra_game_states
 func apply_dialogue_line() -> void:
 	mutation_cooldown.stop()
 
+	progress.hide()
 	is_waiting_for_input = false
 	balloon.focus_mode = Control.FOCUS_ALL
 	balloon.grab_focus()
@@ -142,9 +150,10 @@ func _on_mutation_cooldown_timeout() -> void:
 
 
 func _on_mutated(_mutation: Dictionary) -> void:
-	is_waiting_for_input = false
-	will_hide_balloon = true
-	mutation_cooldown.start(0.1)
+	if not _mutation.is_inline:
+		is_waiting_for_input = false
+		will_hide_balloon = true
+		mutation_cooldown.start(0.1)
 
 
 func _on_balloon_gui_input(event: InputEvent) -> void:

--- a/addons/dialogue_manager/example_balloon/example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/example_balloon.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://73jm5qjy52vq"]
+[gd_scene load_steps=12 format=3 uid="uid://73jm5qjy52vq"]
 
 [ext_resource type="Script" uid="uid://d1wt4ma6055l8" path="res://addons/dialogue_manager/example_balloon/example_balloon.gd" id="1_36de5"]
 [ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="2_a8ve6"]
@@ -63,6 +63,42 @@ MarginContainer/constants/margin_right = 30
 MarginContainer/constants/margin_top = 15
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_qkmqt")
 
+[sub_resource type="Animation" id="Animation_qkmqt"]
+resource_name = "progress"
+loop_mode = 1
+step = 0.1
+tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Progress:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"handle_modes": PackedInt32Array(0, 0, 0, 0, 0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.2, -0.0157438, -4, -0.2, 0.0112069, 0.25, 0, -4, -0.25, 0, 0.25, 0, 0, -0.2, 0.00299701, 0.25, 0),
+"times": PackedFloat32Array(0, 0.1, 0.5, 0.6, 1)
+}
+
+[sub_resource type="Animation" id="Animation_nlsx6"]
+length = 0.001
+tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Progress:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_1337t"]
+_data = {
+&"RESET": SubResource("Animation_nlsx6"),
+&"progress": SubResource("Animation_qkmqt")
+}
+
 [node name="ExampleBalloon" type="CanvasLayer"]
 layer = 100
 script = ExtResource("1_36de5")
@@ -95,10 +131,14 @@ mouse_filter = 1
 [node name="MarginContainer" type="MarginContainer" parent="Balloon/MarginContainer/PanelContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.501961)
 layout_mode = 2
@@ -108,11 +148,26 @@ text = "Character"
 fit_content = true
 scroll_active = false
 
-[node name="DialogueLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("2_a8ve6")]
+[node name="DialogueLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("2_a8ve6")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 text = "Dialogue..."
+
+[node name="Control" type="Control" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(20, 10)
+layout_mode = 2
+size_flags_vertical = 8
+
+[node name="Progress" type="Polygon2D" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+unique_name_in_owner = true
+polygon = PackedVector2Array(0, 0, 10, 10, 20, 0)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+libraries = {
+&"": SubResource("AnimationLibrary_1337t")
+}
+autoplay = "progress"
 
 [node name="ResponsesMenu" type="VBoxContainer" parent="Balloon" node_paths=PackedStringArray("response_template")]
 unique_name_in_owner = true

--- a/addons/dialogue_manager/example_balloon/small_example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/small_example_balloon.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://13s5spsk34qu"]
+[gd_scene load_steps=12 format=3 uid="uid://13s5spsk34qu"]
 
 [ext_resource type="Script" uid="uid://d1wt4ma6055l8" path="res://addons/dialogue_manager/example_balloon/example_balloon.gd" id="1_s2gbs"]
 [ext_resource type="PackedScene" uid="uid://ckvgyvclnwggo" path="res://addons/dialogue_manager/dialogue_label.tscn" id="2_hfvdi"]
@@ -89,6 +89,27 @@ MarginContainer/constants/margin_right = 8
 MarginContainer/constants/margin_top = 4
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_i6nbm")
 
+[sub_resource type="Animation" id="Animation_i6nbm"]
+resource_name = "progress"
+loop_mode = 1
+step = 0.1
+tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Progress:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"handle_modes": PackedInt32Array(0, 0, 0, 0, 0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.2, -0.0157438, -1, -0.2, 0.0112069, 0.25, 0, -1, -0.25, 0, 0.25, 0, 0, -0.2, 0.00299701, 0.25, 0),
+"times": PackedFloat32Array(0, 0.1, 0.5, 0.6, 1)
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_6b6c8"]
+_data = {
+&"progress": SubResource("Animation_i6nbm")
+}
+
 [node name="ExampleBalloon" type="CanvasLayer"]
 layer = 100
 script = ExtResource("1_s2gbs")
@@ -121,10 +142,14 @@ mouse_filter = 1
 [node name="MarginContainer" type="MarginContainer" parent="Balloon/MarginContainer/PanelContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CharacterLabel" type="RichTextLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.501961)
 layout_mode = 2
@@ -134,11 +159,27 @@ text = "Character"
 fit_content = true
 scroll_active = false
 
-[node name="DialogueLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("2_hfvdi")]
+[node name="DialogueLabel" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/VBoxContainer" instance=ExtResource("2_hfvdi")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 text = "Dialogue..."
+
+[node name="Control" type="Control" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(5, 3)
+layout_mode = 2
+size_flags_vertical = 8
+
+[node name="Progress" type="Polygon2D" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+unique_name_in_owner = true
+position = Vector2(0, -0.455998)
+polygon = PackedVector2Array(0, 0, 2.5, 3, 5, 0)
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="Balloon/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/Control"]
+libraries = {
+&"": SubResource("AnimationLibrary_6b6c8")
+}
+autoplay = "progress"
 
 [node name="ResponsesMenu" type="VBoxContainer" parent="Balloon"]
 unique_name_in_owner = true

--- a/addons/dialogue_manager/utilities/waiter.gd
+++ b/addons/dialogue_manager/utilities/waiter.gd
@@ -1,0 +1,18 @@
+class_name DMWaiter extends Node
+
+
+signal waited()
+
+
+var _actions: PackedStringArray
+
+
+func _init(target_actions: PackedStringArray) -> void:
+	_actions = target_actions
+
+
+func _input(event: InputEvent) -> void:
+	for action: String in _actions:
+		if event.is_pressed():
+			if action == "any" or event.is_action(action):
+				waited.emit()

--- a/addons/dialogue_manager/utilities/waiter.gd.uid
+++ b/addons/dialogue_manager/utilities/waiter.gd.uid
@@ -1,0 +1,1 @@
+uid://bx7dtro7ywali

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,7 +78,6 @@ Returns the example balloon's base CanvasLayer in case you want to `queue_free()
 ### Signals
 
 - `spoke(letter: String, letter_index: int, speed: float)` - emitted each step while typing out.
-- `paused_typing(duration: float)` - emitted when the label pauses typing.
 - `started_typing()` - emitted when the label starts typing.
 - `skipped_typing()` - emitted when the player skips the label typing out.
 - `finished_typing()` - emitted when the label finishes typing.

--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -23,7 +23,7 @@ Nathan: This is me talking.
 You can add some spice to your dialogue with [BBCode](https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html#reference). Along with everything available to Godot's `RichTextLabel` you can also use a few extra ones provided by Dialogue Manager:
 
 - `[[This|Or this|Or even this]]` to pick one option at random in the middle of dialogue (note the double "[[").
-- `[wait=N]` where N is the number of seconds to pause typing of dialogue. You can also wait for actions by writing something like `[wait="ui_accept"]`, where "ui_accept" is written as a string (you can *also* wait for any of a list of actions with something like `[wait=["ui_accept","ui_cancel"]]`).
+- `[wait=N]` where N is the number of seconds to pause typing of dialogue. You can also wait for actions by writing something like `[wait="ui_accept"]`, where "ui_accept" is written as a string (you can *also* wait for any of a list of actions with something like `[wait=["ui_accept","ui_cancel"]]` or to just wait for any action, `[wait="any"]`).
 - `[speed=N]` where N is a number to multiply the default typing speed by.
 - `[next=N]` where N is a number of seconds to wait before automatically continuing to the next line of dialogue. You can also use `[next=auto]` to have the label determine a length of time to wait based on the length of the text.
 

--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -23,7 +23,7 @@ Nathan: This is me talking.
 You can add some spice to your dialogue with [BBCode](https://docs.godotengine.org/en/stable/tutorials/ui/bbcode_in_richtextlabel.html#reference). Along with everything available to Godot's `RichTextLabel` you can also use a few extra ones provided by Dialogue Manager:
 
 - `[[This|Or this|Or even this]]` to pick one option at random in the middle of dialogue (note the double "[[").
-- `[wait=N]` where N is the number of seconds to pause typing of dialogue.
+- `[wait=N]` where N is the number of seconds to pause typing of dialogue. You can also wait for actions by writing something like `[wait="ui_accept"]`, where "ui_accept" is written as a string (you can *also* wait for any of a list of actions with something like `[wait=["ui_accept","ui_cancel"]]`).
 - `[speed=N]` where N is a number to multiply the default typing speed by.
 - `[next=N]` where N is a number of seconds to wait before automatically continuing to the next line of dialogue. You can also use `[next=auto]` to have the label determine a length of time to wait based on the length of the text.
 

--- a/project.godot
+++ b/project.godot
@@ -43,6 +43,17 @@ enabled=PackedStringArray("res://addons/dialogue_manager/plugin.cfg")
 import/blender/enabled=false
 import/fbx/enabled=false
 
+[input]
+
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194310,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+
 [internationalization]
 
 locale/translation_remaps={}


### PR DESCRIPTION
This adds support to the `wait` built-in mutation to be able to wait for actions (or *any* action).

To use it you can write something like:

```
Character: This is the first bit.[wait="ui_accept"] Then this bit.
```

If you want to wait for *any* action you can use "any" as the action:

```
Character: This is the first bit.[wait="any"] Then this bit.
```

Related to #954