### PR TITLE
Add value guards to get_current_scene usage

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -584,7 +584,13 @@ func static_id_to_line_ids(resource: DialogueResource, static_id: String) -> Pac
 func _start_balloon(balloon: Node, resource: DialogueResource, cue: String, extra_game_states: Array) -> void:
 	dialogue_started.emit(resource)
 
-	get_current_scene.call().add_child(balloon)
+	assert(get_current_scene.is_valid())
+
+	var current_scene: Node = get_current_scene.call()
+
+	assert(is_instance_valid(current_scene))
+
+	current_scene.add_child(balloon)
 
 	if balloon.has_method(&"start"):
 		balloon.start(resource, cue, extra_game_states)
@@ -781,9 +787,18 @@ func _get_serialised_state_node(key: String, node: Node) -> Dictionary:
 # Get the current game states
 func _get_game_states(extra_game_states: Array) -> Array:
 	_load_autoloads()
-	var current_scene: Node = get_current_scene.call()
+	
+	# Handle Callable() here
+	var current_scene: Node = get_current_scene.call() if get_current_scene.is_valid() else null
+	
+	var states_to_process: Array = extra_game_states 
+	states_to_process += [_registered_contexts]
+	if is_instance_valid(current_scene):
+		states_to_process += [current_scene]
+	states_to_process += game_states
+	
 	var unique_states: Array = []
-	for state: Variant in extra_game_states + [_registered_contexts] + [current_scene] + game_states:
+	for state: Variant in states_to_process:
 		if state != null and not unique_states.has(state):
 			unique_states.append(state)
 	return unique_states
@@ -1008,9 +1023,16 @@ func _warn_about_state_name_collisions(target_key: String, extra_game_states: Ar
 		if state:
 			state_shortcuts.append(state)
 
+	# Handle Callable() here
+	var current_scene: Node = get_current_scene.call() if get_current_scene.is_valid() else null
+	var states_to_process: Array = extra_game_states
+	if is_instance_valid(current_scene):
+		states_to_process += [current_scene]	
+	states_to_process += state_shortcuts
+
 	# Check any top level names for a collision
 	var states_with_key: Array = []
-	for state: Variant in extra_game_states + [get_current_scene.call()] + state_shortcuts:
+	for state: Variant in states_to_process:
 		if typeof(state) == TYPE_DICTIONARY:
 			if state.keys().has(target_key):
 				states_with_key.append("Dictionary")

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -787,18 +787,16 @@ func _get_serialised_state_node(key: String, node: Node) -> Dictionary:
 # Get the current game states
 func _get_game_states(extra_game_states: Array) -> Array:
 	_load_autoloads()
-	
-	# Handle Callable() here
+
 	var current_scene: Node = get_current_scene.call() if get_current_scene.is_valid() else null
-	
-	var states_to_process: Array = extra_game_states 
-	states_to_process += [_registered_contexts]
+	var possible_states: Array = extra_game_states
+	possible_states += [_registered_contexts]
 	if is_instance_valid(current_scene):
-		states_to_process += [current_scene]
-	states_to_process += game_states
-	
+		possible_states += [current_scene]
+	possible_states += game_states
+
 	var unique_states: Array = []
-	for state: Variant in states_to_process:
+	for state: Variant in possible_states:
 		if state != null and not unique_states.has(state):
 			unique_states.append(state)
 	return unique_states
@@ -1023,16 +1021,15 @@ func _warn_about_state_name_collisions(target_key: String, extra_game_states: Ar
 		if state:
 			state_shortcuts.append(state)
 
-	# Handle Callable() here
 	var current_scene: Node = get_current_scene.call() if get_current_scene.is_valid() else null
-	var states_to_process: Array = extra_game_states
+	var possible_states: Array = extra_game_states
 	if is_instance_valid(current_scene):
-		states_to_process += [current_scene]	
-	states_to_process += state_shortcuts
+		possible_states += [current_scene]
+	possible_states += state_shortcuts
 
 	# Check any top level names for a collision
 	var states_with_key: Array = []
-	for state: Variant in states_to_process:
+	for state: Variant in possible_states:
 		if typeof(state) == TYPE_DICTIONARY:
 			if state.keys().has(target_key):
 				states_with_key.append("Dictionary")


### PR DESCRIPTION
This PR improves the robustness of `get_current_scene` usages throughout the DialogueManager to prevent runtime errors when the scene reference is invalid or the callable is not set.

### Changes
- **`_start_balloon`**: Added assertions to ensure `get_current_scene` is valid and the returned node instance is valid before adding the balloon as a child.
- **`_get_game_states`**: Handled the case where `get_current_scene` is an empty/invalid `Callable()` by checking `is_valid()` before calling it, and only adding the current scene to game states if it is a valid instance.
- **`_warn_about_state_name_collisions`**: Applied the same safety checks to avoid calling an invalid callable and to skip null/invalid scene nodes during state collision checks.

This enables users to opt out of providing a `current_scene` reference by leaving `get_current_scene` as a default empty `Callable()`, without causing crashes.