### PR TITLE
Remove legacy resource identifier

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -116,7 +116,7 @@ func find_imported_labels(text: String, path: String) -> void:
 				add_error(id, 0, DMConstants.ERR_ERRORS_IN_IMPORTED_FILE)
 				continue
 
-			var uid: String = ResourceUID.id_to_text(ResourceLoader.get_resource_uid(import_data.path)).replace("uid://", "")
+			var uid: String = var uid: String = ResourceUID.path_to_uid(import_data.path).replace("uid://", "")
 			for label_key: String in imported_resource.labels:
 				# Ignore any labels that are already a reference
 				if "/" in label_key: continue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -1592,7 +1592,7 @@ func _resolve_thing_property(thing: Object, property: String) -> Variant:
 
 
 func _get_resource_uid(resource: DialogueResource) -> String:
-	return ResourceUID.id_to_text(ResourceLoader.get_resource_uid(resource.resource_path)).replace("uid://", "")
+	return ResourceUID.path_to_uid(resource.resource_path).replace("uid://", "")
 
 
 func _get_id_with_resource(resource: DialogueResource, id: String) -> String:

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -490,8 +490,6 @@ func run_test_scene(from_key: String) -> void:
 	DMSettings.set_user_value("is_running_test_scene", true)
 	DMSettings.set_user_value("run_resource_path", current_file_path)
 	var test_scene_path: String = DMSettings.get_setting(DMSettings.CUSTOM_TEST_SCENE_PATH, "res://addons/dialogue_manager/test_scene.tscn")
-	if ResourceUID.has_id(ResourceUID.text_to_id(test_scene_path)):
-		test_scene_path = ResourceUID.get_id_path(ResourceUID.text_to_id(test_scene_path))
 	EditorInterface.play_custom_scene(test_scene_path)
 
 


### PR DESCRIPTION
This removes some legacy resource lookups that have cleaner alternatives since Godot 4.5.