### PR TITLE
Add short-circuit evaluation

### DIFF
--- a/Dialogue Manager.csproj
+++ b/Dialogue Manager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.0">
+<Project Sdk="Godot.NET.Sdk/4.6.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>


### PR DESCRIPTION
This adds short-circuit evaluation when resolving conditions (ie. if the remainder of an expression is irrelevant it won't be evaluated).