### PR TITLE
Fix translation export when character is missing

### DIFF
--- a/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
+++ b/addons/dialogue_manager/components/code_edit_syntax_highlighter.gd
@@ -92,7 +92,7 @@ func _get_line_syntax_highlighting(line: int) -> Dictionary:
 
 			# Highlight character name (but ignore ":" within line ID reference)
 			var split_index: int = dialogue_text.replace("\\:", "??").find(":")
-			if text.substr(split_index - 3, 3) != "[ID":
+			if dialogue_text.substr(split_index - 3, 3) != "[ID":
 				colors[index + split_index + 1] = { color = theme.text_color }
 			else:
 				# If there's no character name then just highlight the text as dialogue.

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -47,7 +47,12 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		var message: String = line.text.replace('"', '\"')
 		var context: String = static_id.replace('"', '\"') if static_id != line.text else ""
 		var plural: String = ""
-		var notes: String = "\n".join(["Character name: %s" % line.character, line.get("notes", "")].filter(func(s: String) -> bool: return not s.is_empty()))
+		var extra_details: PackedStringArray = []
+		if line.has("character"):
+			extra_details.append("Character name: %s" % line.get("character", ""))
+		if line.has("notes"):
+			extra_details.append(line.get("notes", ""))
+		var notes: String = "\n".join(extra_details)
 		msgs.append(PackedStringArray([
 			message,
 			context,


### PR DESCRIPTION
This fixes an issue that was preventing translation exporting when a line was missing a character name.