### PR TITLE
Stop error when dragging text to move it

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -125,8 +125,10 @@ func _can_drop_data(at_position: Vector2, data) -> bool:
 	return files.size() > 0
 
 
-func _drop_data(at_position: Vector2, data) -> void:
+func _drop_data(at_position: Vector2, data: Variant) -> void:
 	var replace_regex: RegEx = RegEx.create_from_string("[^a-zA-Z_0-9]+")
+
+	if typeof(data) == TYPE_STRING: return
 
 	var files: PackedStringArray = Array(data.files)
 	for file in files:


### PR DESCRIPTION
This fixes an error that shows up in the console when dragging the selected text to reposition it.