### PR TITLE
Fixes property access for dictionaries

### DIFF
--- a/addons/dialogue_manager/utilities/builtins.gd
+++ b/addons/dialogue_manager/utilities/builtins.gd
@@ -52,7 +52,9 @@ static func is_supported(thing, with_method: String = "") -> bool:
 
 static func resolve_property(builtin, property: String):
 	match typeof(builtin):
-		TYPE_ARRAY, TYPE_PACKED_STRING_ARRAY, TYPE_DICTIONARY, TYPE_QUATERNION, TYPE_STRING, TYPE_STRING_NAME:
+		TYPE_DICTIONARY:
+			return builtin.get(property)
+		TYPE_ARRAY, TYPE_PACKED_STRING_ARRAY, TYPE_QUATERNION, TYPE_STRING, TYPE_STRING_NAME:
 			return builtin[property]
 
 		# Some types have constants that we need to manually resolve


### PR DESCRIPTION
###  AI Commit Overview:
Ensures that properties are accessed correctly on dictionaries by using the `get()` method instead of bracket notation.

This prevents potential errors when trying to access properties that may not exist, as `get()` will return `null` rather than throwing an error.

### My Overview:
I've been building out my dialogue options by setting `locals` variables for dialogue tracking. 

Example:
```gdscript
~ initial_questions
set locals.asked_about_alibi = false
set locals.asked_about_relationship = false
set locals.asked_about_musicbox = false
set locals.asked_about_key = false
- Where were you between 10:15 and 11:20 this morning? [if not locals.asked_about_alibi]
	set locals.asked_about_alibi = true
``` 

When attempting to access the `initial_questions` portion of my dialogue, the direct bracket access would throw an error if the key didn't exist. This caused an issue because my variables were being evaluated before the variable was set.

Using `.get()` should safely return a null value for any missing keys, so inline `if` statements don't crash before the variable is initialized. 

Original Godot Stack Trace:
```md
E 0:01:32:844   resolve_property: Invalid access to property or key 'asked_about_key' on a base object of type 'Dictionary'.
  <GDScript Source>builtins.gd:56 @ resolve_property()
  <Stack Trace> builtins.gd:56 @ resolve_property()
                dialogue_manager.gd:1141 @ _resolve()
                dialogue_manager.gd:675 @ _resolve_condition_value()
                dialogue_manager.gd:667 @ _check_condition()
                dialogue_manager.gd:758 @ _get_responses()
                dialogue_manager.gd:286 @ get_line()
                dialogue_manager.gd:104 @ get_next_dialogue_line()
                dialogue_manager.gd:126 @ get_next_dialogue_line()
                dialogue_manager.gd:126 @ get_next_dialogue_line()
                dialogue_manager.gd:126 @ get_next_dialogue_line()
                dialogue_manager.gd:126 @ get_next_dialogue_line()
                dialogue_resource.gd:33 @ get_next_dialogue_line()
                dialogue_balloon_base_script.gd:192 @ next()
                dialogue_balloon_base_script.gd:233 @ _on_balloon_gui_input()
 ``` 