### PR TITLE
Add option to disable injecting "self" into game states

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -83,6 +83,13 @@ namespace DialogueManagerRuntime
         }
 
 
+        public static bool IncludeDialogueResourceAsSelf
+        {
+            get => (bool)Instance.Get("include_dialogue_resource_as_self");
+            set => Instance.Set("include_dialogue_resource_as_self", value);
+        }
+
+
         public static TranslationSource TranslationSource
         {
             get => (TranslationSource)(int)Instance.Get("translation_source");

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -40,7 +40,7 @@ var include_singletons: bool = true
 var include_classes: bool = true
 
 ## Allow dialogue to call methods on [code]DialogueResource[/code]
-var include_dialogue_resurce: bool = true
+var include_dialogue_resource_as_self: bool = true
 
 ## A runtime override for the project setting to ignore missing state values.
 var ignore_missing_state_values: bool = false
@@ -125,7 +125,7 @@ func _get_next_dialogue_line(resource: DialogueResource, key: String = "", extra
 			extra_game_states = [autoload] + extra_game_states
 
 	# Inject "self" into the extra game states.
-	if include_dialogue_resurce:
+	if include_dialogue_resource_as_self:
 		_inject_state("self", resource, extra_game_states)
 
 	# Get the line data
@@ -1355,7 +1355,7 @@ func _resolve(tokens: Array, extra_game_states: Array) -> Variant:
 			if str(token.value) == "null":
 				token.type = DMConstants.TOKEN_VALUE
 				token.value = null
-			elif str(token.value) == "self":
+			elif str(token.value) == "self" and extra_game_states.size() > 0 and typeof(extra_game_states[0]) == TYPE_DICTIONARY and extra_game_states[0].has("self"):
 				token.type = DMConstants.TOKEN_VALUE
 				token.value = extra_game_states[0].self
 			elif tokens[i - 1].type == DMConstants.TOKEN_DOT:

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -39,6 +39,9 @@ var include_singletons: bool = true
 ## Allow dialogue to call static methods/properties on classes
 var include_classes: bool = true
 
+## Allow dialogue to call methods on [code]DialogueResource[/code]
+var include_dialogue_resurce: bool = true
+
 ## A runtime override for the project setting to ignore missing state values.
 var ignore_missing_state_values: bool = false
 
@@ -122,7 +125,8 @@ func _get_next_dialogue_line(resource: DialogueResource, key: String = "", extra
 			extra_game_states = [autoload] + extra_game_states
 
 	# Inject "self" into the extra game states.
-	_inject_state("self", resource, extra_game_states)
+	if include_dialogue_resurce:
+		_inject_state("self", resource, extra_game_states)
 
 	# Get the line data
 	var dialogue_line: DialogueLine = await get_line(resource, key, extra_game_states)


### PR DESCRIPTION
#1209 raised some security concerns regarding DM.

This PR allows users to reasonably remove the injection of dialogue_resource, as DM is designed to be a stateless addon.

The injection of Godot objects (in this case, dialogue resources) could be used to modify scripts and trigger reloads, which introduces serious issues. The injection of Node objects also poses problems, such as calling `get_tree().quit()` or accessing low-level objects like `get_tree().window`.

`ExampleBalloon` will still inject the balloon node itself in `balloon.start`, but this injection is removable since custom balloons are expected to be designed and implemented by modifying the balloon template. Therefore, no related changes have been made to the balloon behavior.