### PR TITLE
Change dialogue_ended signal to emit immediately instead of deferred

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -108,7 +108,7 @@ func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_
 
 	# If our dialogue is nothing then we hit the end
 	if not _is_valid(dialogue):
-		dialogue_ended.emit.call_deferred(resource)
+		dialogue_ended.emit(resource)
 		return null
 
 	# Run the mutation if it is one
@@ -123,7 +123,7 @@ func get_next_dialogue_line(resource: DialogueResource, key: String = "", extra_
 				pass
 		if actual_next_id in [DMConstants.ID_END_CONVERSATION, DMConstants.ID_NULL, null]:
 			# End the conversation
-			dialogue_ended.emit.call_deferred(resource)
+			dialogue_ended.emit(resource)
 			return null
 		else:
 			return await get_next_dialogue_line(resource, dialogue.next_id, extra_game_states, mutation_behaviour)


### PR DESCRIPTION
This changes how the `dialogue_ended` signal is emitted. Previously, it was emitted with `call_deferred`, but it is now emitted immediately.

I'm not clear on why `call_deferred` was originally used, but it introduces issues when the last line of a dialogue script is a mutation. For example:

```
~ start
Bob: Hello!
do call_something()
=> END
```

Running this dialogue script will cause the `dialogue_ended` signal to never emit if it's call is deferred. I'm not certain as to why this happens, and it could possibly be a quirk with Godot (I tested this on Godot v4.4.1). This PR fixes the issue.

If `call_deferred` is really needed, another possible workaround would be to defer the emission and then immediately await the signal:

```gdscript
dialogue_ended.emit.call_deferred(resource)
await dialogue_ended
```

However, this seems quite **hacky.**