### PR TITLE
Fix missing context when displaying dialogue

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -667,7 +667,7 @@ func translate(data: Dictionary) -> String:
 	var static_id: String = data.get(&"static_id", data.text)
 
 	if static_id == "" or static_id == data.text:
-		return tr(data.text)
+		return tr(data.text, "dialogue")
 	else:
 		return tr(data.text, StringName(static_id))
 

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -45,7 +45,7 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		translated_lines.append(line)
 
 		var message: String = line.text.replace('"', '\"')
-		var context: String = static_id.replace('"', '\"') if static_id != line.text else ""
+		var context: String = static_id.replace('"', '\"') if static_id != line.text else "dialogue"
 		var plural: String = ""
 		var extra_details: PackedStringArray = []
 		if line.has("character"):


### PR DESCRIPTION
In my previous PR, I added "dialogue" context for exports to POT file
This PR add the context when displaying dialogue in-game (or DM will not be able to find correct translation from PO file)