### PR TITLE
Save open buffers when running project

### DIFF
--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -127,6 +127,10 @@ func _apply_changes() -> void:
 
 
 func _save_external_data() -> void:
+	if is_instance_valid(main_view) and EditorInterface.get_editor_settings().get_setting("run/auto_save/save_before_running"):
+		main_view.apply_changes()
+		_update_localization()
+
 	if dialogue_cache != null:
 		dialogue_cache.reimport_files()
 

--- a/addons/dialogue_manager/utilities/dialogue_cache.gd
+++ b/addons/dialogue_manager/utilities/dialogue_cache.gd
@@ -37,7 +37,7 @@ func reimport_files(and_files: PackedStringArray = []) -> void:
 	for file in and_files:
 		if not _files_marked_for_reimport.has(file):
 			_files_marked_for_reimport.append(file)
-	
+
 	if _files_marked_for_reimport.is_empty(): return
 
 	EditorInterface.get_resource_filesystem().reimport_files(_files_marked_for_reimport)


### PR DESCRIPTION
This will now check for the "run/auto_save/save_before_running" editor setting and, if enabled, will auto-save dialogue files when running the project.

Closes #998 