### PR TITLE
Fix got_dialogue signal not received when ExampleBalloon used as node

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -118,7 +118,7 @@ func _get_next_dialogue_line(resource: DialogueResource, key: String = "", extra
 		else:
 			return await _get_next_dialogue_line(resource, dialogue.next_id, extra_game_states, mutation_behaviour)
 	else:
-		got_dialogue.emit(dialogue)
+		got_dialogue.emit.call_deferred(dialogue)
 		return dialogue
 
 


### PR DESCRIPTION
### Bug Description

When adding `ExampleBalloon` as a child node with `auto_start = true`, the `got_dialogue` signal is emitted as usual, but cannot be received at the first time if the connection is established in `_ready()`, which might be a common pattern.

### Possible Cause

The signal is emitted before the connection is established in `_ready()`.

### Solution

Use `call_deferred` when emit the `got_dialogue` signal. As it only delays the emission, I guess it may not cause other issues.
