### PR TITLE
Update docs to show dictionaries in extra_game_states

### DIFF
--- a/docs/Conditions_Mutations.md
+++ b/docs/Conditions_Mutations.md
@@ -109,7 +109,7 @@ Inline mutations that use `await` in their implementation will pause typing of d
 
 ### Extra Game States
 
-You can pass an array of nodes/objects as the `extra_game_states` parameter when [requesting a line of dialogue](API.md#func-get_next_dialogue_lineresource-resource-key-string--0-extra_game_states-array-----dictionary) which will also be checked for possible mutation methods. Classes should be instantiated, even if their contents are static. Here is an example:
+You can pass an array of nodes/objects/dictionaries as the `extra_game_states` parameter when [requesting a line of dialogue](API.md#func-get_next_dialogue_lineresource-resource-key-string--0-extra_game_states-array-----dictionary) which will also be checked for possible mutation methods. Classes should be instantiated, even if their contents are static. Objects are iterated through in the order provided looking for a matching property. Here is an example:
 ```
 func pirate():
     print("yarrr")
@@ -121,16 +121,17 @@ class GameStateClass:
 
 func _ready() -> void:
     # GameStateClass.new(), not GameStateClass!
-    DialogueManager.show_example_dialogue_balloon(load("res://main.dialogue"), "start", [self, GameStateClass.new()]) 
+    DialogueManager.show_example_dialogue_balloon(load("res://main.dialogue"), "start", [self, { "game" = GameStateClass.new() }]) 
 ```
 
-On the dialogue end, you currently cannot reference the state itself by name, however all of the functions therein should be functional and exposed to the context. The following example script works when called with the above context.
+On the dialogue end, you can call functions directly from objects passed in (for example: `self.pirate()` can be called as `do pirate()`) or through dereference of member variables or dictionary keys (for example: `do game.hello()`):
+
 ```
 ~ start
-do hello()
+do game.hello()
 do pirate()
-set pirate_name = "delilah"
-do debug(pirate_name)
+set game.pirate_name = "delilah"
+do debug(game.pirate_name)
 => END
 ```
 


### PR DESCRIPTION
Expand usage of dictionaries in extra_game_states so that it's clear how they can be used to create named scopes for function invocations.