### PR TITLE
Add input blocking option for example balloon

### DIFF
--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -95,7 +95,7 @@ func _process(delta: float) -> void:
 
 func _unhandled_input(_event: InputEvent) -> void:
 	# Only the balloon is allowed to handle input while it's showing
-	if is_blocking_other_input:
+	if will_block_other_input:
 		get_viewport().set_input_as_handled()
 
 


### PR DESCRIPTION
Added a new export variable to control input blocking during dialogue.

Per default, the showing dialogue balloon is always blocking any other input.
I added an exported variable that easily lets the user change this.

I only added it to the example balloon. By my understanding the "custom balloon generator" works by copying the example balloon, so this should suffice.

This is my first PR ever to any open source project EVER. I hope I did it in an ok way. Please let me know if I did anything wrong.
Keep up the good work and thank you so much :)