### PR TITLE
Remove references to CSharpScript

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1491,7 +1491,7 @@ func _thing_has_method(thing, method: String, args: Array) -> bool:
 	if thing.has_method(method):
 		return true
 
-	if thing is CSharpScript:
+	if thing is Script:
 		thing = thing.new()
 	if thing.get_script() and thing.get_script().resource_path.ends_with(".cs"):
 		# If we get this far then the method might be a C# method with a Task return type
@@ -1576,7 +1576,7 @@ func _resolve_thing_method(thing, method: String, args: Array):
 		return await thing.callv(method, args)
 
 	# If we get here then it's probably a C# method with a Task return type
-	if thing is CSharpScript:
+	if thing is Script:
 		thing = thing.new()
 	var dotnet_dialogue_manager = _get_dotnet_dialogue_manager()
 	dotnet_dialogue_manager.ResolveThingMethod(thing, method, args)


### PR DESCRIPTION
This changes references from `CSharpScript` to `Script` because `CSharpScript` isn't a valid type in the non-dotnet version of Godot.