### PR TITLE
Enable case-insensitive speaker name autocompletion

### DIFF
--- a/addons/dialogue_manager/components/code_edit.gd
+++ b/addons/dialogue_manager/components/code_edit.gd
@@ -272,7 +272,7 @@ func _add_character_name_completions(current_line: String) -> void:
 			return
 
 	var name_so_far: String = WEIGHTED_RANDOM_PREFIX.sub(current_line.strip_edges(), "")
-	if name_so_far == "" or name_so_far[0].to_upper() != name_so_far[0]:
+	if name_so_far == "":
 		return
 
 	var names: PackedStringArray = get_character_names(name_so_far)
@@ -1148,7 +1148,10 @@ func get_character_names(beginning_with: String) -> PackedStringArray:
 		if line.strip_edges().begins_with("#"): continue # skip comments
 		if ": " in line:
 			var character_name: String = WEIGHTED_RANDOM_PREFIX.sub(line.split(": ")[0].strip_edges(), "")
-			if not character_name in names and _matches_prompt(beginning_with, character_name):
+			# Checks for first-letter match before doing fuzzy matching
+			if not character_name in names and character_name.length() > 0 and beginning_with.length() > 0 \
+			and character_name.to_lower()[0] == beginning_with.to_lower()[0] \
+			and _matches_prompt(beginning_with, character_name):
 				names.append(character_name)
 	return names
 


### PR DESCRIPTION
Previously, speaker name autocompletion only triggered when typing uppercase letters. This change allows typing in lowercase (e.g., "fred" will autocomplete to "Fred:").

https://github.com/user-attachments/assets/8efafffb-620c-464a-877c-232c21ee832a

To prevent false matches, we now verify that the first letter of written text matches the first letter of the speaker name (case-insensitive). 
Without this check, typing "v" would incorrectly suggest "Steve", for example, since fuzzy matching would find the 'v' in the middle of the name. 

After the first-letter check passes, fuzzy matching is applied to the remaining characters.

I feel like this is an overall usability improvement (writing dialogue fast gets interrupted if you have to always remember to capitalize the speaker name), but feel free to reject it if you think it's too opinionated! 