### PR TITLE
Make fuzzy matching a little stricter

### DIFF
--- a/Dialogue Manager.csproj
+++ b/Dialogue Manager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.6.0">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/project.godot
+++ b/project.godot
@@ -8,19 +8,23 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="Dialogue Manager"
 config/tags=PackedStringArray("addon")
 run/main_scene="res://tests/tests.tscn"
-config/features=PackedStringArray("4.5", "C#")
+config/features=PackedStringArray("4.6", "C#")
 config/icon="res://icon.svg"
 
 [autoload]
 
 StateForTests="*res://tests/state_for_tests.gd"
 CSharpState="*res://tests/CSharpState.cs"
-DialogueManager="*res://addons/dialogue_manager/dialogue_manager.gd"
+DialogueManager="*uid://c3rodes2l3gxb"
 
 [debug]
 

--- a/tests/tests.tscn
+++ b/tests/tests.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://k2pif7ljmrxq"]
+[gd_scene format=3 uid="uid://k2pif7ljmrxq"]
 
 [ext_resource type="Script" uid="uid://cqc4dndvofmp1" path="res://tests/tests.gd" id="1_ds4fl"]
 
@@ -21,7 +21,7 @@ shadow_offset = Vector2(0, 4)
 offsets = PackedFloat32Array(0, 0.212454, 0.498168, 0.772894, 1)
 colors = PackedColorArray(0, 1, 0, 1, 0.877526, 0.403399, 0, 1, 1, 0, 0.670991, 1, 1, 0.840899, 0, 1, 0.990476, 1, 0.950589, 1)
 
-[node name="Tests" type="ColorRect"]
+[node name="Tests" type="ColorRect" unique_id=1461316828]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -31,7 +31,7 @@ theme = SubResource("Theme_mxx6t")
 color = Color(0.0705882, 0.423529, 0.2, 1)
 script = ExtResource("1_ds4fl")
 
-[node name="AllPassing" type="RichTextLabel" parent="."]
+[node name="AllPassing" type="RichTextLabel" parent="." unique_id=456647872]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -44,7 +44,7 @@ theme_override_font_sizes/normal_font_size = 100
 bbcode_enabled = true
 text = "[wave][center]All tests passed"
 
-[node name="Label" type="Label" parent="."]
+[node name="Label" type="Label" parent="." unique_id=1230363543]
 modulate = Color(1, 1, 1, 0.596078)
 layout_mode = 0
 offset_top = 260.0
@@ -54,7 +54,7 @@ theme_override_font_sizes/font_size = 30
 text = "See Output for details"
 horizontal_alignment = 1
 
-[node name="TestsCount" type="Label" parent="."]
+[node name="TestsCount" type="Label" parent="." unique_id=2040063859]
 layout_mode = 0
 offset_left = 115.0
 offset_top = 415.0
@@ -64,7 +64,7 @@ text = "1"
 label_settings = SubResource("LabelSettings_272v2")
 horizontal_alignment = 1
 
-[node name="Label" type="Label" parent="TestsCount"]
+[node name="Label" type="Label" parent="TestsCount" unique_id=1790924787]
 layout_mode = 0
 offset_left = 1.0
 offset_top = 98.0
@@ -74,7 +74,7 @@ theme_override_font_sizes/font_size = 30
 text = "Tests"
 horizontal_alignment = 1
 
-[node name="AssertionsCount" type="Label" parent="."]
+[node name="AssertionsCount" type="Label" parent="." unique_id=1065288134]
 layout_mode = 0
 offset_left = 452.0
 offset_top = 415.0
@@ -84,7 +84,7 @@ text = "1"
 label_settings = SubResource("LabelSettings_272v2")
 horizontal_alignment = 1
 
-[node name="Label" type="Label" parent="AssertionsCount"]
+[node name="Label" type="Label" parent="AssertionsCount" unique_id=1139420831]
 layout_mode = 0
 offset_left = 1.0
 offset_top = 98.0
@@ -94,7 +94,7 @@ theme_override_font_sizes/font_size = 30
 text = "Assertions"
 horizontal_alignment = 1
 
-[node name="SecondsCount" type="Label" parent="."]
+[node name="SecondsCount" type="Label" parent="." unique_id=1435907716]
 layout_mode = 0
 offset_left = 803.0
 offset_top = 415.0
@@ -104,7 +104,7 @@ text = "0"
 label_settings = SubResource("LabelSettings_272v2")
 horizontal_alignment = 1
 
-[node name="Label" type="Label" parent="SecondsCount"]
+[node name="Label" type="Label" parent="SecondsCount" unique_id=612091933]
 layout_mode = 0
 offset_left = 1.0
 offset_top = 98.0
@@ -114,7 +114,7 @@ theme_override_font_sizes/font_size = 30
 text = "Seconds"
 horizontal_alignment = 1
 
-[node name="CPUParticles2D" type="CPUParticles2D" parent="."]
+[node name="CPUParticles2D" type="CPUParticles2D" parent="." unique_id=141230541]
 position = Vector2(596, -18)
 amount = 13
 preprocess = 10.0


### PR DESCRIPTION
This makes the fuzzy matching in autocompletes a little stricter. Previously the fuzzy matching worked on similarities but now candidates must contain the letters from the prompt in order.