### PR TITLE
Add "$>" as alternative mutation keyword

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -753,7 +753,7 @@ func parse_dialogue_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: 
 	for bbcode: Dictionary in bbcodes:
 		var tag: String = bbcode.code
 		var code: String = bbcode.raw_args
-		if tag.begins_with("do") or tag.begins_with("set") or tag.begins_with("if"):
+		if tag.begins_with("$>") or tag.begins_with("do") or tag.begins_with("set") or tag.begins_with("if"):
 			var expression: Array = expression_parser.tokenise(code, DMConstants.TYPE_MUTATION, bbcode.start + bbcode.code.length())
 			if expression.size() == 0:
 				add_error(tree_line.line_number, tree_line.indent, DMConstants.ERR_INVALID_EXPRESSION)
@@ -967,7 +967,7 @@ func get_line_type(raw_line: String) -> String:
 	if text.begins_with("when "):
 		return DMConstants.TYPE_WHEN
 
-	if text.begins_with("do ") or text.begins_with("do! ") or text.begins_with("set "):
+	if text.begins_with("do ") or text.begins_with("do! ") or text.begins_with("set ") or text.begins_with("$> ") or text.begins_with("$>> "):
 		return DMConstants.TYPE_MUTATION
 
 	if text.begins_with("=> ") or text.begins_with("=>< "):
@@ -1073,7 +1073,7 @@ func extract_mutation(text: String) -> Dictionary:
 		else:
 			return {
 				expression = expression,
-				is_blocking = not "!" in found.strings[found.names.keyword]
+				is_blocking = not "!" in found.strings[found.names.keyword] and found.strings[found.names.keyword] != "$>>"
 			}
 
 	else:

--- a/addons/dialogue_manager/compiler/compiler_regex.gd
+++ b/addons/dialogue_manager/compiler/compiler_regex.gd
@@ -9,7 +9,7 @@ var VALID_TITLE_REGEX: RegEx = RegEx.create_from_string("^[a-zA-Z_0-9\\p{Emoji_P
 var BEGINS_WITH_NUMBER_REGEX: RegEx = RegEx.create_from_string("^\\d")
 var CONDITION_REGEX: RegEx = RegEx.create_from_string("(if|elif|while|else if|match|when) (?<expression>.*)\\:?")
 var WRAPPED_CONDITION_REGEX: RegEx = RegEx.create_from_string("\\[if (?<expression>.*)\\]")
-var MUTATION_REGEX: RegEx = RegEx.create_from_string("(?<keyword>do|do!|set) (?<expression>.*)")
+var MUTATION_REGEX: RegEx = RegEx.create_from_string("(?<keyword>\\$\\>|\\$\\>\\>|do|do!|set) (?<expression>.*)")
 var STATIC_LINE_ID_REGEX: RegEx = RegEx.create_from_string("\\[ID:(?<id>.*?)\\]")
 var WEIGHTED_RANDOM_SIBLINGS_REGEX: RegEx = RegEx.create_from_string("^\\%(?<weight>[\\d.]+)?( \\[if (?<condition>.+?)\\])? ")
 var GOTO_REGEX: RegEx = RegEx.create_from_string("=><? (?<goto>.*)")

--- a/addons/dialogue_manager/compiler/resolved_line_data.gd
+++ b/addons/dialogue_manager/compiler/resolved_line_data.gd
@@ -39,7 +39,7 @@ func _init(line: String) -> void:
 	var accumulaive_length_offset = 0
 	for position in bbcode_positions:
 		# Ignore our own markers
-		if position.code in ["wait", "speed", "/speed", "do", "do!", "set", "next", "if", "else", "/if"]:
+		if position.code in ["wait", "speed", "/speed", "$>", "$>>", "do", "do!", "set", "next", "if", "else", "/if"]:
 			continue
 
 		bbcodes.append({
@@ -59,12 +59,11 @@ func _init(line: String) -> void:
 		limit += 1
 
 		var bbcode = next_bbcode_position[0]
-
 		var index = bbcode.start
 		var code = bbcode.code
 		var raw_args = bbcode.raw_args
 		var args = {}
-		if code in ["do", "do!", "set"]:
+		if code in ["$>", "$>>", "do", "do!", "set"]:
 			var compilation: DMCompilation = DMCompilation.new()
 			args["value"] = compilation.extract_mutation("%s %s" % [code, raw_args])
 		else:
@@ -88,7 +87,7 @@ func _init(line: String) -> void:
 				speeds[index] = args.get("value").to_float()
 			"/speed":
 				speeds[index] = 1.0
-			"do", "do!", "set":
+			"$>", "$>>", "do", "do!", "set":
 				mutations.append([index, args.get("value")])
 			"next":
 				time = args.get("value") if args.has("value") else "0"
@@ -142,7 +141,7 @@ func find_bbcode_positions_in_string(string: String, find_all: bool = true, incl
 			open_brace_count += 1
 
 		else:
-			if not is_finished_code and (string[i].to_upper() != string[i] or string[i] == "/" or string[i] == "!"):
+			if not is_finished_code and (string[i].to_upper() != string[i] or ["/", "!", "$", ">"].has(string[i])):
 				code += string[i]
 			else:
 				is_finished_code = true

--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -186,7 +186,7 @@ func _request_code_completion(force: bool) -> void:
 				add_code_completion_option(CodeEdit.KIND_CLASS, name + ": ", name.substr(name_so_far.length()) + ": ", theme_overrides.text_color, get_theme_icon("Sprite2D", "EditorIcons"))
 
 	# Match autoloads on mutation lines
-	for prefix in ["do ", "do! ", "set ", "if ", "elif ", "else if ", "match ", "when ", "using "]:
+	for prefix in ["$>", "$>>", "do ", "do! ", "set ", "if ", "elif ", "else if ", "match ", "when ", "using "]:
 		if (current_line.strip_edges().begins_with(prefix) and (cursor.x > current_line.find(prefix))):
 			var expression: String = current_line.substr(0, cursor.x).strip_edges().substr(3)
 			# Find the last couple of tokens

--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -62,7 +62,7 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 					_highlight_expression(expression, colors, index)
 
 		DMConstants.TYPE_MUTATION:
-			colors[0] = { color = theme.mutations_color }
+			colors[0] = { color = theme.mutations_line_color }
 			index = text.find(" ")
 			var expression: Array = expression_parser.tokenise(text.substr(index), DMConstants.TYPE_MUTATION, 0)
 			if expression.size() == 0:
@@ -126,7 +126,7 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 					colors[index + bbcode.end + 1] = { color = theme.text_color }
 				else:
 					colors[index + bbcode.start] = { color = theme.symbols_color }
-					if tag.begins_with("do") or tag.begins_with("set") or tag.begins_with("if"):
+					if tag.begins_with("$>") or tag.begins_with("do") or tag.begins_with("set") or tag.begins_with("if"):
 						if tag.begins_with("if"):
 							colors[index + bbcode.start + 1] = { color = theme.conditions_color }
 						else:
@@ -176,8 +176,11 @@ func _highlight_expression(tokens: Array, colors: Dictionary, index: int) -> int
 
 			DMConstants.TOKEN_OPERATOR, DMConstants.TOKEN_COLON, \
 			DMConstants.TOKEN_COMMA, DMConstants.TOKEN_DOT, DMConstants.TOKEN_NULL_COALESCE, \
-			DMConstants.TOKEN_NUMBER, DMConstants.TOKEN_ASSIGNMENT:
+			DMConstants.TOKEN_ASSIGNMENT:
 				colors[index + token.i] = { color = theme.symbols_color }
+
+			DMConstants.TOKEN_NUMBER:
+				colors[index + token.i] = { color = theme.numbers_color }
 
 			DMConstants.TOKEN_STRING:
 				colors[index + token.i] = { color = theme.strings_color }

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -379,12 +379,13 @@ func apply_theme() -> void:
 			text_color = editor_settings.get_setting("text_editor/theme/highlighting/text_color"),
 			conditions_color = editor_settings.get_setting("text_editor/theme/highlighting/keyword_color"),
 			mutations_color = editor_settings.get_setting("text_editor/theme/highlighting/function_color"),
+			mutations_line_color = Color(editor_settings.get_setting("text_editor/theme/highlighting/function_color"), 0.6),
 			members_color = editor_settings.get_setting("text_editor/theme/highlighting/member_variable_color"),
 			strings_color = editor_settings.get_setting("text_editor/theme/highlighting/string_color"),
 			numbers_color = editor_settings.get_setting("text_editor/theme/highlighting/number_color"),
 			symbols_color = editor_settings.get_setting("text_editor/theme/highlighting/symbol_color"),
 			comments_color = editor_settings.get_setting("text_editor/theme/highlighting/comment_color"),
-			jumps_color = Color(editor_settings.get_setting("text_editor/theme/highlighting/control_flow_keyword_color"), 0.7),
+			jumps_color = Color(editor_settings.get_setting("text_editor/theme/highlighting/control_flow_keyword_color"), 0.6),
 
 			font_size = editor_settings.get_setting("interface/editor/code_font_size")
 		}


### PR DESCRIPTION
This adds `$>` as an alternative to the `do` keyword in mutation lines (and `$>>` as an alternative to `do!`).

For example:

```
Nathan: Hello Coco!
$> nathan.wave()
Coco: Hello Nathan!
```