### PR TITLE
Fix warning when closing open inspector popup

### DIFF
--- a/addons/dialogue_manager/components/editor_property/editor_property.gd
+++ b/addons/dialogue_manager/components/editor_property/editor_property.gd
@@ -1,12 +1,13 @@
 @tool
-extends EditorProperty
+
+class_name DMDialogueEditorProperty extends EditorProperty
 
 
-const DialoguePropertyEditorControl = preload("./editor_property_control.tscn")
+const DialoguePropertyEditorControl: PackedScene = preload("./editor_property_control.tscn")
 
 
 var control = DialoguePropertyEditorControl.instantiate()
-var current_value: Resource
+var current_value: DialogueResource
 var is_updating: bool = false
 
 
@@ -19,7 +20,7 @@ func _init() -> void:
 
 
 func _update_property() -> void:
-	var next_value = get_edited_object()[get_edited_property()]
+	var next_value: DialogueResource = get_edited_object()[get_edited_property()]
 
 	# The resource might have been deleted elsewhere so check that it's not in a weird state
 	if is_instance_valid(next_value) and not next_value.resource_path.ends_with(".dialogue"):
@@ -37,7 +38,7 @@ func _update_property() -> void:
 #region Signals
 
 
-func _on_resource_changed(next_resource: Resource) -> void:
+func _on_resource_changed(next_resource: DialogueResource) -> void:
 	emit_changed(get_edited_property(), next_resource)
 
 

--- a/addons/dialogue_manager/components/editor_property/editor_property_control.gd
+++ b/addons/dialogue_manager/components/editor_property/editor_property_control.gd
@@ -1,17 +1,18 @@
 @tool
+
 extends HBoxContainer
 
 
 signal pressed()
-signal resource_changed(next_resource: Resource)
+signal resource_changed(next_resource: DialogueResource)
 
 
-const ITEM_NEW = 100
-const ITEM_QUICK_LOAD = 200
-const ITEM_LOAD = 201
-const ITEM_EDIT = 300
-const ITEM_CLEAR = 301
-const ITEM_FILESYSTEM = 400
+const ITEM_NEW: int = 100
+const ITEM_QUICK_LOAD: int = 200
+const ITEM_LOAD: int = 201
+const ITEM_EDIT: int = 300
+const ITEM_CLEAR: int = 301
+const ITEM_FILESYSTEM: int = 400
 
 
 @onready var button: Button = $ResourceButton
@@ -57,7 +58,7 @@ func build_menu() -> void:
 	menu.size = Vector2.ZERO
 
 
-### Signals
+#region Signals
 
 
 func _on_new_dialog_file_selected(path: String) -> void:
@@ -66,7 +67,7 @@ func _on_new_dialog_file_selected(path: String) -> void:
 	if Engine.get_meta("DMCache").has_file(path):
 		resource_changed.emit(load(path))
 	else:
-		var next_resource: Resource = await editor_plugin.import_plugin.compiled_resource
+		var next_resource: DialogueResource = await editor_plugin.import_plugin.compiled_resource
 		next_resource.resource_path = path
 		resource_changed.emit(next_resource)
 
@@ -82,6 +83,9 @@ func _on_file_dialog_canceled() -> void:
 func _on_resource_button_pressed() -> void:
 	if is_instance_valid(resource):
 		EditorInterface.call_deferred("edit_resource", resource)
+
+	elif menu.visible:
+		menu.hide()
 	else:
 		build_menu()
 		menu.position = get_viewport().position + Vector2i(
@@ -96,12 +100,15 @@ func _on_resource_button_resource_dropped(next_resource: Resource) -> void:
 
 
 func _on_menu_button_pressed() -> void:
-	build_menu()
-	menu.position = get_viewport().position + Vector2i(
-		menu_button.global_position.x + menu_button.size.x - menu.size.x,
-		2 + menu_button.global_position.y + menu_button.size.y
-	)
-	menu.popup()
+	if menu.visible:
+		menu.hide()
+	else:
+		build_menu()
+		menu.position = get_viewport().position + Vector2i(
+			menu_button.global_position.x + menu_button.size.x - menu.size.x,
+			2 + menu_button.global_position.y + menu_button.size.y
+		)
+		menu.popup()
 
 
 func _on_menu_id_pressed(id: int) -> void:
@@ -129,8 +136,7 @@ func _on_menu_id_pressed(id: int) -> void:
 			resource_changed.emit(null)
 
 		ITEM_FILESYSTEM:
-			var file_system = EditorInterface.get_file_system_dock()
-			file_system.navigate_to_path(resource.resource_path)
+			EditorInterface.get_file_system_dock().navigate_to_path(resource.resource_path)
 
 
 func _on_files_list_file_double_clicked(file_path: String) -> void:
@@ -145,3 +151,6 @@ func _on_files_list_file_selected(file_path: String) -> void:
 func _on_quick_open_dialog_confirmed() -> void:
 	if quick_selected_file != "":
 		resource_changed.emit(load(quick_selected_file))
+
+
+#endregion

--- a/addons/dialogue_manager/inspector_plugin.gd
+++ b/addons/dialogue_manager/inspector_plugin.gd
@@ -2,20 +2,16 @@
 class_name DMInspectorPlugin extends EditorInspectorPlugin
 
 
-const DialogueEditorProperty = preload("./components/editor_property/editor_property.gd")
-
-
-func _can_handle(object) -> bool:
+func _can_handle(object: Object) -> bool:
 	if object is GDScript: return false
 	if not object is Node and not object is Resource: return false
 	if "name" in object and object.name == "Dialogue Manager": return false
 	return true
 
 
-func _parse_property(object: Object, type, name: String, hint_type, hint_string: String, usage_flags: int, wide: bool) -> bool:
+func _parse_property(object: Object, type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
 	if hint_string == "DialogueResource" or ("dialogue" in name.to_lower() and hint_string == "Resource"):
-		var property_editor = DialogueEditorProperty.new()
-		add_property_editor(name, property_editor)
+		add_property_editor(name, DMDialogueEditorProperty.new())
 		return true
 
 	return false


### PR DESCRIPTION
This fixes an error that shows up when closing the `DialogueResource` property inspector dropdown menu.