### PR TITLE
Remove "raw_text" property

### DIFF
--- a/addons/dialogue_manager/compiler/compiler.gd
+++ b/addons/dialogue_manager/compiler/compiler.gd
@@ -15,7 +15,6 @@ static func compile_string(text: String, path: String) -> DMCompilerResult:
 	result.first_label = compilation.first_label
 	result.errors = compilation.errors
 	result.lines = compilation.data
-	result.raw_text = text
 
 	return result
 

--- a/addons/dialogue_manager/compiler/compiler_result.gd
+++ b/addons/dialogue_manager/compiler/compiler_result.gd
@@ -22,6 +22,3 @@ var errors: Array[DMError] = []
 
 ## A map of all compiled lines.
 var lines: Dictionary = {}
-
-## The raw dialogue text.
-var raw_text: String = ""

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -174,7 +174,7 @@ func get_line(resource: DialogueResource, key: String, extra_game_states: Array)
 		assert(false, DMConstants.translate(&"errors.key_not_found").format({ key = key }))
 
 	var data: Dictionary = resource.lines.get(key)
-	
+
 	# Inject some debugger information into the game states.
 	extra_game_states = [{ "debugger": {
 		resource_path = resource.resource_path,
@@ -492,7 +492,6 @@ func create_resource_from_text(text: String) -> Resource:
 	resource.first_label = result.first_label
 	resource.character_names = result.character_names
 	resource.lines = result.lines
-	resource.raw_text = text
 
 	return resource
 

--- a/addons/dialogue_manager/dialogue_resource.gd
+++ b/addons/dialogue_manager/dialogue_resource.gd
@@ -20,9 +20,6 @@ class_name DialogueResource extends Resource
 ## A map of the encoded lines of dialogue.
 @export var lines: Dictionary = {}
 
-## raw version of the text
-@export var raw_text: String
-
 
 ## Get the next printable line of dialogue, starting from a referenced line ([code]label[/code] can
 ## be a labels string or a stringified line number). Runs any mutations along the way and then returns

--- a/addons/dialogue_manager/import_plugin.gd
+++ b/addons/dialogue_manager/import_plugin.gd
@@ -5,7 +5,14 @@ class_name DMImportPlugin extends EditorImportPlugin
 signal compiled_resource(resource: Resource)
 
 
-const COMPILER_VERSION: int = 16
+const COMPILER_VERSION: int = 17
+
+
+func _init() -> void:
+	var current_version: int = DMSettings.get_user_value("compiler_version", -1)
+	if current_version != COMPILER_VERSION:
+		DMSettings.set_user_value("compiler_version", COMPILER_VERSION)
+		DMCache.reimport_all_files()
 
 
 func _get_importer_name() -> String:
@@ -91,7 +98,6 @@ func _import(source_file: String, save_path: String, _options: Dictionary, _plat
 	resource.first_label = result.first_label
 	resource.character_names = result.character_names
 	resource.lines = result.lines
-	resource.raw_text = result.raw_text
 
 	# Clear errors and possibly trigger any cascade recompiles
 	DMCache.add_file(source_file, result)

--- a/addons/dialogue_manager/plugin.gd
+++ b/addons/dialogue_manager/plugin.gd
@@ -50,7 +50,7 @@ func _enter_tree() -> void:
 
 		translation_parser_plugin = DMTranslationParserPlugin.new()
 		add_translation_parser_plugin(translation_parser_plugin)
-		
+
 		debugger_plugin = DMDebuggerPlugin.new()
 		add_debugger_plugin(debugger_plugin)
 
@@ -78,7 +78,7 @@ func _exit_tree() -> void:
 
 	remove_translation_parser_plugin(translation_parser_plugin)
 	translation_parser_plugin = null
-	
+
 	remove_debugger_plugin(debugger_plugin)
 	debugger_plugin = null
 

--- a/addons/dialogue_manager/utilities/dialogue_cache.gd
+++ b/addons/dialogue_manager/utilities/dialogue_cache.gd
@@ -53,6 +53,10 @@ static func mark_files_for_reimport(files: PackedStringArray) -> void:
 			_files_marked_for_reimport.append(file)
 
 
+static func reimport_all_files() -> void:
+	reimport_files(_get_dialogue_files_in_filesystem())
+
+
 static func reimport_files(and_files: PackedStringArray = []) -> void:
 	for file: String in and_files:
 		if not _files_marked_for_reimport.has(file):

--- a/tests/main.dialogue.import
+++ b/tests/main.dialogue.import
@@ -1,7 +1,7 @@
 [remap]
 
 importer="dialogue_manager"
-importer_version=16
+importer_version=17
 type="Resource"
 uid="uid://bnnha7rqiubty"
 path="res://.godot/imported/main.dialogue-fdb08bf1f3a902dc953e9d549b742c4a.tres"

--- a/tests/snippets.dialogue.import
+++ b/tests/snippets.dialogue.import
@@ -1,7 +1,7 @@
 [remap]
 
 importer="dialogue_manager"
-importer_version=16
+importer_version=17
 type="Resource"
 uid="uid://m7wueb1et2an"
 path="res://.godot/imported/snippets.dialogue-fef751acf14db992e43cc94dcce41bb4.tres"


### PR DESCRIPTION
This removes the `raw_text` property of `DialogueResource`s which wasn't actually used anywhere and was just adding file bloat.