### PR TITLE
**fix(parser,tests): lock `[wait]` semantics; compute `pauses` from m…

### DIFF
--- a/tests/test_extracting_markers.gd
+++ b/tests/test_extracting_markers.gd
@@ -22,6 +22,30 @@ func test_can_handle_wait_tags() -> void:
 	assert(data.pauses[13] == 1.2, "Should be at position 13 for 1.2s.")
 
 
+# Add: explicit contract—numeric waits MUST surface in pauses AND in mutations.
+func test_can_handle_wait_time_tags() -> void:
+	var data = _extract("Nathan: [wave]Hey![/wave] [wait=1.2]WAIT!")
+	assert(data.pauses.size() == 1)
+	assert(data.pauses[13] == 1.2)
+	assert(data.mutations.size() == 1)
+	var mutation = data.mutations[0]
+	assert(mutation[0] == 13)
+	assert("expression" in mutation[1])
+	assert(mutation[1]["expression"][0]["function"] == "wait")
+	assert(mutation[1]["expression"][0]["value"][0][0]["value"] == 1.2)
+
+# Add: input waits do NOT appear in pauses; they live in mutations with the action string.
+func test_can_handle_wait_input_tags() -> void:
+	var data = _extract("Nathan: [wave]Hey![/wave] [wait=\"ui_accept\"]WAIT!")
+	assert(data.pauses.size() == 0)
+	assert(data.mutations.size() == 1)
+	var mutation = data.mutations[0]
+	assert(mutation[0] == 13)
+	assert("expression" in mutation[1])
+	assert(mutation[1]["expression"][0]["function"] == "wait")
+	assert(mutation[1]["expression"][0]["value"][0][0]["value"] == "ui_accept")
+
+
 func test_can_handle_speed_tags() -> void:
 	var data = _extract("Nathan: [wave]Hey![/wave] [speed=0.1]WAIT!")
 


### PR DESCRIPTION
## Summary

This PR builds on the work in [#970](https://github.com/nathanhoad/godot_dialogue_manager/pull/970) (thanks @TrentSterling 🙌).

- **resolved_line_data.gd**
  - Added a computed `pauses` property (getter only).
  - Implemented `_compute_pauses()` + `_unwrap_wait_value()` to derive `pauses` from `mutations`.
  - Ensures only **numeric** `[wait=…]` values appear in `pauses` (back-compat).
  - Input waits (e.g. `[wait="ui_accept"]`) are excluded from `pauses` but remain in `mutations` as the authoritative runtime source.

- **tests**
  - Kept the legacy `test_can_handle_wait_tags`.  
    > I didn’t feel comfortable deleting it outright since it still asserts back-compat.  
  - Added `test_can_handle_wait_time_tags` to make numeric `[wait]` expectations explicit.
  - Added `test_can_handle_wait_input_tags` to cover input waits, verifying they are omitted from `pauses` but included in `mutations`.

## Rationale

- Prevent regressions: `pauses` remains numeric-only, but `mutations` is the true runtime source of truth.  
- Document the intended split while keeping older consumers working without changes.  
- Clarify semantics so contributors don’t confuse numeric pauses with input waits.

## Breaking changes

None — behavior and indices preserved; `pauses` is computed, not stored.

<img width="1173" height="666" alt="Tests Results" src="https://github.com/user-attachments/assets/d49f6af0-74aa-4da3-be7b-0d281996709b" />

