### PR TITLE
Add shortcuts for bold and italic bbcodes

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -100,6 +100,12 @@ func _gui_input(event: InputEvent) -> void:
 			"text_size_reset":
 				self.font_size = theme_overrides.font_size
 				get_viewport().set_input_as_handled()
+			"make_bold":
+				insert_bbcode("[b]", "[/b]")
+				get_viewport().set_input_as_handled()
+			"make_italic":
+				insert_bbcode("[i]", "[/i]")
+				get_viewport().set_input_as_handled()
 
 	elif event is InputEventMouse:
 		match event.as_text():

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -205,17 +205,25 @@ func get_editor_shortcuts() -> Dictionary:
 		],
 		text_size_reset = [
 			_create_event("Ctrl+0")
+		],
+
+		make_bold = [
+			_create_event("Ctrl+Shift+b")
+		],
+		make_italic = [
+			_create_event("Ctrl+Shift+i")
 		]
 	}
 
 	var paths = EditorInterface.get_editor_paths()
-	var settings
-	if FileAccess.file_exists(paths.get_config_dir() + "/editor_settings-4.3.tres"):
-		settings = load(paths.get_config_dir() + "/editor_settings-4.3.tres")
-	elif FileAccess.file_exists(paths.get_config_dir() + "/editor_settings-4.tres"):
-		settings = load(paths.get_config_dir() + "/editor_settings-4.tres")
-	else:
-		return shortcuts
+	var settings: Resource = null
+	for version in ["4.5", "4.4", "4.3", "4"]:
+		var path: String = paths.get_config_dir() + "/editor_settings-" + version + ".tres"
+		if FileAccess.file_exists(path):
+			settings = load(path)
+			break
+
+	if settings == null: return shortcuts
 
 	for s in settings.get("shortcuts"):
 		for key in shortcuts:


### PR DESCRIPTION
This adds <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>b</kbd>/<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>b</kbd> for inserting bold bbcode and <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>i</kbd>/<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>i</kbd> for inserting italic.

Closes #969