### PR TITLE
Allow pre/post processing lines during compilation

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -25,6 +25,14 @@ var data: Dictionary = {}
 
 #endregion
 
+#region External processing
+
+
+var processor: DMDialogueProcessor = null
+
+
+#endregion
+
 #region Internal variables
 
 
@@ -220,7 +228,7 @@ func build_line_tree(raw_lines: PackedStringArray) -> DMTreeLine:
 	var autoload_names: PackedStringArray = get_autoload_names()
 
 	for i in range(0, raw_lines.size()):
-		var raw_line: String = raw_lines[i]
+		var raw_line: String = get_processor()._preprocess_line(raw_lines[i])
 		var tree_line: DMTreeLine = DMTreeLine.new(str(i - _imported_line_count))
 
 		tree_line.line_number = i + 1
@@ -354,6 +362,9 @@ func parse_line_tree(root: DMTreeLine, parent: DMCompiledLine = null) -> Array[D
 
 		# Main line map is keyed by ID
 		lines[line.id] = line
+
+		# Apply any post-processing.
+		get_processor()._process_line(line)
 
 		# Returned lines order is preserved so that it can be used for compiling children
 		compiled_lines.append(line)
@@ -927,6 +938,14 @@ func extract_import_path_and_name(line: String) -> Dictionary:
 		}
 	else:
 		return {}
+
+
+## Load the configured processor (or the default one is none configured).
+func get_processor() -> DMDialogueProcessor:
+	if processor == null:
+		var processor_path: String = DMSettings.get_setting(DMSettings.DIALOGUE_PROCESSOR_PATH, "")
+		processor = DMDialogueProcessor.new() if processor_path.is_empty() else load(processor_path).new()
+	return processor
 
 
 ## Get the indent of a raw line

--- a/addons/dialogue_manager/dialogue_processor.gd
+++ b/addons/dialogue_manager/dialogue_processor.gd
@@ -1,0 +1,11 @@
+class_name DMDialogueProcessor extends RefCounted
+
+
+## Override to modify the incoming raw string.
+func _preprocess_line(raw_line: String) -> String:
+	return raw_line
+
+
+## Override to modify the outgoing dialogue line.
+func _process_line(line: DMCompiledLine) -> void:
+	pass

--- a/addons/dialogue_manager/dialogue_processor.gd.uid
+++ b/addons/dialogue_manager/dialogue_processor.gd.uid
@@ -1,0 +1,1 @@
+uid://m3b28rmso14t

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -26,6 +26,9 @@ const INCLUDE_NOTES_IN_TRANSLATION_EXPORTS = "editor/translations/include_notes_
 ## Automatically update the project's list of translatable files when dialogue files are added or removed
 const UPDATE_POT_FILES_AUTOMATICALLY = "editor/translations/update_pot_files_automatically"
 
+## A processor handling special case compilation.
+const DIALOGUE_PROCESSOR_PATH = "editor/advanced/dialogue_processor_path"
+
 ## A custom test scene to use when testing dialogue.
 const CUSTOM_TEST_SCENE_PATH = "editor/advanced/custom_test_scene_path"
 ## Extra script files to include in the auto-complete-able list
@@ -92,6 +95,14 @@ static var SETTINGS_CONFIGURATION = {
 	UPDATE_POT_FILES_AUTOMATICALLY: {
 		value = true,
 		type = TYPE_BOOL,
+		is_advanced = true
+	},
+
+	DIALOGUE_PROCESSOR_PATH: {
+		value = "",
+		type = TYPE_STRING,
+		hint = PROPERTY_HINT_FILE,
+		hint_string = "*.gd,*.cs",
 		is_advanced = true
 	},
 

--- a/docs/Processing.md
+++ b/docs/Processing.md
@@ -1,0 +1,22 @@
+# Processing
+
+It is possible to hook into the compilation process in order to modify raw line strings before they are compiled and then also modify compiled lines after they are compiled.
+
+To do so, create a script in your project that extends `DMDialogueProcessor` and then, in **Project Settings > Dialogue Manager > Editor**, point "dialogue processor path" at your script file (make sure Advanced is enabled in order to see the setting).
+
+```gdscript
+extends DMDialogueProcessor
+
+func _preprocess_line(raw_string: String) -> String:
+  # Replace all apples with oranges.
+  return raw_string.replace("apples", "oranges")
+
+
+func _process_line(line: DMCompiledLine) -> void:
+  # Make all dialogue to be spoken by Coco.
+  line.character = "Coco"
+```
+
+The `_preprocess_line` hook is given each raw line string (as a `String`) before any compilation has happened and expects the modified string to be returned.
+
+The `_process_line` hook is given each compiled line (as a `DMCompiledLine`) after it has been compiled.

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -65,6 +65,10 @@ Dialogue Manager settings are found in Project Settings at the bottom of the Gen
 
   Include a _\_notes_ column in CSV exports for doc comments.
 
+- **Dialogue Processor Path** (advanced)
+  
+  A path to a class that extends [`DMDialogueProcessor`](./Processing.md). Used for pre-processing raw lines and post-processing compiled lines.
+
 - **Custom Test Scene Path** (advanced)
 
   Use a custom test scene when running "Test" from the dialogue editor. The scene must extend `BaseDialogueTestScene`.

--- a/tests/test_compilation.gd
+++ b/tests/test_compilation.gd
@@ -44,3 +44,25 @@ func test_get_line_type() -> void:
 
 	assert(compilation.get_line_type("") == DMConstants.TYPE_UNKNOWN, "Empty should be unknown.")
 	assert(compilation.get_line_type(" ") == DMConstants.TYPE_UNKNOWN, "Empty should be unknown.")
+
+
+func test_can_use_processor() -> void:
+	compilation.processor = TestProcessor.new()
+
+	compilation.compile("
+~ start
+Nathan: {macro}.
+Nathan: Or is it Coco?
+=> END")
+
+	assert(compilation.lines["2"].text == "SOMETHING.", "Should replace macro.")
+	assert(compilation.lines["2"].character == "Coco", "Should replace character.")
+	assert(compilation.lines["3"].character == "Coco", "Should replace character.")
+
+
+class TestProcessor extends DMDialogueProcessor:
+	func _preprocess_line(raw_line: String) -> String:
+		return raw_line.replace("{macro}", "SOMETHING")
+
+	func _process_line(line: DMCompiledLine) -> void:
+		line.character = "Coco"


### PR DESCRIPTION
This adds hooks for modifying lines during compilation. To use it, create a new script file in your project that extends `DMDialogueProcessor` and override the relevant hook/s that you need:

- `func _preprocess_line(raw_line: String) -> String` can be used to replace content on a raw line string before it gets compiled.
- `func _process_line(line: DMCompiledLine) -> void` can be used to modify a compiled line after it has been compiled.

Then, in **Project Settings > Dialogue Manager > Editor** point the "Dialogue Processor Path" to your script file.

Related to #997