### PR TITLE
Fix generating static IDs with multiline text

### DIFF
--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -36,6 +36,8 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		if not line.type in [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE]: continue
 
 		var static_id: String = line.get(&"static_id", line.text)
+		if static_id.is_empty():
+			static_id = line.text
 
 		if static_id in known_keys: continue
 
@@ -43,7 +45,7 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		translated_lines.append(line)
 
 		var message: String = line.text.replace('"', '\"')
-		var context: String = line.static_id.replace('"', '\"') if static_id != line.text else ""
+		var context: String = static_id.replace('"', '\"') if static_id != line.text else ""
 		var plural: String = ""
 		var notes: String = "\n".join(["Character name: %s" % line.character, line.get("notes", "")].filter(func(s: String) -> bool: return not s.is_empty()))
 		msgs.append(PackedStringArray([

--- a/addons/dialogue_manager/utilities/translations.gd
+++ b/addons/dialogue_manager/utilities/translations.gd
@@ -41,8 +41,9 @@ static func generate_static_line_ids_for_text(text: String, file_path: String) -
 		var key: String = _generate_id(file_path)
 		while key in DMCache.known_static_ids:
 			key = _generate_id(file_path)
+
 		line = line.replace("\\n", "!NEWLINE!")
-		translatable_text = translatable_text.replace("\n", "!NEWLINE!")
+		translatable_text = translatable_text.replace("\\n", "!NEWLINE!")
 		lines[i] = line.replace(translatable_text, translatable_text + " [ID:%s]" % [key]).replace("!NEWLINE!", "\\n")
 
 		DMCache.known_static_ids[key] = file_path


### PR DESCRIPTION
This fixes an issue with generating static IDs when `\n` was in the line.