### PR TITLE
Add documentation for "locals"

### DIFF
--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -127,6 +127,8 @@ Similarly, if the name of a character is based on a variable you can provide it 
 
 If you need temporary variables that only exist during a dialogue conversation, you can use locals. Locals are temporary variables that only live for the current conversation. When the conversation ends or changes dialogue files, the variables are deleted.
 
+_Note: `locals` is a feature provided by the example balloon as a demonstration of handling temporary state, not a built-in feature of Dialogue Manager itself._
+
 You can create local variables in two ways:
 
 1. **Setting them within dialogue** using `set` or `do`:

--- a/docs/Conditions_Mutations.md
+++ b/docs/Conditions_Mutations.md
@@ -135,7 +135,7 @@ do debug(game.pirate_name)
 => END
 ```
 
-Extra game states are similar to locals in that they only exist during the current conversation. The key difference is that extra game states are accessed directly by name (e.g., `level`), while variables created with `set locals.variable_name = value` must always be prefixed with `locals.` (e.g., `locals.counter`).
+Extra game states provide references to objects, nodes, or dictionaries that exist outside the dialogue system. Changes made to their properties will persist after the conversation ends. The main difference from locals is that extra game states are accessed directly by name (e.g., `level`), while variables created with `set locals.variable_name = value` must always be prefixed with `locals.` (e.g., `locals.counter`).
 
 ### Signals
 


### PR DESCRIPTION
## Summary
This PR adds documentation for using local variables in dialogue sessions, making them more visible for everyone.
I hope it helps everyone in their games as well as it helped with mine.


__ 

## Changed
- Updated `docs/Basic_Dialogue.md`
- Added a new page: `docs/Local_Variables.md`

__

## Notes
This is a follow-up to my previous branch: https://github.com/nathanhoad/godot_dialogue_manager/pull/1008 which added a redundant feature.

Adding this as requested from @Fireye04 .