### PR TITLE
Add support for _to_dialogue_string()

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -396,6 +396,8 @@ func get_resolved_line_data(data: Dictionary, extra_game_states: Array = []) -> 
 			# by special quotes while translating.
 			index = text.replace("“", "\"").replace("”", "\"").find(replacement.value_in_text)
 		if index > -1:
+			if value is Object and "_to_dialogue_string" in value:
+				value = value._to_dialogue_string()
 			text = text.substr(0, index) + str(value) + text.substr(index + replacement.value_in_text.length())
 
 	var compilation: DMCompilation = DMCompilation.new()

--- a/docs/State.md
+++ b/docs/State.md
@@ -29,7 +29,6 @@ Once you have some state hooked up you can start using conditions in branches an
 
 See [Conditions & Mutations](./Conditions_Mutations.md).
 
-
 ## Variables in dialogue
 
 To show some value of game state within a line of dialogue, wrap it in double curlies.
@@ -43,6 +42,10 @@ Similarly, if the name of a character is based on a variable you can provide it 
 ```
 {{SomeGlobal.some_character_name}}: My name was provided by the player.
 ```
+
+### `_to_string` and `_to_dialogue_string`
+
+By default, variables will be resolved with `str` which calls `_to_string` on the value but you can define `_to_dialogue_string() -> String` on your objects if you need a different string representation (ie. debugging non-primitives might need a different string compared to using it in dialogue).
 
 ### Local variables
 
@@ -73,7 +76,7 @@ Nathan: What would you like to know?
     => END
 ```
 
-2. **Passing extra game states** when starting dialogue (see [Extra Game States](./Conditions_Mutations.md#extra-game-states) for details). Variables from extra game states can be referenced directly without the `locals.` prefix.
+1. **Passing extra game states** when starting dialogue (see [Extra Game States](./Conditions_Mutations.md#extra-game-states) for details). Variables from extra game states can be referenced directly without the `locals.` prefix.
 
 ### Expression Jumps
 

--- a/tests/test_basic_dialogue.gd
+++ b/tests/test_basic_dialogue.gd
@@ -148,6 +148,16 @@ Nathan: Your name is {{StateForTests.character_name}}?")
 	assert(line.text == "Your name is changed?", "Name should have changed.")
 
 
+func test_can_resolve_custom_strings() -> void:
+	var resource: DialogueResource = create_resource("
+~ start
+Nathan: This is a {{thing}}.
+=> END")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start", [{ thing = Thing.new() }])
+	assert(line.text == "This is a thing.", "Should resolve to simple string.")
+
+
 func test_can_parse_tags() -> void:
 	var output: DMCompilerResult = compile("Nathan: This is some dialogue [#tag1, #tag2]")
 
@@ -304,3 +314,8 @@ Nathan: Third line [ID:THIRD]")
 	var id: String = DialogueManager.static_id_to_line_id(resource, "SECOND")
 	var line: DialogueLine = await resource.get_next_dialogue_line(id)
 	assert(line.text == "Second line", "Should match second line")
+
+
+class Thing:
+	func _to_dialogue_string() -> String:
+		return "thing"


### PR DESCRIPTION
This adds support for using `_to_dialogue_string` to convert non-primitives to strings for printing in dialogue.