### PR TITLE
Add support for simple voice overs

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -147,7 +147,20 @@ func _drop_data(at_position: Vector2, data) -> void:
 			if cursor.x > -1 and cursor.y > -1:
 				set_cursor(cursor)
 				remove_secondary_carets()
-				insert_text("\"%s\"" % file, cursor.y, cursor.x)
+				var resource = load(file)
+				# If the dropped file is an audio stream then assume it's a voice reference
+				if is_instance_of(resource, AudioStream):
+					var current_voice_regex: RegEx = RegEx.create_from_string("\\[#voice=.+\\]")
+					var path: String = ResourceUID.path_to_uid(file)
+					var line_text: String = get_line(cursor.y)
+					var voice_text: String = "[#voice=%s]" % [path]
+					if current_voice_regex.search(line_text):
+						set_line(cursor.y, current_voice_regex.replace(get_line(cursor.y), voice_text))
+					else:
+						insert_text(" " + voice_text, cursor.y, line_text.length())
+				# Other wise it's just a file reference
+				else:
+					insert_text("\"%s\"" % file, cursor.y, cursor.x)
 	grab_focus()
 
 

--- a/addons/dialogue_manager/dialogue_line.gd
+++ b/addons/dialogue_manager/dialogue_line.gd
@@ -87,8 +87,18 @@ func _to_string() -> String:
 	return ""
 
 
+## Check if a dialogue line has a given tag.
+func has_tag(tag_name: String) -> bool:
+	var wrapped: String = "%s=" % tag_name
+	for t in tags:
+		if t.begins_with(wrapped):
+			return true
+	return false
+
+
+## Get the value of a tag if the tag is in the form of [code]tag=value[/code]
 func get_tag_value(tag_name: String) -> String:
-	var wrapped := "%s=" % tag_name
+	var wrapped: String = "%s=" % tag_name
 	for t in tags:
 		if t.begins_with(wrapped):
 			return t.replace(wrapped, "").strip_edges()

--- a/addons/dialogue_manager/example_balloon/example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/example_balloon.tscn
@@ -193,5 +193,8 @@ response_template = NodePath("ResponseExample")
 layout_mode = 2
 text = "Response example"
 
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
+
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
 [connection signal="response_selected" from="Balloon/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]

--- a/addons/dialogue_manager/example_balloon/small_example_balloon.tscn
+++ b/addons/dialogue_manager/example_balloon/small_example_balloon.tscn
@@ -203,5 +203,8 @@ script = ExtResource("3_1j1j0")
 layout_mode = 2
 text = "Response Example"
 
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
+
 [connection signal="gui_input" from="Balloon" to="." method="_on_balloon_gui_input"]
 [connection signal="response_selected" from="Balloon/ResponsesMenu" to="." method="_on_responses_menu_response_selected"]


### PR DESCRIPTION
This adds support for simple voice overs. When dragging an `AudioStream` file from the file system onto a line it will insert a `[#voice=<UID>]` tag that points to the audio file's UID. The example balloon will also now check for those tags and play them as voice lines, wait for them to finish, and then auto advance to the next line.