### PR TITLE
Fix backwards compatibility with Godot 4.4

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -109,7 +109,7 @@ func find_imported_titles(text: String, path: String) -> void:
 				add_error(id, 0, DMConstants.ERR_ERRORS_IN_IMPORTED_FILE)
 				continue
 
-			var uid: String = ResourceUID.path_to_uid(import_data.path).replace("uid://", "")
+			var uid: String = ResourceUID.id_to_text(ResourceLoader.get_resource_uid(import_data.path)).replace("uid://", "")
 			for title_key: String in imported_resource.titles:
 				# Ignore any titles that are already a reference
 				if "/" in title_key: continue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1587,7 +1587,7 @@ func _resolve_thing_property(thing: Object, property: String) -> Variant:
 
 
 func _get_resource_uid(resource: DialogueResource) -> String:
-	return ResourceUID.path_to_uid(resource.resource_path).replace("uid://", "")
+	return ResourceUID.id_to_text(ResourceLoader.get_resource_uid(resource.resource_path)).replace("uid://", "")
 
 
 func _get_id_with_resource(resource: DialogueResource, id: String) -> String:

--- a/tests/main.dialogue
+++ b/tests/main.dialogue
@@ -1,0 +1,8 @@
+import "res://tests/snippets.dialogue" as snippets
+
+
+~ start
+Nathan: Testing a snippet.
+=>< snippets/snippet
+Nathan: ...and back again.
+=> END

--- a/tests/main.dialogue.import
+++ b/tests/main.dialogue.import
@@ -1,0 +1,16 @@
+[remap]
+
+importer="dialogue_manager"
+importer_version=15
+type="Resource"
+uid="uid://bnnha7rqiubty"
+path="res://.godot/imported/main.dialogue-fdb08bf1f3a902dc953e9d549b742c4a.tres"
+
+[deps]
+
+source_file="res://tests/main.dialogue"
+dest_files=["res://.godot/imported/main.dialogue-fdb08bf1f3a902dc953e9d549b742c4a.tres"]
+
+[params]
+
+defaults=true

--- a/tests/snippets.dialogue
+++ b/tests/snippets.dialogue
@@ -1,0 +1,3 @@
+~ snippet
+Nathan: This is a snippet.
+=> END

--- a/tests/snippets.dialogue.import
+++ b/tests/snippets.dialogue.import
@@ -1,0 +1,16 @@
+[remap]
+
+importer="dialogue_manager"
+importer_version=15
+type="Resource"
+uid="uid://m7wueb1et2an"
+path="res://.godot/imported/snippets.dialogue-fef751acf14db992e43cc94dcce41bb4.tres"
+
+[deps]
+
+source_file="res://tests/snippets.dialogue"
+dest_files=["res://.godot/imported/snippets.dialogue-fef751acf14db992e43cc94dcce41bb4.tres"]
+
+[params]
+
+defaults=true

--- a/tests/test_snippets.gd
+++ b/tests/test_snippets.gd
@@ -1,0 +1,14 @@
+extends AbstractTest
+
+
+func test_can_run_snippets() -> void:
+	var resource: DialogueResource = load("res://tests/main.dialogue")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
+	assert(line.text == "Testing a snippet.", "Text should match.")
+
+	line = await resource.get_next_dialogue_line(line.next_id)
+	assert(line.text == "This is a snippet.", "Text should be from the snippets file.")
+
+	line = await resource.get_next_dialogue_line(line.next_id)
+	assert(line.text == "...and back again.")

--- a/tests/test_snippets.gd.uid
+++ b/tests/test_snippets.gd.uid
@@ -1,0 +1,1 @@
+uid://b2j0xq85ikmv


### PR DESCRIPTION
This fixes backwards compatibility with Godot 4.4 by swapping out the newer `path_to_uid` method that was introduced in Godot 4.5.