### PR TITLE
Add types to files outside the addons directory

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -99,7 +99,7 @@ func _notification(what: int) -> void:
 	## Detect a change of locale and update the current dialogue line to show the new language
 	if what == NOTIFICATION_TRANSLATION_CHANGED and _locale != TranslationServer.get_locale() and is_instance_valid(dialogue_label):
 		_locale = TranslationServer.get_locale()
-		var visible_ratio = dialogue_label.visible_ratio
+		var visible_ratio: float = dialogue_label.visible_ratio
 		dialogue_line = await dialogue_resource.get_next_dialogue_line(dialogue_line.id)
 		if visible_ratio < 1:
 			dialogue_label.skip_typing()
@@ -154,7 +154,7 @@ func apply_dialogue_line() -> void:
 		balloon.focus_mode = Control.FOCUS_NONE
 		responses_menu.show()
 	elif dialogue_line.time != "":
-		var time = dialogue_line.text.length() * 0.02 if dialogue_line.time == "auto" else dialogue_line.time.to_float()
+		var time: float = dialogue_line.text.length() * 0.02 if dialogue_line.time == "auto" else dialogue_line.time.to_float()
 		await get_tree().create_timer(time).timeout
 		next(dialogue_line.next_id)
 	else:

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,11 @@ StateForTests="*res://tests/state_for_tests.gd"
 CSharpState="*res://tests/CSharpState.cs"
 DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
 
+[debug]
+
+gdscript/warnings/untyped_declaration=2
+gdscript/warnings/inferred_declaration=2
+
 [dialogue_manager]
 
 runtime/advanced/uses_dotnet=true

--- a/tests/some_class.gd
+++ b/tests/some_class.gd
@@ -1,6 +1,6 @@
 class_name SomeClass extends RefCounted
 
 
-const SOME_CONST = "constant"
+const SOME_CONST: String = "constant"
 
 static var some_static_property: int = 27

--- a/tests/state_for_tests.gd
+++ b/tests/state_for_tests.gd
@@ -8,7 +8,7 @@ var dictionary: Dictionary = {}
 
 var jump_target: String = "start"
 
-var something_null = null
+var something_null: Variant = null
 
 var thing: SomeClass = SomeClass.new()
 

--- a/tests/test_dialogue_label.gd
+++ b/tests/test_dialogue_label.gd
@@ -41,7 +41,7 @@ func test_inline_mutations() -> void:
 		counter = 0
 	}
 
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: This line has[set counter += 1][set counter += 10] two mutations.
 => END")

--- a/tests/test_extracting_markers.gd
+++ b/tests/test_extracting_markers.gd
@@ -10,17 +10,17 @@ func _resolve(text: String) -> DMResolvedLineData:
 
 
 func test_ignores_rich_text_bbcode() -> void:
-	var data = _extract("This is [wait=1]some [color=blue]blue[/color] text.")
+	var data: DMResolvedLineData = _extract("This is [wait=1]some [color=blue]blue[/color] text.")
 
 	assert(data.text == "This is some [color=blue]blue[/color] text.", "It should only contain BBCode.")
 
 
 func test_can_handle_wait_time_tags() -> void:
-	var data = _extract("Nathan: [wave]Hey![/wave] [wait=1.2]WAIT!")
+	var data: DMResolvedLineData = _extract("Nathan: [wave]Hey![/wave] [wait=1.2]WAIT!")
 
 	assert(data.mutations.size() == 1, "Should have 1 mutation.")
 
-	var mutation = data.mutations[0]
+	var mutation: Array = data.mutations[0]
 
 	assert(mutation[0] == 13, "Should be at position 13")
 
@@ -31,11 +31,11 @@ func test_can_handle_wait_time_tags() -> void:
 
 
 func test_can_handle_wait_input_tags() -> void:
-	var data = _extract("Nathan: [wave]Hey![/wave] [wait=\"ui_accept\"]WAIT!")
+	var data: DMResolvedLineData = _extract("Nathan: [wave]Hey![/wave] [wait=\"ui_accept\"]WAIT!")
 
 	assert(data.mutations.size() == 1, "Should have 1 mutation.")
 
-	var mutation = data.mutations[0]
+	var mutation: Array = data.mutations[0]
 
 	assert(mutation[0] == 13, "Should be at position 13")
 
@@ -46,18 +46,18 @@ func test_can_handle_wait_input_tags() -> void:
 
 
 func test_can_handle_speed_tags() -> void:
-	var data = _extract("Nathan: [wave]Hey![/wave] [speed=0.1]WAIT!")
+	var data: DMResolvedLineData = _extract("Nathan: [wave]Hey![/wave] [speed=0.1]WAIT!")
 
 	assert(data.speeds.size() == 1, "Should have 1 speed change.")
 	assert(data.speeds[13] == 0.1, "Should be at position 13 for a speed of 0.1.")
 
 
 func test_can_handle_inline_mutations() -> void:
-	var data = _extract("Nathan: [wave]Hey![/wave] [do something()]DO SOMETHING!")
+	var data: DMResolvedLineData = _extract("Nathan: [wave]Hey![/wave] [do something()]DO SOMETHING!")
 
 	assert(data.mutations.size() == 1, "Should have 1 mutation.")
 
-	var mutation = data.mutations[0]
+	var mutation: Array = data.mutations[0]
 
 	assert(mutation[0] == 13, "Should be at position 13.")
 	assert("expression" in mutation[1], "Should have an expression.")
@@ -66,8 +66,8 @@ func test_can_handle_inline_mutations() -> void:
 
 	assert(data.mutations.size() == 2, "Should have 2 mutations")
 
-	var mutation_1 = data.mutations[0]
-	var mutation_2 = data.mutations[1]
+	var mutation_1: Array = data.mutations[0]
+	var mutation_2: Array = data.mutations[1]
 
 	assert(mutation_1[0] == 13, "Should be at position 13.")
 	assert("expression" in mutation_1[1], "Should have an expression.")
@@ -76,14 +76,14 @@ func test_can_handle_inline_mutations() -> void:
 
 
 func test_mutations_can_have_errors() -> void:
-	var data = _extract("Nathan: [wave]Hey![/wave] [do incomplete(]This is an error?")
+	var data: DMResolvedLineData = _extract("Nathan: [wave]Hey![/wave] [do incomplete(]This is an error?")
 
 	assert("error" in data.mutations[0][1], "Should have an error.")
 	assert(data.mutations[0][1].error == DMConstants.ERR_UNEXPECTED_END_OF_EXPRESSION, "Should have an error.")
 
 
 func test_can_resolve_inline_conditions() -> void:
-	var data = await _resolve("Nathan: [if false]I won't say this[/if][if true]I will say this[/if].")
+	var data: DMResolvedLineData = await _resolve("Nathan: [if false]I won't say this[/if][if true]I will say this[/if].")
 	assert(data.text == "I will say this.", "Should resolve condition.")
 
 	data = await _resolve("Nathan: What I'm saying is [if true]true[else]false[/if].")
@@ -91,5 +91,5 @@ func test_can_resolve_inline_conditions() -> void:
 
 
 func test_can_handle_escaped_brackets() -> void:
-	var data = await _resolve("Nathan: This[wait=1] is a \\[[color=lime]special[/color]\\] thing")
+	var data: DMResolvedLineData = await _resolve("Nathan: This[wait=1] is a \\[[color=lime]special[/color]\\] thing")
 	assert(data.text == "This is a [[color=lime]special[/color]] thing")

--- a/tests/test_jumps.gd
+++ b/tests/test_jumps.gd
@@ -2,7 +2,7 @@ extends AbstractTest
 
 
 func test_can_parse_jumps() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 Nathan: Responses?
 - Simple => start
@@ -41,7 +41,7 @@ Nathan: After
 
 
 func test_can_run_jumps() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: Start.
 - Simple => start
@@ -53,7 +53,7 @@ Nathan: After 2.
 ~ snippet
 Nathan: Snippet.")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 
 	line = await resource.get_next_dialogue_line(line.responses[0].next_id)
 	assert(line.text == "Start.", "Simple jump should point back to start.")
@@ -91,7 +91,7 @@ Nathan: After
 
 
 func test_can_parse_expression_jumps() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 Nathan: Restart?
 => {{StateForTests.jump_target}}")
@@ -111,7 +111,7 @@ Nathan: Restart?
 
 
 func test_can_run_expression_jumps() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: Start.
 Nathan: Restart?
@@ -119,7 +119,7 @@ Nathan: Restart?
 
 	StateForTests.jump_target = "start"
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Start.", "Line should be first line.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)

--- a/tests/test_responses.gd
+++ b/tests/test_responses.gd
@@ -2,7 +2,7 @@ extends AbstractTest
 
 
 func test_can_parse_responses() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 Nathan: Here are some options.
 - Simple
@@ -14,7 +14,7 @@ Nathan: Line after.")
 
 	assert(output.errors.is_empty(), "Should be no errors.")
 
-	var responses = output.lines.values().filter(func(line): return line.type == DMConstants.TYPE_RESPONSE)
+	var responses: Array = output.lines.values().filter(func(line: Dictionary) -> bool: return line.type == DMConstants.TYPE_RESPONSE)
 
 	assert(responses.size() == 4, "Should have 4 responses.")
 	assert(responses[0].text == "Simple", "Should match text")
@@ -58,7 +58,7 @@ Nathan: Responses.
 
 
 func test_can_parse_responses_with_static_ids() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 Nathan: Here are some responses. [ID:HERE]
 - First [ID:FIRST]
@@ -70,7 +70,7 @@ Nathan: Here are some responses. [ID:HERE]
 
 
 func test_can_have_responses_without_dialogue() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 Nathan: Hello.
 do StateForTests.noop()
 - First
@@ -80,7 +80,7 @@ do StateForTests.noop()
 	assert(output.errors.size() == 0, "Should have no errors.")
 	assert(output.lines["2"].next_id == "3", "Mutation should point to first response.")
 
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: Hello.
 do StateForTests.noop()
@@ -88,7 +88,7 @@ do StateForTests.noop()
 - Second
 - Third")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Hello.", "Should start with hello.")
 	line = await resource.get_next_dialogue_line(line.next_id)
 	assert(line.type == DMConstants.TYPE_RESPONSE, "Should point to the response")
@@ -96,7 +96,7 @@ do StateForTests.noop()
 
 
 func test_can_run_responses() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: Here are some options.
 - Empty one
@@ -107,13 +107,13 @@ Nathan: Here are some options.
 - Fail condition [if false]
 Nathan: Line after.")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.responses.size() == 5, "Failed conditions are included.")
 
 	assert(line.responses[3].is_allowed == true, "Passed condition is allowed.")
 	assert(line.responses[4].is_allowed == false, "Failed condition is not allowed.")
 
-	var responses = line.responses.duplicate()
+	var responses: Array = line.responses.duplicate()
 
 	line = await resource.get_next_dialogue_line(responses[0].next_id)
 	assert(line.text == "Line after.", "First response points to the line after.")

--- a/tests/test_simultaneous_dialogue.gd
+++ b/tests/test_simultaneous_dialogue.gd
@@ -2,7 +2,7 @@ extends AbstractTest
 
 
 func test_can_parse_simultaneous_dialogue() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 Nathan: I'm saying this.
 | Coco: While I'm saying this.
@@ -40,7 +40,7 @@ Nathan: Lastly, I say this.
 
 
 func test_can_run_simultaneous_dialogue() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: I'm saying this.
 | Coco: While I'm saying this.
@@ -48,7 +48,7 @@ Nathan: I'm saying this.
 Nathan: Then I say this.
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "I'm saying this.", "Should have the correct text.")
 	assert(line.concurrent_lines.size() == 2, "Should have two concurrent lines.")
 	assert(line.concurrent_lines[0].text == "While I'm saying this.", "Should have concurrent line.")

--- a/tests/test_state.gd
+++ b/tests/test_state.gd
@@ -13,7 +13,7 @@ func _after_all() -> void:
 
 
 func test_can_parse_conditions() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 if StateForTests.some_property == 0:
 	Nathan: It is 0.
 elif StateForTests.some_property == 10:
@@ -25,7 +25,7 @@ Nathan: After.")
 	assert(output.errors.is_empty(), "Should have no errors.")
 
 	# if
-	var condition = output.lines["1"]
+	var condition: Dictionary = output.lines["1"]
 	assert(condition.type == DMConstants.TYPE_CONDITION, "Should be a condition.")
 	assert(condition.next_id == "2", "Should point to next line.")
 	assert(condition.next_sibling_id == "3", "Should reference elif.")
@@ -56,7 +56,7 @@ Nathan: After")
 
 
 func test_can_group_conditions() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 if false
 	Nathan: False
@@ -73,7 +73,7 @@ else
 
 
 func test_ignore_escaped_conditions() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 \\if this is dialogue.
 \\elif this too.
 \\else and this one.")
@@ -91,7 +91,7 @@ func test_ignore_escaped_conditions() -> void:
 
 
 func test_can_run_conditions() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 if StateForTests.some_property == 0:
 	Nathan: It is 0.
@@ -101,7 +101,7 @@ else:
 	Nathan: It is something else.")
 
 	StateForTests.some_property = 0
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "It is 0.", "Should match if condition.")
 
 	StateForTests.some_property = 11
@@ -114,7 +114,7 @@ else:
 
 
 func test_can_parse_while_loops() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 Before
 while true
 	During 1
@@ -130,7 +130,7 @@ After")
 
 
 func test_can_run_while_loops() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Before
 while StateForTests.some_property < 2
@@ -139,7 +139,7 @@ while StateForTests.some_property < 2
 After")
 
 	StateForTests.some_property = 0
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Before", "Should be before while loop.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
@@ -153,7 +153,7 @@ After")
 
 
 func test_can_parse_match_statements() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 Before
 match StateForTests.some_property
 	when 1
@@ -178,7 +178,7 @@ After")
 
 
 func test_can_run_match_cases() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Before
 match StateForTests.some_property + 1
@@ -193,7 +193,7 @@ match StateForTests.some_property + 1
 After")
 
 	StateForTests.some_property = 1
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Before", "Should be before match.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
@@ -264,13 +264,13 @@ After")
 
 
 func test_can_parse_mutations() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 $> StateForTests.some_property = StateForTests.some_method(-10, \"something\")
 $> long_mutation()")
 
 	assert(output.errors.is_empty(), "Should have no errors.")
 
-	var mutation = output.lines["1"]
+	var mutation: Dictionary = output.lines["1"]
 	assert(mutation.type == DMConstants.TYPE_MUTATION, "Should be a mutation.")
 
 	mutation = output.lines["2"]
@@ -278,7 +278,7 @@ $> long_mutation()")
 
 
 func test_can_run_mutations() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 $> StateForTests.some_property = StateForTests.some_method(-10, \"something\")
 $> StateForTests.some_property += 5-10
@@ -290,7 +290,7 @@ Nathan: Done.")
 
 	StateForTests.some_property = 0
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(StateForTests.some_property == StateForTests.some_method(-10, "something") + 5-10, "Should have updated the property.")
 
 	var started_at: float = Time.get_unix_time_from_system()
@@ -300,13 +300,13 @@ Nathan: Done.")
 
 
 func test_can_run_non_blocking_mutations() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: This mutation should not wait.
 $>> StateForTests.long_mutation()
 Nathan: Done.")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 
 	var started_at: float = Time.get_unix_time_from_system()
 	line = await resource.get_next_dialogue_line(line.next_id)
@@ -315,12 +315,12 @@ Nathan: Done.")
 
 
 func test_can_run_non_blocking_inline_mutations() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: This mutation [$> StateForTests.long_mutation()]should wait.
 Nathan: This one [$>> StateForTests.long_mutation()]won't.")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	dialogue_label.dialogue_line = line
 	var started_at: float = Time.get_unix_time_from_system()
 	dialogue_label.type_out()
@@ -340,16 +340,16 @@ Nathan: This one [$>> StateForTests.long_mutation()]won't.")
 
 
 func test_can_run_mutations_with_typed_arrays() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: {{StateForTests.typed_array_method([-1, 27], [\"something\"], [{ \"key\": \"value\" }])}}")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "[-1, 27][\"something\"][{ \"key\": \"value\" }]", "Should match output.")
 
 
 func test_can_run_expressions() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 $> StateForTests.some_property = 10 * 2-1.5 / 2 + (5 * 5)
 Nathan: Done.")
@@ -362,14 +362,14 @@ Nathan: Done.")
 
 
 func test_can_use_extra_state() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: {{extra_value}}
 $> extra_value = 10")
 
-	var extra_state = { extra_value = 5 }
+	var extra_state: Dictionary = { extra_value = 5 }
 
-	var line = await resource.get_next_dialogue_line("start", [extra_state])
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [extra_state])
 	assert(line.text == "5", "Should have initial value.")
 
 	line = await  resource.get_next_dialogue_line(line.next_id, [extra_state])
@@ -377,37 +377,37 @@ $> extra_value = 10")
 
 
 func test_can_use_using_clause() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 using StateForTests
 ~ start
 Nathan: {{some_property}}")
 
 	StateForTests.some_property = 27
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "27", "Should match property.")
 
 
 func test_can_use_color_constants() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: {{Color.BLUE}} == {{Color(0,0,1)}}")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "%s == %s" % [Color.BLUE, Color(0, 0, 1)], "Should match blue.")
 
 
 func test_can_use_vector_constants() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: {{Vector2.UP}} == {{Vector2(0, -1)}}")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "%s == %s" % [str(Vector2.UP), str(Vector2(0, -1))], "Should match up.")
 
 
 func test_can_use_lua_dictionary_syntax() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 $> StateForTests.dictionary = { key = \"value\" }
 Nathan: Stop!
@@ -417,7 +417,7 @@ $> StateForTests.dictionary.key3 = \"value3\"")
 
 	assert(StateForTests.dictionary.is_empty(), "Dictionary is empty")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(StateForTests.dictionary.size() == 1, "Dictionary has one entry")
 	assert(StateForTests.dictionary.has("key") and StateForTests.dictionary.get("key") == "value", "Dictionary should be updated.")
 
@@ -431,16 +431,16 @@ $> StateForTests.dictionary.key3 = \"value3\"")
 
 
 func test_can_use_callable() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: The number is {{Callable(StateForTests, \"some_method\").bind(\"blah\").call(10)}}.")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "The number is 40.", "Should resolve callable.")
 
 
 func test_can_warn_about_conflicts() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 using StateForTests
 ~ start
 $> some_property = 1
@@ -448,18 +448,18 @@ Value is {{some_property}}")
 
 	ProjectSettings.set_setting("dialogue_manager/runtime/warn_about_method_property_or_signal_name_conflicts", true)
 
-	var line = await resource.get_next_dialogue_line("start", [{ some_property = 1000 }])
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ some_property = 1000 }])
 	assert(line.text == "Value is 1", "Should process first occurance of property.")
 
 
 func test_can_use_self() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 $> what_is_self = self
 Nathan: That should not be null.
 => END")
 
-	var extra_state = {
+	var extra_state: Dictionary = {
 		what_is_self = null
 	}
 
@@ -468,7 +468,7 @@ Nathan: That should not be null.
 
 
 func test_can_parse_null_coalesce() -> void:
-	var output = compile("
+	var output: DMCompilerResult = compile("
 ~ start
 if StateForTests.something_null?.begins_with(\"value\") == true:
 	Nathan: Should not be here.
@@ -480,7 +480,7 @@ else:
 
 
 func test_can_handle_null_coalesce() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 if StateForTests.something_null?.begins_with(\"value\") == true:
 	Nathan: Should not be here.
@@ -488,7 +488,7 @@ else:
 	Nathan: Should be here.
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Should be here.", "Should coalesce to null and not pass condition.")
 
 	StateForTests.something_null = "value is not null"
@@ -497,7 +497,7 @@ else:
 
 
 func test_can_handle_classes() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: Is it?
 if StateForTests.is_something(StateForTests.thing, SomeClass)
@@ -509,7 +509,7 @@ if StateForTests.some_static_function()
 	Nathan: Static functions work.
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Is it?", "Should match start.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
@@ -520,20 +520,20 @@ if StateForTests.some_static_function()
 
 
 func test_can_handle_class_properties() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 ~ start
 Nathan: The constant is {{SomeClass.SOME_CONST}}.
 Nathan: The static property is {{SomeClass.some_static_property}}.
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "The constant is constant.", "Should read constant value.")
 	line = await resource.get_next_dialogue_line(line.next_id)
 	assert(line.text == "The static property is 27.", "Should read static value.")
 
 
 func test_csharp_state() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 using CSharpState
 
 ~ start
@@ -547,7 +547,7 @@ if Things.FirstThing == ThingsProperty
 	The enum value matches.
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Here first.", "Should be less than constant value first.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)
@@ -558,7 +558,7 @@ if Things.FirstThing == ThingsProperty
 
 
 func test_csharp_mutation() -> void:
-	var resource = create_resource("
+	var resource: DialogueResource = create_resource("
 using CSharpState
 
 ~ start
@@ -569,7 +569,7 @@ $> LongMutation()
 Nathan: Done!
 => END")
 
-	var line = await resource.get_next_dialogue_line("start")
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "Hello.", "Should be first line.")
 
 	line = await resource.get_next_dialogue_line(line.next_id)

--- a/tests/tests.gd
+++ b/tests/tests.gd
@@ -18,8 +18,8 @@ func _ready() -> void:
 	started_at = Time.get_ticks_msec()
 
 	var tests: PackedStringArray = Array(DirAccess.get_files_at("res://tests")) \
-		.filter(func(path: String): return path.begins_with("test_") and path.ends_with(".gd"))
-	for test in tests:
+		.filter(func(path: String) -> bool: return path.begins_with("test_") and path.ends_with(".gd"))
+	for test: String in tests:
 		await _run_tests(test)
 
 	var duration: float = (Time.get_ticks_msec() - started_at) / 1000
@@ -39,7 +39,7 @@ func _run_tests(path: String) -> void:
 
 	await node._before_all()
 
-	for method in node.get_method_list():
+	for method: Dictionary in node.get_method_list():
 		if method.name.begins_with("test_"):
 			await node._before_each()
 			await node.call(method.name)


### PR DESCRIPTION
This adds some missing types to the example balloon so that, when it gets cloned, it doesn't affect any fully typed projects.