### PR TITLE
Add a safety wrapper when using `load` in dialogue

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -52,7 +52,7 @@ var get_current_scene: Callable = func() -> Node:
 
 ## Used to resolve the load function used in [code]*.dialogue[/code] files.
 ## Override this if you need safer loading or custom loading logic.
-var dialogue_dsl_load: Callable = load
+var load_from_within_dialogue: Callable = load
 
 var _has_loaded_autoloads: bool = false
 var _autoloads: Dictionary = {}
@@ -1218,9 +1218,9 @@ func _resolve(tokens: Array, extra_game_states: Array) -> Variant:
 							4:
 								token.value = Color(args[0], args[1], args[2], args[3])
 						found = true
-					&"load", &"Load" when dialogue_dsl_load.is_valid():
+					&"load", &"Load" when load_from_within_dialogue.is_valid():
 						token.type = DMConstants.TOKEN_VALUE
-						token.value = dialogue_dsl_load.call(args[0])
+						token.value = load_from_within_dialogue.call(args[0])
 						found = true
 					&"roll_dice", &"RollDice":
 						token.type = DMConstants.TOKEN_VALUE

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -50,6 +50,10 @@ var get_current_scene: Callable = func() -> Node:
 		current_scene = root.get_child(root.get_child_count() - 1)
 	return current_scene
 
+## Used to resolve the load function used in [code]*.dialogue[/code] files.
+## Override this if you need safer loading or custom loading logic.
+var dialogue_dsl_load: Callable = load
+
 var _has_loaded_autoloads: bool = false
 var _autoloads: Dictionary = {}
 
@@ -1214,9 +1218,9 @@ func _resolve(tokens: Array, extra_game_states: Array) -> Variant:
 							4:
 								token.value = Color(args[0], args[1], args[2], args[3])
 						found = true
-					&"load", &"Load":
+					&"load", &"Load" when dialogue_dsl_load.is_valid():
 						token.type = DMConstants.TOKEN_VALUE
-						token.value = load(args[0])
+						token.value = dialogue_dsl_load.call(args[0])
 						found = true
 					&"roll_dice", &"RollDice":
 						token.type = DMConstants.TOKEN_VALUE

--- a/tests/test_dialogue_dsl_load.gd
+++ b/tests/test_dialogue_dsl_load.gd
@@ -2,8 +2,8 @@ extends AbstractTest
 
 
 func test_custom_load_function_is_called() -> void:
-	var original_load: Callable = DialogueManager.dialogue_dsl_load
-	DialogueManager.dialogue_dsl_load = func(path: String) -> String:
+	var original_load: Callable = DialogueManager.load_from_within_dialogue
+	DialogueManager.load_from_within_dialogue = func(path: String) -> String:
 		return "loaded:" + path
 
 	var resource: DialogueResource = create_resource("
@@ -13,12 +13,12 @@ Nathan: {{load(\"my_resource\")}}")
 	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "loaded:my_resource", "Should use custom load function.")
 
-	DialogueManager.dialogue_dsl_load = original_load
+	DialogueManager.load_from_within_dialogue = original_load
 
 
 func test_custom_load_function_with_capital_l() -> void:
-	var original_load: Callable = DialogueManager.dialogue_dsl_load
-	DialogueManager.dialogue_dsl_load = func(path: String) -> String:
+	var original_load: Callable = DialogueManager.load_from_within_dialogue
+	DialogueManager.load_from_within_dialogue = func(path: String) -> String:
 		return "capital:" + path
 
 	var resource: DialogueResource = create_resource("
@@ -28,12 +28,12 @@ Nathan: {{Load(\"other_resource\")}}")
 	var line: DialogueLine = await resource.get_next_dialogue_line("start")
 	assert(line.text == "capital:other_resource", "Should use custom load function with capital L.")
 
-	DialogueManager.dialogue_dsl_load = original_load
+	DialogueManager.load_from_within_dialogue = original_load
 
 
 func test_invalid_callable_prevents_load_from_resolving() -> void:
-	var original_load: Callable = DialogueManager.dialogue_dsl_load
-	DialogueManager.dialogue_dsl_load = Callable()
+	var original_load: Callable = DialogueManager.load_from_within_dialogue
+	DialogueManager.load_from_within_dialogue = Callable()
 	var original_ignore: bool = DialogueManager.ignore_missing_state_values
 	DialogueManager.ignore_missing_state_values = true
 
@@ -46,4 +46,4 @@ Nathan: {{load(\"anything\")}}")
 	assert(line.text != "loaded:anything", "Custom callable should not be used.")
 
 	DialogueManager.ignore_missing_state_values = original_ignore
-	DialogueManager.dialogue_dsl_load = original_load
+	DialogueManager.load_from_within_dialogue = original_load

--- a/tests/test_dialogue_dsl_load.gd
+++ b/tests/test_dialogue_dsl_load.gd
@@ -1,0 +1,49 @@
+extends AbstractTest
+
+
+func test_custom_load_function_is_called() -> void:
+	var original_load: Callable = DialogueManager.dialogue_dsl_load
+	DialogueManager.dialogue_dsl_load = func(path: String) -> String:
+		return "loaded:" + path
+
+	var resource: DialogueResource = create_resource("
+~ start
+Nathan: {{load(\"my_resource\")}}")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
+	assert(line.text == "loaded:my_resource", "Should use custom load function.")
+
+	DialogueManager.dialogue_dsl_load = original_load
+
+
+func test_custom_load_function_with_capital_l() -> void:
+	var original_load: Callable = DialogueManager.dialogue_dsl_load
+	DialogueManager.dialogue_dsl_load = func(path: String) -> String:
+		return "capital:" + path
+
+	var resource: DialogueResource = create_resource("
+~ start
+Nathan: {{Load(\"other_resource\")}}")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
+	assert(line.text == "capital:other_resource", "Should use custom load function with capital L.")
+
+	DialogueManager.dialogue_dsl_load = original_load
+
+
+func test_invalid_callable_prevents_load_from_resolving() -> void:
+	var original_load: Callable = DialogueManager.dialogue_dsl_load
+	DialogueManager.dialogue_dsl_load = Callable()
+	var original_ignore: bool = DialogueManager.ignore_missing_state_values
+	DialogueManager.ignore_missing_state_values = true
+
+	var resource: DialogueResource = create_resource("
+~ start
+Nathan: {{load(\"anything\")}}")
+
+	var line: DialogueLine = await resource.get_next_dialogue_line("start")
+	assert(line != null, "Should not crash with invalid callable.")
+	assert(line.text != "loaded:anything", "Custom callable should not be used.")
+
+	DialogueManager.ignore_missing_state_values = original_ignore
+	DialogueManager.dialogue_dsl_load = original_load

--- a/tests/test_dialogue_dsl_load.gd.uid
+++ b/tests/test_dialogue_dsl_load.gd.uid
@@ -1,0 +1,1 @@
+uid://d5mqyl1cqdn2p

--- a/tests/tests.tscn
+++ b/tests/tests.tscn
@@ -36,20 +36,21 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_top = 94.0
-offset_bottom = -403.0
+offset_top = -5.5
+offset_bottom = -379.5
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/normal_font_size = 100
 bbcode_enabled = true
 text = "[wave][center]All tests passed"
+fit_content = true
 
 [node name="Label" type="Label" parent="." unique_id=1230363543]
 modulate = Color(1, 1, 1, 0.596078)
 layout_mode = 0
-offset_top = 260.0
+offset_top = 293.0
 offset_right = 1153.0
-offset_bottom = 286.0
+offset_bottom = 335.0
 theme_override_font_sizes/font_size = 30
 text = "See Output for details"
 horizontal_alignment = 1


### PR DESCRIPTION
#1209 highlights a security risk associated with the `load/Load` DSL function in `*.dialogue` files.

This PR introduces a `Callable` field, allowing users to configure the behavior of the `load`/`Load` functions. Corresponding tests have been added.

This PR only adds the configuration and does not modify the language server or code hints for `*.dialogue` files.

> For example, this slice of code will be prevent if the load function was set to `Callable()`. No compile time warnings. 
```gdscript
DialogueManager.dialogue_dsl_load = Callable()
```
```dialogue
$> debug(load("res://icon.svg"))
```