### PR TITLE
Simplify DialogueResource.to_string()

### DIFF
--- a/addons/dialogue_manager/dialogue_resource.gd
+++ b/addons/dialogue_manager/dialogue_resource.gd
@@ -39,4 +39,7 @@ func get_titles() -> PackedStringArray:
 
 
 func _to_string() -> String:
-	return "<DialogueResource titles=\"%s\">" % [",".join(titles.keys())]
+	if resource_path:
+		return "<DialogueResource path=\"%s\">" % [resource_path]
+	else:
+		return "<DialogueResource>"


### PR DESCRIPTION
This simplifies the output of a `DialogueResource`'s `to_string()` method.