### PR TITLE
Use differentiated colour for tags

### DIFF
--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -118,14 +118,14 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 				var tag: String = bbcode.code
 				var code: String = bbcode.raw_args
 				if code.begins_with("["):
-					colors[index + bbcode.start] = { color = theme.symbols_color }
+					colors[index + bbcode.start] = { color = theme.tags_color }
 					colors[index + bbcode.start + 2] = { color = theme.text_color }
 					var pipe_cursor: int = code.find("|")
 					while pipe_cursor > -1:
-						colors[index + bbcode.start + pipe_cursor + 1] = { color = theme.symbols_color }
+						colors[index + bbcode.start + pipe_cursor + 1] = { color = theme.tags_color }
 						colors[index + bbcode.start + pipe_cursor + 2] = { color = theme.text_color }
 						pipe_cursor = code.find("|", pipe_cursor + 1)
-					colors[index + bbcode.end - 1] = { color = theme.symbols_color }
+					colors[index + bbcode.end - 1] = { color = theme.tags_color }
 					colors[index + bbcode.end + 1] = { color = theme.text_color }
 				else:
 					colors[index + bbcode.start] = { color = theme.tags_color }

--- a/addons/dialogue_manager/plugin.cfg
+++ b/addons/dialogue_manager/plugin.cfg
@@ -3,5 +3,5 @@
 name="Dialogue Manager"
 description="A powerful nonlinear dialogue system"
 author="Nathan Hoad"
-version="3.10.0"
+version="3.10.1"
 script="plugin.gd"

--- a/addons/dialogue_manager/utilities/theme_values.gd
+++ b/addons/dialogue_manager/utilities/theme_values.gd
@@ -11,6 +11,7 @@ var notice_color: Color = Color.WHITE
 
 var labels_color: Color = Color.WHITE
 var text_color: Color = Color.WHITE
+var tags_color: Color = Color.WHITE
 var conditions_color: Color = Color.WHITE
 var mutations_color: Color = Color.WHITE
 var mutations_line_color: Color = Color.WHITE
@@ -36,6 +37,7 @@ func _init(values: Dictionary) -> void:
 
 	labels_color = values.labels_color
 	text_color = values.text_color
+	tags_color = values.tags_color
 	conditions_color = values.conditions_color
 	mutations_color = values.mutations_color
 	mutations_line_color = values.mutations_line_color
@@ -64,6 +66,7 @@ static func get_values_from_editor() -> DMThemeValues:
 
 		labels_color = editor_settings.get_setting("text_editor/theme/highlighting/control_flow_keyword_color"),
 		text_color = editor_settings.get_setting("text_editor/theme/highlighting/text_color"),
+		tags_color = editor_settings.get_setting("text_editor/theme/highlighting/string_placeholder_color"),
 		conditions_color = editor_settings.get_setting("text_editor/theme/highlighting/keyword_color"),
 		mutations_color = editor_settings.get_setting("text_editor/theme/highlighting/function_color"),
 		mutations_line_color = Color(editor_settings.get_setting("text_editor/theme/highlighting/function_color"), 0.6),


### PR DESCRIPTION
> [!WARNING]
> This theme value is new in Godot 4.6

Use the new `string_placeholder_color` theme value to differentiate tags.