### PR TITLE
Add dialogue_ended signal to Actionable nodes

### DIFF
--- a/addons/dialogue_manager/components/cue_editor_property/editor_property_control.gd
+++ b/addons/dialogue_manager/components/cue_editor_property/editor_property_control.gd
@@ -33,18 +33,21 @@ func _ready() -> void:
 
 
 func _update() -> void:
-	if not is_instance_valid(actionable): return
+	var has_valid_dialogue_resource: bool = is_instance_valid(actionable) and "dialogue_resource" in actionable and is_instance_valid(actionable.dialogue_resource)
 
-	var cues: PackedStringArray = Array(actionable.dialogue_resource.get_cues()).filter(func(l: String) -> bool: return not l.contains("/"))
+	var cues: PackedStringArray = []
+	if has_valid_dialogue_resource:
+		cues = Array(actionable.dialogue_resource.get_cues()).filter(func(l: String) -> bool: return not l.contains("/"))
 
 	var popup: PopupMenu = button.get_popup()
 	popup.clear()
 
 	var cue_icon: Texture2D = DMThemeValues.get_icon_with_color(CUE_ICON, DMThemeValues.get_values_from_editor().cues_color)
 
-	if actionable.dialogue_resource == null:
+	if cues.is_empty() or not has_valid_dialogue_resource:
 		popup.add_item(DMConstants.translate("<empty>"))
 		popup.set_item_disabled(0, true)
+		link_button.disabled = true
 	else:
 		for existing_cue: String in cues:
 			popup.add_icon_item(cue_icon, existing_cue)
@@ -54,11 +57,14 @@ func _update() -> void:
 	if cue.is_empty():
 		button.text = DMConstants.translate("<empty>")
 		button.icon = null
+		link_button.disabled = true
 	elif cues.has(cue):
 		button.select(-1)
 		button.select(cues.find(cue))
+		link_button.disabled = false
 	else:
 		button.selected = cues.size()
+		link_button.disabled = true
 
 
 func show_cue_in_editor(next_cue: String) -> void:

--- a/addons/dialogue_manager/nodes/actionable/actionable_2d.gd
+++ b/addons/dialogue_manager/nodes/actionable/actionable_2d.gd
@@ -12,6 +12,10 @@ class_name Actionable2D extends Area2D
 ## Emitted when this [Actionable2D] has [code]action()[/code] called on it.
 signal actioned()
 
+## Emitted when the [DialogueResource] associated with this [Actionable2D] ends. [b]NOTE:[/b] The
+## signal is also emitted if the same resource is used for multiple [Actionable2D] nodes in the tree.
+signal dialogue_ended()
+
 
 ## The [DialogueResource] to use when starting dialogue.
 @export var dialogue_resource: DialogueResource = null:
@@ -24,19 +28,21 @@ signal actioned()
 		return dialogue_resource
 
 ## The target cue to start dialogue from.
-var dialogue_cue: String = ""
+@export var dialogue_cue: String = ""
 
 ## The dialogue balloon that was last used by calling [code]action()[/code] (if there was one).
 var dialogue_balloon: Node
 
 ## The method used to start dialogue action [code]action()[/code] is called. Override if you need
 ## different logic.
-static var start_dialogue: Callable = func(p_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node2D:
-	return DialogueManager.show_dialogue_balloon(p_dialogue_resource, from_cue, extra_game_states)
+static var start_dialogue: Callable = func(with_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node2D:
+	return DialogueManager.show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
 
 
 func _ready() -> void:
-	add_to_group("dialogue_actionables")
+	if not Engine.is_editor_hint():
+		add_to_group("dialogue_actionables")
+		DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
 
 #region Public
@@ -66,53 +72,12 @@ static func get_nearest_actionable_to(target_position: Vector2) -> Actionable2D:
 
 #endregion
 
-#region Properties
+#region Signals
 
 
-func _get_property_list() -> Array[Dictionary]:
-	var props: Array[Dictionary] = []
-
-	if is_instance_valid(dialogue_resource):
-		props.append({
-			name = "dialogue_cue",
-			type = TYPE_STRING
-		})
-
-	return props
-
-
-func _get(property: StringName) -> Variant:
-	match property:
-		"dialogue_cue":
-			return dialogue_cue
-
-	return null
-
-
-func _set(property: StringName, value: Variant) -> bool:
-	match property:
-		"dialogue_cue":
-			dialogue_cue = value
-			notify_property_list_changed()
-			return true
-
-	return false
-
-
-func _property_can_revert(property: StringName) -> bool:
-	match property:
-		"dialogue_cue":
-			return true
-
-	return false
-
-
-func _property_get_revert(property: StringName) -> Variant:
-	match property:
-		"dialogue_cue":
-			return ""
-
-	return null
+func _on_dialogue_ended(ending_dialogue_resource: DialogueResource) -> void:
+	if ending_dialogue_resource == dialogue_resource:
+		dialogue_ended.emit()
 
 
 #endregion

--- a/addons/dialogue_manager/nodes/actionable/actionable_3d.gd
+++ b/addons/dialogue_manager/nodes/actionable/actionable_3d.gd
@@ -12,6 +12,10 @@ class_name Actionable3D extends Area3D
 ## Emitted when this [Actionable3D] has [code]action()[/code] called on it.
 signal actioned()
 
+## Emitted when the [DialogueResource] associated with this [Actionable2D] ends. [b]NOTE:[/b] The
+## signal is also emitted if the same resource is used for multiple [Actionable2D] nodes in the tree.
+signal dialogue_ended()
+
 
 ## The [DialogueResource] to use when starting dialogue.
 @export var dialogue_resource: DialogueResource = null:
@@ -24,19 +28,21 @@ signal actioned()
 		return dialogue_resource
 
 ## The target cue to start dialogue from.
-var dialogue_cue: String = ""
+@export var dialogue_cue: String = ""
 
 ## The dialogue balloon that was last used by calling [code]action()[/code] (if there was one).
 var dialogue_balloon: Node
 
 ## The method used to start dialogue action [code]action()[/code] is called. Override if you need
 ## different logic.
-static var start_dialogue: Callable = func(p_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node2D:
-	return DialogueManager.show_dialogue_balloon(p_dialogue_resource, from_cue, extra_game_states)
+static var start_dialogue: Callable = func(with_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node2D:
+	return DialogueManager.show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
 
 
 func _ready() -> void:
-	add_to_group("dialogue_actionables")
+	if not Engine.is_editor_hint():
+		add_to_group("dialogue_actionables")
+		DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
 
 
 #region Public
@@ -66,53 +72,12 @@ static func get_nearest_actionable_to(target_position: Vector3) -> Actionable3D:
 
 #endregion
 
-#region Properties
+#region Signals
 
 
-func _get_property_list() -> Array[Dictionary]:
-	var props: Array[Dictionary] = []
-
-	if is_instance_valid(dialogue_resource):
-		props.append({
-			name = "dialogue_cue",
-			type = TYPE_STRING
-		})
-
-	return props
-
-
-func _get(property: StringName) -> Variant:
-	match property:
-		"dialogue_cue":
-			return dialogue_cue
-
-	return null
-
-
-func _set(property: StringName, value: Variant) -> bool:
-	match property:
-		"dialogue_cue":
-			dialogue_cue = value
-			notify_property_list_changed()
-			return true
-
-	return false
-
-
-func _property_can_revert(property: StringName) -> bool:
-	match property:
-		"dialogue_cue":
-			return true
-
-	return false
-
-
-func _property_get_revert(property: StringName) -> Variant:
-	match property:
-		"dialogue_cue":
-			return ""
-
-	return null
+func _on_dialogue_ended(ending_dialogue_resource: DialogueResource) -> void:
+	if ending_dialogue_resource == dialogue_resource:
+		dialogue_ended.emit()
 
 
 #endregion

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,20 +5,20 @@
 ### Signals
 
 - `dialogue_started(resource: DialogueResource)` - emitted when a dialogue balloon is created by `DialogueManager` and dialogue begins.
-- `passed_label(label: String)` - emitted when a label marker is passed through.
+- `passed_Cue(Cue: String)` - emitted when a Cue marker is passed through.
 - `got_dialogue(line: DialogueLine)` - emitted when a dialogue line is found.
 - `mutated(mutation: Dictionary)` - emitted when a mutation line is about to be run (not including `set` lines).
 - `dialogue_ended(resource: DialogueResource)` - emitted when the next line of dialogue is empty and provides the calling resource.
 
 ### Methods
 
-#### `func show_dialogue_balloon(resource: DialogueResource, label: String = "", extra_game_states: Array = []) -> Node`
+#### `func show_dialogue_balloon(resource: DialogueResource, Cue: String = "", extra_game_states: Array = []) -> Node`
 
 Opens the dialogue balloon configured in settings (or the example balloon if none has been set).
 
 Returns the balloon's base node in case you want to `queue_free()` it yourself.
 
-#### `func show_dialogue_balloon_scene(balloon_scene: Node | String, resource: DialogueResource, label: String = "", extra_game_states: Array = []) -> Node`
+#### `func show_dialogue_balloon_scene(balloon_scene: Node | String, resource: DialogueResource, Cue: String = "", extra_game_states: Array = []) -> Node`
 
 Opens a dialogue balloon given in `balloon_scene`.
 
@@ -28,7 +28,7 @@ Returns the balloon's base node in case you want to `queue_free()` it yourself.
 
 **Must be used with `await`.**
 
-Given a resource and label/ID, it will find the next printable line of dialogue (running mutations along the way).
+Given a resource and Cue/ID, it will find the next printable line of dialogue (running mutations along the way).
 
 Returns a `DialogueLine` or `null`.
 
@@ -36,7 +36,7 @@ Pass an array of nodes as `extra_game_states` in order to temporarily add to the
 
 You can specify `mutation_behaviour` to be one of the values provided in the `DialogueManager.MutationBehaviour` enum. `Wait` is the default and will `await` any mutation lines. `DoNoWait` will run the mutations but not wait for them before moving to the next line. `Skip` will skip mutations entirely. In most cases, you should leave this as the default. _The example balloon only supports `Wait`_.
 
-#### `func show_example_dialogue_balloon(resource: DialogueResource, label: String = "", extra_game_states: Array = []) -> CanvasLayer`
+#### `func show_example_dialogue_balloon(resource: DialogueResource, Cue: String = "", extra_game_states: Array = []) -> CanvasLayer`
 
 Opens the example balloon.
 

--- a/docs/Basic_Dialogue.md
+++ b/docs/Basic_Dialogue.md
@@ -212,7 +212,7 @@ If you want to end the flow from within the dialogue you can jump to `END`:
 
 This will end the current flow of dialogue.
 
-You can also use a "jump and return" kind of jump that redirects the flow of dialogue and then returns to where it jumped from. Those lines are prefixed with `=>< ` and then specify the label to jump to. Once the flow encounters an `END` (or the end of the file) flow will return to where it jumped from and continue from there.
+You can also use a "jump and return" kind of jump that redirects the flow of dialogue and then returns to where it jumped from. Those lines are prefixed with `=>< ` and then specify the cue to jump to. Once the flow encounters an `END` (or the end of the file) flow will return to where it jumped from and continue from there.
 
 If you want to force the end of the conversation regardless of any chained "jump and returns", you can use an `=> END!` line.
 
@@ -222,20 +222,20 @@ Jumps can also be used inline for responses:
 ~ start
 Nathan: Well?
 - First one
-- Another one => another_label
+- Another one => another_cue
 - Start again => start
 => END
 
-~ another_label
+~ another_cue
 Nathan: Another one?
 => END
 ```
 
 ### Expression Jumps
 
-You can use expressions as jump directives. The expression needs to resolve to a known label name or results will be unexpected.
+You can use expressions as jump directives. The expression needs to resolve to a known cue name or results will be unexpected.
 
-**Use these with caution** as the dialogue compiler can't verify expression values match any labels at compile time.
+**Use these with caution** as the dialogue compiler can't verify expression values match any cues at compile time.
 
 Expression jumps look something like:
 
@@ -253,7 +253,7 @@ Nathan: Blah blah blah.
 => END
 ```
 
-Which we can then import into another dialogue file and jump to the `banter` label from the snippets file (note the `=><` syntax which denotes to return to this line after the jumped dialogue finishes):
+Which we can then import into another dialogue file and jump to the `banter` cue from the snippets file (note the `=><` syntax which denotes to return to this line after the jumped dialogue finishes):
 
 ```
 import "res://snippets.dialogue" as snippets

--- a/docs/Conditions_Mutations.md
+++ b/docs/Conditions_Mutations.md
@@ -32,7 +32,7 @@ Responses can also have "if" conditions. Wrap these in `[` and `/]` (sometimes r
 Nathan: What would you like?
 - This one [if SomeGlobal.some_property == 0 or SomeGlobal.some_other_property == false /]
     Nathan: Ah, so you want this one?
-- Another one [if SomeGlobal.some_method() /] => another_label
+- Another one [if SomeGlobal.some_method() /] => another_cue
 - Nothing => END
 ```
 
@@ -53,9 +53,9 @@ Nathan: You have {{num_apples}} [if num_apples == 1]apple[else]apples[/if], nice
 Randomised lines and randomised jump lines can also have conditions. Conditions for randomised lines go in square brackets after the `%` and before the line's content:
 
 ```
-% => some_label
-%2 => some_other_label
-% [if SomeGlobal.some_condition] => another_label
+% => some_cue
+%2 => some_other_cue
+% [if SomeGlobal.some_condition] => another_cue
 ```
 
 ### Match

--- a/tests/main.dialogue.import
+++ b/tests/main.dialogue.import
@@ -1,7 +1,7 @@
 [remap]
 
 importer="dialogue_manager"
-importer_version=17
+importer_version=18
 type="Resource"
 uid="uid://bnnha7rqiubty"
 path="res://.godot/imported/main.dialogue-fdb08bf1f3a902dc953e9d549b742c4a.tres"

--- a/tests/snippets.dialogue.import
+++ b/tests/snippets.dialogue.import
@@ -1,7 +1,7 @@
 [remap]
 
 importer="dialogue_manager"
-importer_version=17
+importer_version=18
 type="Resource"
 uid="uid://m7wueb1et2an"
 path="res://.godot/imported/snippets.dialogue-fef751acf14db992e43cc94dcce41bb4.tres"


### PR DESCRIPTION
This adds a convenience shortcut to `Actionable2D` and `Actionable3D` nodes for connecting to the `dialogue_ended` signal from `DialogueManager`.