### PR TITLE
Add options for configuring response menu focus

### DIFF
--- a/addons/dialogue_manager/dialogue_responses_menu.gd
+++ b/addons/dialogue_manager/dialogue_responses_menu.gd
@@ -17,51 +17,22 @@ signal response_selected(response: Control)
 ## The action for accepting a response (is possibly overridden by parent dialogue balloon).
 @export var next_action: StringName = &""
 
+## Automatically set up focus neighbours when the responses list changes.
+@export var auto_configure_focus: bool = true
+
+## Automatically focus the first item when showing.
+@export var auto_focus_first_item: bool = true
+
 ## Hide any responses where [code]is_allowed[/code] is false
 @export var hide_failed_responses: bool = false
 
 ## The list of dialogue responses.
 var responses: Array = []:
-	get:
-		return responses
 	set(value):
 		responses = value
-
-		# Remove any current items
-		for item in get_children():
-			if item == response_template: continue
-
-			remove_child(item)
-			item.queue_free()
-
-		# Add new items
-		if responses.size() > 0:
-			for response in responses:
-				if hide_failed_responses and not response.is_allowed: continue
-
-				var item: Control
-				if is_instance_valid(response_template):
-					item = response_template.duplicate(DUPLICATE_GROUPS | DUPLICATE_SCRIPTS | DUPLICATE_SIGNALS)
-					item.show()
-				else:
-					item = Button.new()
-				item.name = "Response%d" % get_child_count()
-				if not response.is_allowed:
-					item.name = item.name + &"Disallowed"
-					item.disabled = true
-
-				# If the item has a response property then use that
-				if "response" in item:
-					item.response = response
-				# Otherwise assume we can just set the text
-				else:
-					item.text = response.text
-
-				item.set_meta("response", response)
-
-				add_child(item)
-
-			_configure_focus()
+		_apply_responses()
+	get:
+		return responses
 
 # The previously focused item in this menu.
 var _previously_focused_item: Control = null
@@ -69,7 +40,7 @@ var _previously_focused_item: Control = null
 
 func _ready() -> void:
 	visibility_changed.connect(func():
-		if visible and get_menu_items().size() > 0:
+		if auto_focus_first_item and visible and get_menu_items().size() > 0:
 			var first_item: Control = get_menu_items()[0]
 			if first_item.is_inside_tree():
 				first_item.grab_focus()
@@ -92,11 +63,8 @@ func get_menu_items() -> Array:
 	return items
 
 
-#region Internal
-
-
-# Prepare the menu for keyboard and mouse navigation.
-func _configure_focus() -> void:
+## Prepare the menu for keyboard and mouse navigation.
+func configure_focus() -> void:
 	var items = get_menu_items()
 	for i in items.size():
 		var item: Control = items[i]
@@ -128,7 +96,52 @@ func _configure_focus() -> void:
 		item.gui_input.connect(_on_response_gui_input.bind(item, item.get_meta("response")))
 
 	_previously_focused_item = items[0]
-	items[0].grab_focus()
+
+	if auto_focus_first_item:
+		items[0].grab_focus()
+
+
+#region Internal
+
+
+# Set up the visual side of things.
+func _apply_responses() -> void:
+	# Remove any current items
+	for item in get_children():
+		if item == response_template: continue
+
+		remove_child(item)
+		item.queue_free()
+
+	# Add new items
+	if responses.size() > 0:
+		for response in responses:
+			if hide_failed_responses and not response.is_allowed: continue
+
+			var item: Control
+			if is_instance_valid(response_template):
+				item = response_template.duplicate(DUPLICATE_GROUPS | DUPLICATE_SCRIPTS | DUPLICATE_SIGNALS)
+				item.show()
+			else:
+				item = Button.new()
+			item.name = "Response%d" % get_child_count()
+			if not response.is_allowed:
+				item.name = item.name + &"Disallowed"
+				item.disabled = true
+
+			# If the item has a response property then use that
+			if "response" in item:
+				item.response = response
+			# Otherwise assume we can just set the text
+			else:
+				item.text = response.text
+
+			item.set_meta("response", response)
+
+			add_child(item)
+
+		if auto_configure_focus:
+			configure_focus()
 
 
 #endregion

--- a/addons/dialogue_manager/example_balloon/example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/example_balloon.tscn
@@ -63,6 +63,20 @@ MarginContainer/constants/margin_right = 30
 MarginContainer/constants/margin_top = 15
 PanelContainer/styles/panel = SubResource("StyleBoxFlat_qkmqt")
 
+[sub_resource type="Animation" id="Animation_nlsx6"]
+length = 0.001
+tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Progress:position:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+
 [sub_resource type="Animation" id="Animation_qkmqt"]
 resource_name = "progress"
 loop_mode = 1
@@ -77,20 +91,6 @@ tracks/0/keys = {
 "handle_modes": PackedInt32Array(0, 0, 0, 0, 0),
 "points": PackedFloat32Array(0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.2, -0.0157438, -4, -0.2, 0.0112069, 0.25, 0, -4, -0.25, 0, 0.25, 0, 0, -0.2, 0.00299701, 0.25, 0),
 "times": PackedFloat32Array(0, 0.1, 0.5, 0.6, 1)
-}
-
-[sub_resource type="Animation" id="Animation_nlsx6"]
-length = 0.001
-tracks/0/type = "bezier"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("Progress:position:y")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"handle_modes": PackedInt32Array(0),
-"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
-"times": PackedFloat32Array(0)
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_1337t"]


### PR DESCRIPTION
This adds options to the `DialogueResponsesMenu` node for disabling auto-configured focus neighbours:

<img width="375" height="92" alt="image" src="https://github.com/user-attachments/assets/3081f799-7403-436b-a9cd-53e476c660d7" />
