### PR TITLE
Fix C# example balloon mutation handler

### DIFF
--- a/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
+++ b/addons/dialogue_manager/example_balloon/ExampleBalloon.cs
@@ -251,11 +251,14 @@ namespace DialogueManagerRuntime
     #region signals
 
 
-    private void OnMutated(Dictionary _mutation)
+    private void OnMutated(Dictionary mutation)
     {
-      isWaitingForInput = false;
-      willHideBalloon = true;
-      MutationCooldown.Start(0.1f);
+      if (!(bool)mutation["is_inline"])
+      {
+        isWaitingForInput = false;
+        willHideBalloon = true;
+        MutationCooldown.Start(0.1f);
+      }
     }
 
 

--- a/addons/dialogue_manager/example_balloon/example_balloon.gd
+++ b/addons/dialogue_manager/example_balloon/example_balloon.gd
@@ -181,8 +181,8 @@ func _on_mutation_cooldown_timeout() -> void:
 		balloon.hide()
 
 
-func _on_mutated(_mutation: Dictionary) -> void:
-	if not _mutation.is_inline:
+func _on_mutated(mutation: Dictionary) -> void:
+	if not mutation.is_inline:
 		is_waiting_for_input = false
 		will_hide_balloon = true
 		mutation_cooldown.start(0.1)


### PR DESCRIPTION
This updates the C# example balloon to check for inline mutations before hiding the balloon.

Fixes #1130 