### PR TITLE
Allow creating cues from Actionable nodes

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -1091,18 +1091,18 @@ func go_to_cue(cue: String, create_if_none: bool = false) -> void:
 			found_cue = true
 			set_caret_line(i)
 			set_caret_column(0)
-			center_viewport_to_caret()
+			center_viewport_to_caret.call_deferred()
 
 	if create_if_none and not found_cue:
 		text += "\n\n\n~ %s\n\n=> END" % [cue]
 		set_caret_line(text.split("\n").size() - 2)
-		center_viewport_to_caret()
+		center_viewport_to_caret.call_deferred()
 
 
 ## Go to a given line number.
 func go_to_line_number(line_number: int) -> void:
 	set_caret_line(line_number)
-	center_viewport_to_caret()
+	center_viewport_to_caret.call_deferred()
 
 
 ## Get all character names from the dialogue that match the given prefix.

--- a/addons/dialogue_manager/components/cue_editor_property/editor_property_control.gd
+++ b/addons/dialogue_manager/components/cue_editor_property/editor_property_control.gd
@@ -19,17 +19,24 @@ var cue: String = "":
 	get:
 		return cue
 
+var link_action: String = "show"
+
 @onready var button: OptionButton = %Button
 @onready var link_button: Button = %LinkButton
+@onready var confirm_cue_name_dialog: ConfirmationDialog = %ConfirmCueNameDialog
+@onready var cue_name_label: Label = %CueNameLabel
+@onready var cue_name_edit: LineEdit = %CueNameEdit
 
 
 func _ready() -> void:
+	confirm_cue_name_dialog.register_text_enter(cue_name_edit)
+
 	_update()
 
-	link_button.icon = get_theme_icon("ExternalLink", "EditorIcons")
 	button.get_popup().index_pressed.connect(_on_index_pressed)
-
 	button.get_popup().about_to_popup.connect(_on_menu_about_to_popup)
+
+	DMPlugin.instance.import_plugin.compiled_resource.connect(_on_dialogue_compiled)
 
 
 func _update() -> void:
@@ -37,7 +44,10 @@ func _update() -> void:
 
 	var cues: PackedStringArray = []
 	if has_valid_dialogue_resource:
-		cues = Array(actionable.dialogue_resource.get_cues()).filter(func(l: String) -> bool: return not l.contains("/"))
+		var resource: DialogueResource = ResourceLoader.load(actionable.dialogue_resource.resource_path, "", ResourceLoader.CACHE_MODE_REPLACE)
+		cues = Array(resource.get_cues()).filter(func(l: String) -> bool: return not l.contains("/"))
+
+	link_button.disabled = not has_valid_dialogue_resource
 
 	var popup: PopupMenu = button.get_popup()
 	popup.clear()
@@ -47,7 +57,6 @@ func _update() -> void:
 	if cues.is_empty() or not has_valid_dialogue_resource:
 		popup.add_item(DMConstants.translate("<empty>"))
 		popup.set_item_disabled(0, true)
-		link_button.disabled = true
 	else:
 		for existing_cue: String in cues:
 			popup.add_icon_item(cue_icon, existing_cue)
@@ -57,14 +66,17 @@ func _update() -> void:
 	if cue.is_empty():
 		button.text = DMConstants.translate("<empty>")
 		button.icon = null
-		link_button.disabled = true
+		link_button.icon = get_theme_icon("New", "EditorIcons")
+		link_action = "create"
 	elif cues.has(cue):
 		button.select(-1)
 		button.select(cues.find(cue))
-		link_button.disabled = false
+		link_button.icon = get_theme_icon("ExternalLink", "EditorIcons")
+		link_action = "show"
 	else:
-		button.selected = cues.size()
-		link_button.disabled = true
+		button.select(cues.size())
+		link_button.icon = get_theme_icon("New", "EditorIcons")
+		link_action = "create"
 
 
 func show_cue_in_editor(next_cue: String) -> void:
@@ -74,6 +86,10 @@ func show_cue_in_editor(next_cue: String) -> void:
 
 
 #region Signals
+
+
+func _on_dialogue_compiled(_resource: DialogueResource) -> void:
+	_update.call_deferred()
 
 
 func _on_menu_about_to_popup() -> void:
@@ -87,10 +103,25 @@ func _on_index_pressed(index: int) -> void:
 
 
 func _on_link_button_pressed() -> void:
-	if cue.is_empty():
-		cue = actionable.name.to_snake_case()
-		cue_changed.emit(cue)
+	match link_action:
+		"create":
+			if cue.is_empty():
+				cue_name_edit.text = actionable.name.to_snake_case()
+			else:
+				cue_name_edit.text = cue
+			cue_name_label.text = DMConstants.translate("Cue:")
+			confirm_cue_name_dialog.popup_centered()
+			cue_name_edit.grab_focus.call_deferred()
+			cue_name_edit.select_all.call_deferred()
 
+		"show":
+			show_cue_in_editor.call_deferred(cue)
+			_update.call_deferred()
+
+
+func _on_confirm_cue_name_dialog_confirmed() -> void:
+	cue = cue_name_edit.text.to_snake_case()
+	cue_changed.emit(cue)
 	show_cue_in_editor.call_deferred(cue)
 	_update.call_deferred()
 

--- a/addons/dialogue_manager/components/cue_editor_property/editor_property_control.tscn
+++ b/addons/dialogue_manager/components/cue_editor_property/editor_property_control.tscn
@@ -19,4 +19,31 @@ unique_name_in_owner = true
 layout_mode = 2
 flat = true
 
+[node name="ConfirmCueNameDialog" type="ConfirmationDialog" parent="." unique_id=967805543]
+unique_name_in_owner = true
+oversampling_override = 1.0
+size = Vector2i(200, 115)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ConfirmCueNameDialog" unique_id=151160442]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -49.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="CueNameLabel" type="Label" parent="ConfirmCueNameDialog/VBoxContainer" unique_id=1635294933]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Cue:"
+
+[node name="CueNameEdit" type="LineEdit" parent="ConfirmCueNameDialog/VBoxContainer" unique_id=830071500]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
 [connection signal="pressed" from="LinkButton" to="." method="_on_link_button_pressed"]
+[connection signal="confirmed" from="ConfirmCueNameDialog" to="." method="_on_confirm_cue_name_dialog_confirmed"]

--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -473,3 +473,6 @@ msgstr "Auto"
 
 msgid "<empty>"
 msgstr "<empty>"
+
+msgid "Cue:"
+msgstr ""

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -463,3 +463,6 @@ msgstr ""
 
 msgid "<empty>"
 msgstr ""
+
+msgid "Cue:"
+msgstr ""


### PR DESCRIPTION
This adds a button for creating new cues when the `Actionable2D`/`Actionable3D` cue is empty.