### PR TITLE
Add "dialogue" POT context if no static ID exists

### DIFF
--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -45,7 +45,7 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		translated_lines.append(line)
 
 		var message: String = line.text.replace('"', '\"')
-		var context: String = static_id.replace('"', '\"') if static_id != line.text else ""
+		var context: String = static_id.replace('"', '\"') if static_id != line.text else "dialogue"
 		var plural: String = ""
 		var extra_details: PackedStringArray = []
 		if line.has("character"):


### PR DESCRIPTION
Hello,

There is already a "dialogue" context for character names
It could be nice to use it for all dialog lines too in order to regroup translations inside po files like in this screenshot :

<img width="1254" height="740" alt="Capture d’écran 2026-05-14 à 17 00 00" src="https://github.com/user-attachments/assets/015fb59e-2193-4f48-a4d7-61f3b5118921" />

If you think it's not necessary for all users, this could depend on a plugin global option