### PR TITLE
Allow generating IDs in all files at once

### DIFF
--- a/addons/dialogue_manager/compiler/compiler_regex.gd
+++ b/addons/dialogue_manager/compiler/compiler_regex.gd
@@ -23,8 +23,6 @@ var TAGS_REGEX: RegEx = RegEx.create_from_string("\\[#(?<tags>.*?)\\]")
 
 var REPLACEMENTS_REGEX: RegEx = RegEx.create_from_string("{{(.*?)}}")
 
-var ALPHA_NUMERIC: RegEx = RegEx.create_from_string("[^a-zA-Z0-9\\p{Han}\\p{Katakana}\\p{Hiragana}\\p{Cyrillic}]+")
-
 var TOKEN_DEFINITIONS: Dictionary = {
 	DMConstants.TOKEN_FUNCTION: RegEx.create_from_string("^[a-zA-Z_\\p{Emoji_Presentation}\\p{Han}\\p{Katakana}\\p{Hiragana}\\p{Cyrillic}][a-zA-Z_0-9\\p{Emoji_Presentation}\\p{Han}\\p{Katakana}\\p{Hiragana}\\p{Cyrillic}]*\\("),
 	DMConstants.TOKEN_DICTIONARY_REFERENCE: RegEx.create_from_string("^[a-zA-Z_\\p{Emoji_Presentation}\\p{Han}\\p{Katakana}\\p{Hiragana}\\p{Cyrillic}][a-zA-Z_0-9\\p{Emoji_Presentation}\\p{Han}\\p{Katakana}\\p{Hiragana}\\p{Cyrillic}]*\\["),

--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -82,7 +82,7 @@ func _ready() -> void:
 func _gui_input(event: InputEvent) -> void:
 	# Handle shortcuts that come from the editor
 	if event is InputEventKey and event.is_pressed():
-		var shortcut: String = Engine.get_meta("DialogueManagerPlugin").get_editor_shortcut(event)
+		var shortcut: String = DMPlugin.get_editor_shortcut(event)
 		match shortcut:
 			"toggle_comment":
 				toggle_comment()
@@ -529,7 +529,7 @@ func _get_members_for_script(script: Variant) -> Array[Dictionary]:
 					type = "property"
 				})
 	elif script.resource_path.ends_with(".cs"):
-		var dotnet: RefCounted = load(Engine.get_meta("DialogueManagerPlugin").get_plugin_path() + "/DialogueManager.cs").new()
+		var dotnet: RefCounted = load(DMPlugin.get_plugin_path() + "/DialogueManager.cs").new()
 		for m: Dictionary in dotnet.GetMembersForScript(script):
 			members.append(m)
 
@@ -556,7 +556,7 @@ func _get_method_info_from_script(script: Script, method_name: String) -> Dictio
 			if m.name == method_name:
 				return m
 	elif script.resource_path.ends_with(".cs"):
-		var dotnet: RefCounted = load(Engine.get_meta("DialogueManagerPlugin").get_plugin_path() + "/DialogueManager.cs").new()
+		var dotnet: RefCounted = load(DMPlugin.get_plugin_path() + "/DialogueManager.cs").new()
 		for m: Dictionary in dotnet.GetMembersForScript(script):
 			if m.get("name") == method_name and m.get("type") == "method":
 				return m
@@ -1155,8 +1155,8 @@ func _on_project_settings_changed() -> void:
 				_autoloads[autoload] = project.get_value("autoload", autoload).substr(1)
 
 	# Add project-defined classes if they contain static properties or methods
-	if Engine.has_meta("DialogueManagerPlugin"):
-		var plugin_path: String = Engine.get_meta("DialogueManagerPlugin").get_plugin_path()
+	var plugin_path: String = DMPlugin.get_plugin_path()
+	if not plugin_path.is_empty():
 		for script_info: Dictionary in ProjectSettings.get_global_class_list():
 			if not script_info.path.begins_with(plugin_path):
 				var script: Script = load(script_info.path)

--- a/addons/dialogue_manager/components/editor_property/editor_property_control.gd
+++ b/addons/dialogue_manager/components/editor_property/editor_property_control.gd
@@ -23,8 +23,6 @@ const ITEM_FILESYSTEM: int = 400
 @onready var new_dialog: FileDialog = $NewDialog
 @onready var open_dialog: FileDialog = $OpenDialog
 
-var editor_plugin: EditorPlugin
-
 var resource: Resource:
 	set(next_resource):
 		resource = next_resource
@@ -39,13 +37,12 @@ var quick_selected_file: String = ""
 
 func _ready() -> void:
 	menu_button.icon = get_theme_icon("GuiDropdown", "EditorIcons")
-	editor_plugin = Engine.get_meta("DialogueManagerPlugin")
 
 
 func build_menu() -> void:
 	menu.clear()
 
-	menu.add_icon_item(editor_plugin._get_plugin_icon(), "New Dialogue", ITEM_NEW)
+	menu.add_icon_item(DMPlugin.instance._get_plugin_icon(), "New Dialogue", ITEM_NEW)
 	menu.add_separator()
 	menu.add_icon_item(get_theme_icon("Load", "EditorIcons"), "Quick Load", ITEM_QUICK_LOAD)
 	menu.add_icon_item(get_theme_icon("Load", "EditorIcons"), "Load", ITEM_LOAD)
@@ -62,12 +59,12 @@ func build_menu() -> void:
 
 
 func _on_new_dialog_file_selected(path: String) -> void:
-	editor_plugin.main_view.new_file(path)
+	DMPlugin.instance.main_view.new_file(path)
 	is_waiting_for_file = false
-	if Engine.get_meta("DMCache").has_file(path):
+	if DMCache.has_file(path):
 		resource_changed.emit(load(path))
 	else:
-		var next_resource: DialogueResource = await editor_plugin.import_plugin.compiled_resource
+		var next_resource: DialogueResource = await DMPlugin.instance.import_plugin.compiled_resource
 		next_resource.resource_path = path
 		resource_changed.emit(next_resource)
 
@@ -119,7 +116,7 @@ func _on_menu_id_pressed(id: int) -> void:
 
 		ITEM_QUICK_LOAD:
 			quick_selected_file = ""
-			files_list.files = Engine.get_meta("DMCache").get_files()
+			files_list.files = DMCache.get_files()
 			if resource:
 				files_list.select_file(resource.resource_path)
 			quick_open_dialog.popup_centered()

--- a/addons/dialogue_manager/components/editor_property/resource_button.gd
+++ b/addons/dialogue_manager/components/editor_property/resource_button.gd
@@ -9,7 +9,7 @@ var resource: Resource:
 	set(next_resource):
 		resource = next_resource
 		if resource:
-			icon = Engine.get_meta("DialogueManagerPlugin")._get_plugin_icon()
+			icon = DMPlugin.instance._get_plugin_icon()
 			text = resource.resource_path.get_file().replace(".dialogue", "")
 		else:
 			icon = null

--- a/addons/dialogue_manager/components/update_button.gd
+++ b/addons/dialogue_manager/components/update_button.gd
@@ -63,7 +63,7 @@ func check_for_update() -> void:
 func _on_http_request_request_completed(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray) -> void:
 	if result != HTTPRequest.RESULT_SUCCESS: return
 
-	var current_version: String = Engine.get_meta("DialogueManagerPlugin").get_version()
+	var current_version: String = DMPlugin.get_version()
 
 	# Work out the next version from the releases information on GitHub
 	var response = JSON.parse_string(body.get_string_from_utf8())

--- a/addons/dialogue_manager/export_plugin.gd
+++ b/addons/dialogue_manager/export_plugin.gd
@@ -14,7 +14,7 @@ func _get_name() -> String:
 
 
 func _export_file(path: String, type: String, features: PackedStringArray) -> void:
-	var plugin_path: String = Engine.get_meta("DialogueManagerPlugin").get_plugin_path()
+	var plugin_path: String = DMPlugin.get_plugin_path()
 
 	# Ignore any editor stuff
 	for ignored_path: String in IGNORED_PATHS:

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -108,6 +108,15 @@ msgstr "End dialogue"
 msgid "generate_line_ids"
 msgstr "Generate line IDs"
 
+msgid "generate_ids.warning_title"
+msgstr "Generate line IDs?"
+
+msgid "generate_ids.warning_text"
+msgstr "Generate line IDs for all lines in all dialogue files?\n\n**Make sure to commit any changes to source control BEFORE running this because it cannot be undone.**"
+
+msgid "generate_ids.ok_button"
+msgstr "Generate IDs"
+
 msgid "use_uuid_only_for_ids"
 msgstr "Use UUID only for IDs"
 
@@ -259,7 +268,7 @@ msgid "errors.unexpected_condition"
 msgstr "Unexpected condition."
 
 msgid "errors.duplicate_id"
-msgstr "This ID is already on another line."
+msgstr "This ID is already in use."
 
 msgid "errors.missing_id"
 msgstr "This line is missing an ID."

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -101,6 +101,15 @@ msgstr ""
 msgid "generate_line_ids"
 msgstr ""
 
+msgid "generate_ids.warning_title"
+msgstr ""
+
+msgid "generate_ids.warning_text"
+msgstr ""
+
+msgid "generate_ids.ok_button"
+msgstr ""
+
 msgid "use_uuid_only_for_ids"
 msgstr ""
 

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -47,10 +47,7 @@ const WARN_ABOUT_METHOD_PROPERTY_OR_SIGNAL_NAME_CONFLICTS = "runtime/warn_about_
 const IGNORE_MISSING_STATE_VALUES = "runtime/advanced/ignore_missing_state_values"
 ## Whether or not the project is utilising dotnet.
 const USES_DOTNET = "runtime/advanced/uses_dotnet"
-## Maximum length of text prefix in auto-generated IDs
-const AUTO_GENERATED_ID_PREFIX_LENGTH = "editor/translations/auto_generated_id_prefix_length"
-## Use only UUID for auto-generated IDs without text prefix
-const USE_UUID_ONLY_FOR_IDS = "editor/translations/use_uuid_only_for_ids"
+
 
 static var SETTINGS_CONFIGURATION = {
 	WRAP_LONG_LINES: {
@@ -154,19 +151,7 @@ static var SETTINGS_CONFIGURATION = {
 		value = false,
 		type = TYPE_BOOL,
 		is_hidden = true
-	},
-	AUTO_GENERATED_ID_PREFIX_LENGTH: {
-		value = 30,
-		type = TYPE_INT,
-		hint = PROPERTY_HINT_RANGE,
-		hint_string = "0,100,1",
-		is_advanced = true
-	},
-	USE_UUID_ONLY_FOR_IDS: {
-		value = false,
-		type = TYPE_BOOL,
-		is_advanced = true
-	},
+	}
 }
 
 

--- a/addons/dialogue_manager/utilities/dialogue_cache.gd
+++ b/addons/dialogue_manager/utilities/dialogue_cache.gd
@@ -1,7 +1,4 @@
-class_name DMCache extends Node
-
-
-signal file_content_changed(path: String, new_content: String)
+class_name DMCache extends RefCounted
 
 
 # Keep track of errors and dependencies
@@ -12,29 +9,52 @@ signal file_content_changed(path: String, new_content: String)
 # 		errors = [<error>, <error>]
 # 	}
 # }
-var _cache: Dictionary = {}
+static var _cache: Dictionary = {}
 
-var _update_dependency_timer: Timer = Timer.new()
-var _update_dependency_paths: PackedStringArray = []
+static var _update_dependency_timer: Timer
+static var _update_dependency_paths: PackedStringArray = []
 
-var _files_marked_for_reimport: PackedStringArray = []
+static var _files_marked_for_reimport: PackedStringArray = []
+
+# Keep track of used static IDs
+# {
+# 	<static ID> = <file path>
+# }
+# Before compiling a file, remove any static IDs with a file path that matches
+# the file
+static var known_static_ids: Dictionary = {}
 
 
-func _ready() -> void:
-	add_child(_update_dependency_timer)
-	_update_dependency_timer.timeout.connect(_on_update_dependency_timeout)
+# Build the initial cache for dialogue files
+static func prepare() -> void:
+	_update_dependency_timer = Timer.new()
+	_update_dependency_timer.timeout.connect(_on_dependency_timer_timeout)
+	DMPlugin.instance.add_child(_update_dependency_timer)
 
-	_build_cache()
+	var current_files: PackedStringArray = _get_dialogue_files_in_filesystem()
+	for file: String in current_files:
+		add_file(file)
+
+	# Find any static IDs
+	var key_regex: RegEx = RegEx.create_from_string("\\[ID:(?<key>.*?)\\]")
+	for file_path: String in get_files():
+		var text: String = FileAccess.get_file_as_string(file_path)
+		var lines: PackedStringArray = text.split("\n")
+		for i: int in range(0, lines.size()):
+			var line = lines[i]
+			var found = key_regex.search(line)
+			if found:
+				known_static_ids[found.strings[found.names.get("key")]] = file_path
 
 
-func mark_files_for_reimport(files: PackedStringArray) -> void:
-	for file in files:
+static func mark_files_for_reimport(files: PackedStringArray) -> void:
+	for file: String in files:
 		if not _files_marked_for_reimport.has(file):
 			_files_marked_for_reimport.append(file)
 
 
-func reimport_files(and_files: PackedStringArray = []) -> void:
-	for file in and_files:
+static func reimport_files(and_files: PackedStringArray = []) -> void:
+	for file: String in and_files:
 		if not _files_marked_for_reimport.has(file):
 			_files_marked_for_reimport.append(file)
 
@@ -53,14 +73,14 @@ func reimport_files(and_files: PackedStringArray = []) -> void:
 
 
 ## Helper to try and resolve recursive import crashes while importer is busy.
-func _schedule_deferred_reimport() -> void:
+static func _schedule_deferred_reimport() -> void:
 	# Wait before trying again.
 	if _files_marked_for_reimport.is_empty(): return
 
 	var filesystem: EditorFileSystem = EditorInterface.get_resource_filesystem()
 	if filesystem.is_scanning():
 		# Still working on it. Try again later.
-		await get_tree().create_timer(0.1).timeout
+		await Engine.get_main_loop().create_timer(0.1).timeout
 		_schedule_deferred_reimport()
 		return
 
@@ -69,7 +89,7 @@ func _schedule_deferred_reimport() -> void:
 
 
 ## Add a dialogue file to the cache.
-func add_file(path: String, compile_result: DMCompilerResult = null) -> void:
+static func add_file(path: String, compile_result: DMCompilerResult = null) -> void:
 	_cache[path] = {
 		path = path,
 		dependencies = [],
@@ -80,23 +100,21 @@ func add_file(path: String, compile_result: DMCompilerResult = null) -> void:
 		_cache[path].dependencies = Array(compile_result.imported_paths).filter(func(d): return d != path)
 		_cache[path].compiled_at = Time.get_ticks_msec()
 
-	# If this is a fresh cache entry, check for dependencies
-	if compile_result == null and not _update_dependency_paths.has(path):
-		queue_updating_dependencies(path)
+	queue_updating_dependencies(path)
 
 
 ## Get the file paths in the cache
-func get_files() -> PackedStringArray:
+static func get_files() -> PackedStringArray:
 	return _cache.keys()
 
 
 ## Check if a file is known to the cache
-func has_file(path: String) -> bool:
+static func has_file(path: String) -> bool:
 	return _cache.has(path)
 
 
 ## Remember any errors in a dialogue file
-func add_errors_to_file(path: String, errors: Array[Dictionary]) -> void:
+static func add_errors_to_file(path: String, errors: Array[Dictionary]) -> void:
 	if _cache.has(path):
 		_cache[path].errors = errors
 	else:
@@ -109,7 +127,7 @@ func add_errors_to_file(path: String, errors: Array[Dictionary]) -> void:
 
 
 ## Get a list of files that have errors
-func get_files_with_errors() -> Array[Dictionary]:
+static func get_files_with_errors() -> Array[Dictionary]:
 	var files_with_errors: Array[Dictionary] = []
 	for dialogue_file in _cache.values():
 		if dialogue_file and dialogue_file.errors.size() > 0:
@@ -118,7 +136,9 @@ func get_files_with_errors() -> Array[Dictionary]:
 
 
 ## Queue a file to have its dependencies checked
-func queue_updating_dependencies(of_path: String) -> void:
+static func queue_updating_dependencies(of_path: String) -> void:
+	if _update_dependency_paths.has(of_path): return
+
 	_update_dependency_timer.stop()
 	if not _update_dependency_paths.has(of_path):
 		_update_dependency_paths.append(of_path)
@@ -126,7 +146,7 @@ func queue_updating_dependencies(of_path: String) -> void:
 
 
 ## Update any references to a file path that has moved
-func move_file_path(from_path: String, to_path: String) -> void:
+static func move_file_path(from_path: String, to_path: String) -> void:
 	if not _cache.has(from_path): return
 
 	if to_path != "":
@@ -135,32 +155,25 @@ func move_file_path(from_path: String, to_path: String) -> void:
 
 
 ## Get every dialogue file that imports on a file of a given path
-func get_files_with_dependency(imported_path: String) -> Array:
+static func get_files_with_dependency(imported_path: String) -> Array:
 	return _cache.values().filter(func(d): return d.dependencies.has(imported_path))
 
 
 ## Get any paths that are dependent on a given path
-func get_dependent_paths_for_reimport(on_path: String) -> PackedStringArray:
+static func get_dependent_paths_for_reimport(on_path: String) -> PackedStringArray:
 	return get_files_with_dependency(on_path) \
 		.filter(func(d): return Time.get_ticks_msec() - d.get("compiled_at", 0) > 3000) \
 		.map(func(d): return d.path)
 
 
-# Build the initial cache for dialogue files
-func _build_cache() -> void:
-	var current_files: PackedStringArray = _get_dialogue_files_in_filesystem()
-	for file in current_files:
-		add_file(file)
-
-
 # Recursively find any dialogue files in a directory
-func _get_dialogue_files_in_filesystem(path: String = "res://") -> PackedStringArray:
+static func _get_dialogue_files_in_filesystem(path: String = "res://") -> PackedStringArray:
 	var files: PackedStringArray = []
 
 	if DirAccess.dir_exists_absolute(path):
-		var dir = DirAccess.open(path)
+		var dir: DirAccess = DirAccess.open(path)
 		dir.list_dir_begin()
-		var file_name = dir.get_next()
+		var file_name: String = dir.get_next()
 		while file_name != "":
 			var file_path: String = (path + "/" + file_name).simplify_path()
 			if dir.current_is_dir():
@@ -176,7 +189,7 @@ func _get_dialogue_files_in_filesystem(path: String = "res://") -> PackedStringA
 #region Signals
 
 
-func _on_update_dependency_timeout() -> void:
+static func _on_dependency_timer_timeout() -> void:
 	_update_dependency_timer.stop()
 	var import_regex: RegEx = RegEx.create_from_string("import \"(?<path>.*?)\"")
 	var file: FileAccess

--- a/addons/dialogue_manager/utilities/translations.gd
+++ b/addons/dialogue_manager/utilities/translations.gd
@@ -3,80 +3,51 @@ class_name DMTranslationUtilities extends RefCounted
 
 
 ## Generate translation keys from some text.
-static func generate_translation_keys(text: String) -> String:
+static func generate_translation_keys() -> void:
 	var rng: RandomNumberGenerator = RandomNumberGenerator.new()
 	rng.randomize()
 
-	var lines: PackedStringArray = text.split("\n")
+	for file_path: String in DMCache.get_files():
+		var text: String = FileAccess.get_file_as_string(file_path)
 
-	var key_regex = RegEx.new()
-	key_regex.compile("\\[ID:(?<key>.*?)\\]")
+		var lines: PackedStringArray = text.split("\n")
+		var compiled_lines: Dictionary = DMCompiler.compile_string(text, "").lines
 
-	var compiled_lines: Dictionary = DMCompiler.compile_string(text, "").lines
+		# Add in any that are missing
+		for i in lines.size():
+			var line = lines[i]
+			var l = line.strip_edges()
 
-	# Make list of known keys
-	var known_keys = {}
-	for i in range(0, lines.size()):
-		var line = lines[i]
-		var found = key_regex.search(line)
-		if found:
+			if not [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE].has(DMCompiler.get_line_type(l)): continue
+			if not compiled_lines.has(str(i)): continue
+
+			if "[ID:" in line: continue
+
 			var translatable_text: String = ""
-			var l = line.replace(found.strings[0], "").strip_edges().strip_edges()
 			if l.begins_with("- "):
 				translatable_text = DMCompiler.extract_translatable_string(l)
-			elif ":" in l:
-				translatable_text = l.split(":")[1]
 			else:
-				translatable_text = l
-			known_keys[found.strings[found.names.get("key")]] = translatable_text
+				translatable_text = l.substr(l.find(":") + 1)
 
-	# Add in any that are missing
-	for i in lines.size():
-		var line = lines[i]
-		var l = line.strip_edges()
+			var key: String = _generate_id(file_path)
+			while key in DMCache.known_static_ids:
+				key = _generate_id(file_path)
+			line = line.replace("\\n", "!NEWLINE!")
+			translatable_text = translatable_text.replace("\n", "!NEWLINE!")
+			lines[i] = line.replace(translatable_text, translatable_text + " [ID:%s]" % [key]).replace("!NEWLINE!", "\\n")
 
-		if not [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE].has(DMCompiler.get_line_type(l)): continue
-		if not compiled_lines.has(str(i)): continue
+			DMCache.known_static_ids[key] = file_path
 
-		if "[ID:" in line: continue
+		text = "\n".join(lines)
 
-		var translatable_text: String = ""
-		if l.begins_with("- "):
-			translatable_text = DMCompiler.extract_translatable_string(l)
-		else:
-			translatable_text = l.substr(l.find(":") + 1)
+		var file: FileAccess = FileAccess.open(file_path, FileAccess.WRITE)
+		file.store_string(text)
+		file.close()
 
-		var key: String = ""
-		if known_keys.values().has(translatable_text):
-			key = known_keys.find_key(translatable_text)
-		else:
-			var regex: DMCompilerRegEx = DMCompilerRegEx.new()
-			if DMSettings.get_setting(DMSettings.USE_UUID_ONLY_FOR_IDS, false):
-				# Generate UUID only
-				var uuid = str(randi() % 1000000).sha1_text().substr(0, 12)
-				key = uuid.to_upper()
-			else:
-				# Generate text prefix + hash
-				var prefix_length = DMSettings.get_setting(DMSettings.AUTO_GENERATED_ID_PREFIX_LENGTH, 30)
-				key = regex.ALPHA_NUMERIC.sub(translatable_text.strip_edges(), "_", true).substr(0, prefix_length)
-				if key.begins_with("_"):
-					key = key.substr(1)
-				if key.ends_with("_"):
-					key = key.substr(0, key.length() - 1)
 
-				# Make sure key is unique
-				var hashed_key: String = key + "_" + str(randi() % 1000000).sha1_text().substr(0, 6)
-				while hashed_key in known_keys and translatable_text != known_keys.get(hashed_key):
-					hashed_key = key + "_" + str(randi() % 1000000).sha1_text().substr(0, 6)
-				key = hashed_key.to_upper()
-
-		line = line.replace("\\n", "!NEWLINE!")
-		translatable_text = translatable_text.replace("\n", "!NEWLINE!")
-		lines[i] = line.replace(translatable_text, translatable_text + " [ID:%s]" % [key]).replace("!NEWLINE!", "\\n")
-
-		known_keys[key] = translatable_text
-
-	return "\n".join(lines)
+## Get a random-ish ID for a line.
+static func _generate_id(file_path: String) -> String:
+	return (file_path.sha1_text().substr(0, 6) + "_" + str(randi() % 1000000).sha1_text().substr(0, 6)).to_upper()
 
 
 ## Export dialogue and responses to CSV.

--- a/addons/dialogue_manager/views/find_in_dialogue_view.gd
+++ b/addons/dialogue_manager/views/find_in_dialogue_view.gd
@@ -125,9 +125,8 @@ func find_in_files() -> Dictionary:
 	var results: Dictionary = {}
 
 	var q: String = input.text
-	var cache = Engine.get_meta("DMCache")
 	var file: FileAccess
-	for path in cache.get_files():
+	for path in DMCache.get_files():
 		var path_results: Array = []
 		var lines: PackedStringArray = []
 

--- a/addons/dialogue_manager/views/main_view.tscn
+++ b/addons/dialogue_manager/views/main_view.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://cbuf1q3xsse3q"]
+[gd_scene format=3 uid="uid://cbuf1q3xsse3q"]
 
 [ext_resource type="Script" uid="uid://cipjcc7bkh1pc" path="res://addons/dialogue_manager/views/main_view.gd" id="1_h6qfq"]
 [ext_resource type="PackedScene" uid="uid://civ6shmka5e8u" path="res://addons/dialogue_manager/components/code_edit.tscn" id="2_f73fm"]
@@ -37,7 +37,7 @@ image = SubResource("Image_y6rqu")
 [sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_mpdoc"]
 script = ExtResource("7_necsa")
 
-[node name="MainView" type="Control"]
+[node name="MainView" type="Control" unique_id=1975859718]
 clip_contents = true
 layout_mode = 3
 anchors_preset = 15
@@ -49,9 +49,9 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("1_h6qfq")
 
-[node name="ParseTimer" type="Timer" parent="."]
+[node name="ParseTimer" type="Timer" parent="." unique_id=1210958138]
 
-[node name="Margin" type="MarginContainer" parent="."]
+[node name="Margin" type="MarginContainer" parent="." unique_id=424731994]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -64,27 +64,27 @@ theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 metadata/_edit_layout_mode = 1
 
-[node name="Content" type="HSplitContainer" parent="Margin"]
+[node name="Content" type="HSplitContainer" parent="Margin" unique_id=267962742]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 dragger_visibility = 1
 
-[node name="SidePanel" type="VBoxContainer" parent="Margin/Content"]
+[node name="SidePanel" type="VBoxContainer" parent="Margin/Content" unique_id=408822052]
 custom_minimum_size = Vector2(150, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Toolbar" type="HBoxContainer" parent="Margin/Content/SidePanel"]
+[node name="Toolbar" type="HBoxContainer" parent="Margin/Content/SidePanel" unique_id=1890446441]
 layout_mode = 2
 
-[node name="NewButton" type="Button" parent="Margin/Content/SidePanel/Toolbar"]
+[node name="NewButton" type="Button" parent="Margin/Content/SidePanel/Toolbar" unique_id=916776070]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Start a new file"
 flat = true
 
-[node name="OpenButton" type="MenuButton" parent="Margin/Content/SidePanel/Toolbar"]
+[node name="OpenButton" type="MenuButton" parent="Margin/Content/SidePanel/Toolbar" unique_id=880106178]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Open a file"
@@ -113,44 +113,44 @@ popup/item_7/separator = true
 popup/item_8/text = "Clear recent files"
 popup/item_8/id = 102
 
-[node name="SaveAllButton" type="Button" parent="Margin/Content/SidePanel/Toolbar"]
+[node name="SaveAllButton" type="Button" parent="Margin/Content/SidePanel/Toolbar" unique_id=940841574]
 unique_name_in_owner = true
 layout_mode = 2
 disabled = true
 flat = true
 
-[node name="FindInFilesButton" type="Button" parent="Margin/Content/SidePanel/Toolbar"]
+[node name="FindInFilesButton" type="Button" parent="Margin/Content/SidePanel/Toolbar" unique_id=213493052]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Find in files..."
 flat = true
 
-[node name="Bookmarks" type="VSplitContainer" parent="Margin/Content/SidePanel"]
+[node name="Bookmarks" type="VSplitContainer" parent="Margin/Content/SidePanel" unique_id=1966503844]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="FilesList" parent="Margin/Content/SidePanel/Bookmarks" instance=ExtResource("2_npj2k")]
+[node name="FilesList" parent="Margin/Content/SidePanel/Bookmarks" unique_id=1460458494 instance=ExtResource("2_npj2k")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="FilesPopupMenu" type="PopupMenu" parent="Margin/Content/SidePanel/Bookmarks/FilesList"]
+[node name="FilesPopupMenu" type="PopupMenu" parent="Margin/Content/SidePanel/Bookmarks/FilesList" unique_id=253084069]
 unique_name_in_owner = true
 
-[node name="TitleList" parent="Margin/Content/SidePanel/Bookmarks" instance=ExtResource("2_onb4i")]
+[node name="TitleList" parent="Margin/Content/SidePanel/Bookmarks" unique_id=2063152064 instance=ExtResource("2_onb4i")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="CodePanel" type="VBoxContainer" parent="Margin/Content"]
+[node name="CodePanel" type="VBoxContainer" parent="Margin/Content" unique_id=2013417278]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 4.0
 
-[node name="Toolbar" type="HBoxContainer" parent="Margin/Content/CodePanel"]
+[node name="Toolbar" type="HBoxContainer" parent="Margin/Content/CodePanel" unique_id=177899511]
 layout_mode = 2
 
-[node name="InsertButton" type="MenuButton" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="InsertButton" type="MenuButton" parent="Margin/Content/CodePanel/Toolbar" unique_id=1765432833]
 unique_name_in_owner = true
 layout_mode = 2
 disabled = true
@@ -201,7 +201,7 @@ popup/item_14/text = "End dialogue"
 popup/item_14/icon = SubResource("ImageTexture_57eek")
 popup/item_14/id = 12
 
-[node name="TranslationsButton" type="MenuButton" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="TranslationsButton" type="MenuButton" parent="Margin/Content/CodePanel/Toolbar" unique_id=2010201295]
 unique_name_in_owner = true
 layout_mode = 2
 disabled = true
@@ -222,10 +222,10 @@ popup/item_4/text = "Import line changes from CSV..."
 popup/item_4/icon = SubResource("ImageTexture_57eek")
 popup/item_4/id = 203
 
-[node name="Separator" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="Separator" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar" unique_id=821562382]
 layout_mode = 2
 
-[node name="SearchButton" type="Button" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="SearchButton" type="Button" parent="Margin/Content/CodePanel/Toolbar" unique_id=121689358]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Search for text"
@@ -233,60 +233,60 @@ disabled = true
 toggle_mode = true
 flat = true
 
-[node name="Separator2" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="Separator2" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar" unique_id=175043853]
 layout_mode = 2
 
-[node name="TestButton" type="Button" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="TestButton" type="Button" parent="Margin/Content/CodePanel/Toolbar" unique_id=1610822770]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Test dialogue"
 disabled = true
 flat = true
 
-[node name="TestLineButton" type="Button" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="TestLineButton" type="Button" parent="Margin/Content/CodePanel/Toolbar" unique_id=1575726308]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Test dialogue"
 disabled = true
 flat = true
 
-[node name="Spacer2" type="Control" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="Spacer2" type="Control" parent="Margin/Content/CodePanel/Toolbar" unique_id=249482575]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="SupportButton" type="Button" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="SupportButton" type="Button" parent="Margin/Content/CodePanel/Toolbar" unique_id=1042093313]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Support Dialogue Manager"
 text = "Sponsor"
 flat = true
 
-[node name="Separator4" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="Separator4" type="VSeparator" parent="Margin/Content/CodePanel/Toolbar" unique_id=321395257]
 layout_mode = 2
 
-[node name="DocsButton" type="Button" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="DocsButton" type="Button" parent="Margin/Content/CodePanel/Toolbar" unique_id=1404920471]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Docs"
 flat = true
 
-[node name="VersionLabel" type="Label" parent="Margin/Content/CodePanel/Toolbar"]
+[node name="VersionLabel" type="Label" parent="Margin/Content/CodePanel/Toolbar" unique_id=630990714]
 unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.490196)
 layout_mode = 2
 text = "v2.42.2"
 vertical_alignment = 1
 
-[node name="UpdateButton" parent="Margin/Content/CodePanel/Toolbar" instance=ExtResource("2_ph3vs")]
+[node name="UpdateButton" parent="Margin/Content/CodePanel/Toolbar" unique_id=1595256128 instance=ExtResource("2_ph3vs")]
 unique_name_in_owner = true
 layout_mode = 2
 text = "v2.44.1 available"
 
-[node name="SearchAndReplace" parent="Margin/Content/CodePanel" instance=ExtResource("6_ylh0t")]
+[node name="SearchAndReplace" parent="Margin/Content/CodePanel" unique_id=2132004091 instance=ExtResource("6_ylh0t")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="CodeEdit" parent="Margin/Content/CodePanel" instance=ExtResource("2_f73fm")]
+[node name="CodeEdit" parent="Margin/Content/CodePanel" unique_id=302141693 instance=ExtResource("2_f73fm")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -315,11 +315,11 @@ Coco: Meow.
 scroll_smooth = true
 syntax_highlighter = SubResource("SyntaxHighlighter_mpdoc")
 
-[node name="ErrorsPanel" parent="Margin/Content/CodePanel" instance=ExtResource("7_5cvl4")]
+[node name="ErrorsPanel" parent="Margin/Content/CodePanel" unique_id=1975824789 instance=ExtResource("7_5cvl4")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Banner" type="CenterContainer" parent="."]
+[node name="Banner" type="CenterContainer" parent="." unique_id=1848328987]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -330,11 +330,11 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="PanelContainer" type="VBoxContainer" parent="Banner"]
+[node name="PanelContainer" type="VBoxContainer" parent="Banner" unique_id=1211498578]
 layout_mode = 2
 theme_override_constants/separation = 5
 
-[node name="BannerImage" type="TextureRect" parent="Banner/PanelContainer"]
+[node name="BannerImage" type="TextureRect" parent="Banner/PanelContainer" unique_id=899616034]
 custom_minimum_size = Vector2(600, 200)
 layout_mode = 2
 mouse_filter = 0
@@ -342,41 +342,41 @@ mouse_default_cursor_shape = 2
 texture = ExtResource("9_y6rqu")
 expand_mode = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Banner/PanelContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Banner/PanelContainer" unique_id=874356896]
 layout_mode = 2
 theme_override_constants/separation = 5
 
-[node name="BannerNewButton" type="Button" parent="Banner/PanelContainer/HBoxContainer"]
+[node name="BannerNewButton" type="Button" parent="Banner/PanelContainer/HBoxContainer" unique_id=1034773049]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "New Dialogue..."
 
-[node name="BannerQuickOpen" type="Button" parent="Banner/PanelContainer/HBoxContainer"]
+[node name="BannerQuickOpen" type="Button" parent="Banner/PanelContainer/HBoxContainer" unique_id=1614953837]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Quick open..."
 
-[node name="BannerExamples" type="Button" parent="Banner/PanelContainer/HBoxContainer"]
+[node name="BannerExamples" type="Button" parent="Banner/PanelContainer/HBoxContainer" unique_id=1066745213]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Example projects..."
 
-[node name="NewDialog" type="FileDialog" parent="."]
+[node name="NewDialog" type="FileDialog" parent="." unique_id=458925087]
 size = Vector2i(900, 750)
 min_size = Vector2i(600, 500)
 dialog_hide_on_ok = true
 filters = PackedStringArray("*.dialogue ; Dialogue")
 
-[node name="SaveDialog" type="FileDialog" parent="."]
+[node name="SaveDialog" type="FileDialog" parent="." unique_id=325906832]
 size = Vector2i(900, 750)
 min_size = Vector2i(600, 500)
 dialog_hide_on_ok = true
 filters = PackedStringArray("*.dialogue ; Dialogue")
 
-[node name="OpenDialog" type="FileDialog" parent="."]
+[node name="OpenDialog" type="FileDialog" parent="." unique_id=1252768767]
 title = "Open a File"
 size = Vector2i(900, 750)
 min_size = Vector2i(600, 500)
@@ -385,19 +385,19 @@ dialog_hide_on_ok = true
 file_mode = 0
 filters = PackedStringArray("*.dialogue ; Dialogue")
 
-[node name="QuickOpenDialog" type="ConfirmationDialog" parent="."]
+[node name="QuickOpenDialog" type="ConfirmationDialog" parent="." unique_id=254740052]
 title = "Quick open"
 size = Vector2i(600, 900)
 min_size = Vector2i(400, 600)
 ok_button_text = "Open"
 
-[node name="QuickOpenFilesList" parent="QuickOpenDialog" instance=ExtResource("2_npj2k")]
+[node name="QuickOpenFilesList" parent="QuickOpenDialog" unique_id=1813408245 instance=ExtResource("2_npj2k")]
 
-[node name="ExportDialog" type="FileDialog" parent="."]
+[node name="ExportDialog" type="FileDialog" parent="." unique_id=2035775999]
 size = Vector2i(900, 750)
 min_size = Vector2i(600, 500)
 
-[node name="ImportDialog" type="FileDialog" parent="."]
+[node name="ImportDialog" type="FileDialog" parent="." unique_id=1326083376]
 title = "Open a File"
 size = Vector2i(900, 750)
 min_size = Vector2i(600, 500)
@@ -405,22 +405,24 @@ ok_button_text = "Open"
 file_mode = 0
 filters = PackedStringArray("*.csv ; Translation CSV")
 
-[node name="ErrorsDialog" type="AcceptDialog" parent="."]
+[node name="ErrorsDialog" type="AcceptDialog" parent="." unique_id=2100629189]
 title = "Error"
 dialog_text = "You have errors in your script. Fix them and then try again."
 
-[node name="BuildErrorDialog" type="AcceptDialog" parent="."]
+[node name="BuildErrorDialog" type="AcceptDialog" parent="." unique_id=1879686579]
 title = "Errors"
 dialog_text = "You need to fix dialogue errors before you can run your game."
 
-[node name="CloseConfirmationDialog" type="ConfirmationDialog" parent="."]
+[node name="CloseConfirmationDialog" type="ConfirmationDialog" parent="." unique_id=1048140490]
 title = "Unsaved changes"
 ok_button_text = "Save changes"
 
-[node name="UpdatedDialog" type="AcceptDialog" parent="."]
+[node name="UpdatedDialog" type="AcceptDialog" parent="." unique_id=955879802]
 title = "Updated"
 size = Vector2i(191, 100)
 dialog_text = "You're now up to date!"
+
+[node name="GenerateStaticIdsConfirmationDialog" type="ConfirmationDialog" parent="." unique_id=1311101975]
 
 [connection signal="theme_changed" from="." to="." method="_on_main_view_theme_changed"]
 [connection signal="visibility_changed" from="." to="." method="_on_main_view_visibility_changed"]
@@ -462,3 +464,4 @@ dialog_text = "You're now up to date!"
 [connection signal="file_selected" from="ImportDialog" to="." method="_on_import_dialog_file_selected"]
 [connection signal="confirmed" from="CloseConfirmationDialog" to="." method="_on_close_confirmation_dialog_confirmed"]
 [connection signal="custom_action" from="CloseConfirmationDialog" to="." method="_on_close_confirmation_dialog_custom_action"]
+[connection signal="confirmed" from="GenerateStaticIdsConfirmationDialog" to="." method="_on_generate_static_ids_confirmation_dialog_confirmed"]


### PR DESCRIPTION
This changes the "generate line IDs" action to generate them across all dialogue files at once.

This also improves the duplicate ID checker to check other files for conflicts.

Closes #1080