### PR TITLE
Fix character name completions suggesting names from commented lines

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -1064,6 +1064,7 @@ func get_character_names(beginning_with: String) -> PackedStringArray:
 	var names: PackedStringArray = []
 	var lines: PackedStringArray = text.split("\n")
 	for line: String in lines:
+		if line.strip_edges().begins_with("#"): continue # skip comments
 		if ": " in line:
 			var character_name: String = WEIGHTED_RANDOM_PREFIX.sub(line.split(": ")[0].strip_edges(), "")
 			if not character_name in names and _matches_prompt(beginning_with, character_name):


### PR DESCRIPTION
There was a bug where, if you had a comment in the Dialogue Editor that included a ":" character, the autocompletion system would consider that to be a character name and offer it as an autocompletion result when typing.

<img width="565" height="97" alt="2026-02-25_01 00 23" src="https://github.com/user-attachments/assets/7e5fba5d-a8b1-4fad-b9c3-757b51652c79" />

This change fixes that by skipping any commented lines when looking for character names.
