### PR TITLE
Fix _check_condition() crash and wrong results for non-primitive condition values

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -721,12 +721,12 @@ func _check_condition(data: Dictionary, extra_game_states: Array) -> bool:
 		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY, \
 		TYPE_PACKED_STRING_ARRAY, \
 		TYPE_PACKED_VECTOR2_ARRAY, TYPE_PACKED_VECTOR3_ARRAY, TYPE_PACKED_VECTOR4_ARRAY]:
-			return (result as String).is_empty()
+			return not (result as String).is_empty()
 
 	if result is Node or result is Resource:
 		return is_instance_valid(result)
 
-	return bool(result)
+	return true if result else false
 
 
 # Resolve a condition's expression value

--- a/tests/test_bool_condition.gd
+++ b/tests/test_bool_condition.gd
@@ -1,0 +1,64 @@
+extends AbstractTest
+
+
+func test_can_evaluate_empty_string_condition_as_falsy() -> void:
+	var resource: DialogueResource = create_resource("
+~ start
+if empty_flag
+	Nathan: FAIL.
+else
+	Nathan: PASS.
+=> END")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ empty_flag = "" }])
+	assert(line.text == "PASS.", "Empty string condition should be falsy.")
+
+
+func test_can_evaluate_nonempty_string_condition_as_truthy() -> void:
+	var resource: DialogueResource = create_resource("
+~ start
+if nonempty_flag
+	Nathan: PASS.
+else
+	Nathan: FAIL.
+=> END")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ nonempty_flag = "hello" }])
+	assert(line.text == "PASS.", "Non-empty string condition should be truthy.")
+
+
+func test_can_evaluate_color_condition() -> void:
+	var resource: DialogueResource = create_resource("
+~ start
+if color_val
+	Nathan: Truthy.
+else
+	Nathan: Falsy.
+=> END")
+
+	# In Godot 4, Variant::booleanize() returns true for all value types not
+	# explicitly listed (NIL/BOOL/INT/FLOAT/STRING/OBJECT), so Color is always
+	# truthy regardless of its component values.
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ color_val = Color.RED }])
+	assert(line.text == "Truthy.", "Color should be truthy and not crash.")
+
+	line = await resource.get_next_dialogue_line("start", [{ color_val = Color(0.0, 0.0, 0.0, 0.0) }])
+	assert(line.text == "Truthy.", "Zero Color is still truthy (value type, no falsy zero in GDScript).")
+
+
+func test_can_evaluate_vector2_condition() -> void:
+	var resource: DialogueResource = create_resource("
+~ start
+if vec_val
+	Nathan: Truthy.
+else
+	Nathan: Falsy.
+=> END")
+
+	# Unlike Color, Godot 4's Variant::booleanize() has an explicit case for Vector2:
+	# zero vector is falsy, non-zero is truthy.
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ vec_val = Vector2.UP }])
+	assert(line.text == "Truthy.", "Non-zero Vector2 should be truthy and not crash.")
+
+	line = await resource.get_next_dialogue_line("start", [{ vec_val = Vector2.ZERO }])
+	assert(line.text == "Falsy.", "Zero Vector2 should be falsy.")

--- a/tests/test_bool_condition.gd.uid
+++ b/tests/test_bool_condition.gd.uid
@@ -1,0 +1,1 @@
+uid://b7e5gkamkcj8g


### PR DESCRIPTION
Both issues originate in `_check_condition()` in `dialogue_manager.gd`, which evaluates the resolved value of a condition expression and returns a `bool` indicating whether the condition is met.

**Issue 1: crash for non-primitive types** (`bool()` as a hard cast)

`return bool(result)` at line 729 is the fallback for any type not matched by the guards above it. In GDScript 4, `bool()` is a constructor, not a truthiness check. For `Color`, `Vector2`, and similar value types it throws `"Invalid conversion from X to bool"`. The safe equivalent for every `Variant` type is `true if result else false`, which uses the same evaluation path as a plain `if result:` statement and never throws.

**Issue 2: inverted `String` condition logic**

The `typeof()` guard at line 724 returned `(result as String).is_empty()` directly. `is_empty()` returns `true` for an empty string, so the function was returning `true` (condition met) for `""` — the opposite of the correct behaviour. The fix is adding `not`.

---

```gdscript
# before
return (result as String).is_empty()   # line 724 (inverted)
return bool(result)                    # line 729 (crashes for Color, Vector2, etc.)

# after
return not (result as String).is_empty()
return true if result else false
```

Extending the `typeof()` guard list with `TYPE_COLOR`, `TYPE_VECTOR2`, etc. is an alternative for the crash fix, but those types would be fed into `(result as String)` which is incorrect. The `true if result else false` fallback is already safe for every remaining `Variant` type.

Regression tests are added in `tests/test_bool_condition.gd`.

---

fixes #1116, fixes #1117
