### PR TITLE
Clip contents of editor window to stop overlapping UI

### DIFF
--- a/addons/dialogue_manager/views/main_view.tscn
+++ b/addons/dialogue_manager/views/main_view.tscn
@@ -38,6 +38,7 @@ image = SubResource("Image_y6rqu")
 script = ExtResource("7_necsa")
 
 [node name="MainView" type="Control"]
+clip_contents = true
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION
Fixes #1009 

Allows editor window to clip contents so overflow is simply cut rather than drawn over the editor. 

Functions perfectly normally in godot 4.5.1, and fixes the visual glitch present in 4.6