### PR TITLE
Allow responses to have doc comments

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -102,13 +102,13 @@ func find_imported_titles(text: String, path: String) -> void:
 		else:
 			# Get titles from other file and map them to the known list of titles.
 			var imported_resource: DialogueResource = load(import_data.path)
-			
+
 			# Guard against failed loads -- namely during reimport cascade.
 			if imported_resource == null:
 				# Might be worth investigating a better constant here.
 				add_error(id, 0, DMConstants.ERR_ERRORS_IN_IMPORTED_FILE)
 				continue
-			
+
 			var uid: String = ResourceUID.path_to_uid(import_data.path).replace("uid://", "")
 			for title_key: String in imported_resource.titles:
 				# Ignore any titles that are already a reference
@@ -158,7 +158,7 @@ func build_line_tree(raw_lines: PackedStringArray) -> DMTreeLine:
 		# Attach doc comments
 		if raw_line.strip_edges().begins_with("##"):
 			doc_comments.append(raw_line.replace("##", "").strip_edges())
-		elif tree_line.type == DMConstants.TYPE_DIALOGUE:
+		elif tree_line.type == DMConstants.TYPE_DIALOGUE or tree_line.type == DMConstants.TYPE_RESPONSE:
 			tree_line.notes = "\n".join(doc_comments)
 			doc_comments.clear()
 
@@ -471,6 +471,9 @@ func parse_response_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: 
 
 	# Remove the "- "
 	tree_line.text = tree_line.text.substr(2)
+
+	# Attach any doc comments.
+	line.notes = tree_line.notes
 
 	# Extract the static line ID
 	var static_line_id: String = extract_static_line_id(tree_line.text)

--- a/tests/test_notes.gd
+++ b/tests/test_notes.gd
@@ -1,0 +1,23 @@
+extends AbstractTest
+
+
+func test_has_notes() -> void:
+	var output: DMCompilerResult = compile("
+~ start
+## Dialogue comment
+Nathan: Some Dialogue
+## Multi
+## Line
+## Comment
+Nathan: More dialogue
+## Response comment
+- Response 1
+## Another response
+## comment
+- Response 2
+=> END")
+
+	assert(output.lines["3"].notes == "Dialogue comment", "Comment should match.")
+	assert(output.lines["7"].notes == "Multi\nLine\nComment", "Comment should have 3 lines.")
+	assert(output.lines["9"].notes == "Response comment", "Response should have comment.")
+	assert(output.lines["12"].notes == "Another response\ncomment", "Response comment should have 2 lines.")

--- a/tests/test_notes.gd.uid
+++ b/tests/test_notes.gd.uid
@@ -1,0 +1,1 @@
+uid://cuit24mq8o78a


### PR DESCRIPTION
This adds support for doc comments for response lines so that they can be used as translation help.