### PR TITLE
Add option to export all dialogue files to a single CSV

### DIFF
--- a/addons/dialogue_manager/l10n/en.po
+++ b/addons/dialogue_manager/l10n/en.po
@@ -135,6 +135,9 @@ msgstr "Save character names to CSV..."
 msgid "save_to_csv"
 msgstr "Save lines to CSV..."
 
+msgid "save_all_to_csv"
+msgstr "Save all lines to single CSV..."
+
 msgid "import_from_csv"
 msgstr "Import line changes from CSV..."
 

--- a/addons/dialogue_manager/l10n/translations.pot
+++ b/addons/dialogue_manager/l10n/translations.pot
@@ -125,6 +125,9 @@ msgstr ""
 msgid "save_to_csv"
 msgstr ""
 
+msgid "save_all_to_csv"
+msgstr ""
+
 msgid "import_from_csv"
 msgstr ""
 

--- a/addons/dialogue_manager/utilities/translations.gd
+++ b/addons/dialogue_manager/utilities/translations.gd
@@ -160,6 +160,107 @@ static func export_translations_to_csv(to_path: String, text: String, dialogue_p
 	file.close()
 
 
+## Export the dialogue and responses of every dialogue file in the project to a single CSV.
+static func export_all_translations_to_csv(to_path: String) -> void:
+	var default_locale: String = DMSettings.get_setting(DMSettings.DEFAULT_CSV_LOCALE, "en")
+
+	var file: FileAccess
+
+	# If the file exists, read it first so we can keep any translations that are already in
+	# it and match its existing column layout
+	var existing_csv: Dictionary = {}
+	var headings: PackedStringArray = []
+	var delimiter: String = get_delimiter_for_csv(to_path)
+	var column_count: int = 2
+	var default_locale_column: int = 1
+	var character_column: int = -1
+	var notes_column: int = -1
+	if FileAccess.file_exists(to_path):
+		file = FileAccess.open(to_path, FileAccess.READ)
+		var is_first_line = true
+		var line: Array
+		while !file.eof_reached():
+			line = file.get_csv_line(delimiter)
+			if is_first_line:
+				is_first_line = false
+				headings = PackedStringArray(line)
+				column_count = line.size()
+				for i in range(1, line.size()):
+					if line[i] == default_locale:
+						default_locale_column = i
+					elif line[i] == "_character":
+						character_column = i
+					elif line[i] == "_notes":
+						notes_column = i
+				continue
+
+			# Make sure the line isn't empty before adding it
+			if line.size() > 0 and line[0].strip_edges() != "":
+				existing_csv[line[0]] = line
+		file.close()
+
+	# If there wasn't an existing file then start a fresh heading row
+	if headings.is_empty():
+		headings = ["keys", default_locale] + DMSettings.get_setting(DMSettings.EXTRA_CSV_LOCALES, [])
+		column_count = headings.size()
+
+	# Add the optional columns if their settings are turned on but they aren't in the file yet
+	if character_column == -1 and DMSettings.get_setting(DMSettings.INCLUDE_CHARACTER_IN_TRANSLATION_EXPORTS, false):
+		character_column = column_count
+		column_count += 1
+		headings.append("_character")
+	if notes_column == -1 and DMSettings.get_setting(DMSettings.INCLUDE_NOTES_IN_TRANSLATION_EXPORTS, false):
+		notes_column = column_count
+		column_count += 1
+		headings.append("_notes")
+
+	# Gather every translatable line from every dialogue file in the project. Files are
+	# processed in a stable (sorted) order and their lines are kept in source order, so
+	# editing one file only ever changes that file's section of the CSV instead of
+	# shuffling rows around.
+	var files: Array = Array(DMCache.get_files())
+	files.sort()
+
+	var known_keys: PackedStringArray = []
+	var lines_to_save: Array = []
+	for file_path: String in files:
+		var dialogue: Dictionary = DMCompiler.compile_string(FileAccess.get_file_as_string(file_path), file_path).lines
+		for key in dialogue.keys():
+			var line: Dictionary = dialogue.get(key)
+
+			if not line.type in [DMConstants.TYPE_DIALOGUE, DMConstants.TYPE_RESPONSE]: continue
+
+			var translation_key: String = line.get(&"translation_key", line.text)
+
+			if translation_key in known_keys: continue
+
+			known_keys.append(translation_key)
+
+			var line_to_save: PackedStringArray = []
+			if existing_csv.has(translation_key):
+				line_to_save = existing_csv.get(translation_key)
+				line_to_save.resize(column_count)
+			else:
+				line_to_save.resize(column_count)
+				line_to_save[0] = translation_key
+
+			line_to_save[default_locale_column] = line.text
+			if character_column > -1:
+				line_to_save[character_column] = "(response)" if line.type == DMConstants.TYPE_RESPONSE else line.character
+			if notes_column > -1:
+				line_to_save[notes_column] = line.get("notes", "")
+
+			lines_to_save.append(line_to_save)
+
+	# Write the combined CSV. Any keys left in existing_csv are no longer used by any
+	# dialogue and are intentionally dropped.
+	file = FileAccess.open(to_path, FileAccess.WRITE)
+	file.store_csv_line(headings, delimiter)
+	for line in lines_to_save:
+		file.store_csv_line(line, delimiter)
+	file.close()
+
+
 ## Get the delimiter used for an existing CSV
 static func get_delimiter_for_csv(path: String) -> String:
 	if FileAccess.file_exists(path):

--- a/addons/dialogue_manager/views/main_view.gd
+++ b/addons/dialogue_manager/views/main_view.gd
@@ -11,6 +11,7 @@ const TRANSLATIONS_GENERATE_LINE_IDS_FOR_FILE = 101
 const TRANSLATIONS_SAVE_CHARACTERS_TO_CSV = 201
 const TRANSLATIONS_SAVE_TO_CSV = 202
 const TRANSLATIONS_IMPORT_FROM_CSV = 203
+const TRANSLATIONS_SAVE_ALL_TO_CSV = 204
 
 const ITEM_SAVE = 100
 const ITEM_SAVE_AS = 101
@@ -22,7 +23,8 @@ const ITEM_SHOW_IN_FILESYSTEM = 201
 
 enum TranslationSource {
 	CharacterNames,
-	Lines
+	Lines,
+	AllLines
 }
 
 
@@ -466,6 +468,7 @@ func apply_theme() -> void:
 		popup.add_separator()
 		popup.add_icon_item(get_theme_icon("FileList", "EditorIcons"), DMConstants.translate(&"save_characters_to_csv"), TRANSLATIONS_SAVE_CHARACTERS_TO_CSV)
 		popup.add_icon_item(get_theme_icon("FileList", "EditorIcons"), DMConstants.translate(&"save_to_csv"), TRANSLATIONS_SAVE_TO_CSV)
+		popup.add_icon_item(get_theme_icon("FileList", "EditorIcons"), DMConstants.translate(&"save_all_to_csv"), TRANSLATIONS_SAVE_ALL_TO_CSV)
 		popup.add_icon_item(get_theme_icon("AssetLib", "EditorIcons"), DMConstants.translate(&"import_from_csv"), TRANSLATIONS_IMPORT_FROM_CSV)
 
 		# Dialog sizes
@@ -551,6 +554,20 @@ func add_path_to_project_translations(path: String) -> void:
 # Export dialogue and responses to CSV
 func export_translations_to_csv(path: String) -> void:
 	DMTranslationUtilities.export_translations_to_csv(path, code_edit.text, current_file_path)
+
+	EditorInterface.get_resource_filesystem().scan()
+	EditorInterface.get_file_system_dock().call_deferred("navigate_to_path", path)
+
+	# Add it to the project l10n settings if it's not already there
+	var default_locale: String = DMSettings.get_setting(DMSettings.DEFAULT_CSV_LOCALE, "en")
+	var language_code: RegExMatch = RegEx.create_from_string("^[a-z]{2,3}").search(default_locale)
+	var translation_path: String = path.replace(".csv", ".%s.translation" % language_code.get_string())
+	call_deferred("add_path_to_project_translations", translation_path)
+
+
+# Export every dialogue file in the project to a single CSV
+func export_all_translations_to_csv(path: String) -> void:
+	DMTranslationUtilities.export_all_translations_to_csv(path)
 
 	EditorInterface.get_resource_filesystem().scan()
 	EditorInterface.get_file_system_dock().call_deferred("navigate_to_path", path)
@@ -705,6 +722,12 @@ func _on_translations_button_menu_id_pressed(id: int) -> void:
 			export_dialog.current_path = get_last_export_path("csv")
 			export_dialog.popup_centered()
 
+		TRANSLATIONS_SAVE_ALL_TO_CSV:
+			translation_source = TranslationSource.AllLines
+			export_dialog.filters = PackedStringArray(["*.csv ; Translation CSV"])
+			export_dialog.current_path = get_last_export_path("csv")
+			export_dialog.popup_centered()
+
 		TRANSLATIONS_IMPORT_FROM_CSV:
 			import_dialog.current_path = get_last_export_path("csv")
 			import_dialog.popup_centered()
@@ -719,6 +742,8 @@ func _on_export_dialog_file_selected(path: String) -> void:
 					export_character_names_to_csv(path)
 				TranslationSource.Lines:
 					export_translations_to_csv(path)
+				TranslationSource.AllLines:
+					export_all_translations_to_csv(path)
 
 
 func _on_import_dialog_file_selected(path: String) -> void:


### PR DESCRIPTION
## What

Adds a new **"Save all lines to single CSV..."** item to the Translations menu. It exports every dialogue file in the project into a single CSV instead of one CSV per file.

## Why

When a project has many `.dialogue` files, keeping a separate CSV per file is tedious to manage and to hand to translators. This lets you collect everything in one place while keeping the per-file "Save lines to CSV..." option untouched.

## How it stays stable

The whole point is that re-exporting after editing a file shouldn't scramble the CSV:

- Dialogue files are processed in a stable (sorted by path) order, and within each file the lines stay in source order. So the CSV is grouped per file, and adding a line to one dialogue only inserts a row inside that file's section — existing rows keep their place.
- Existing translations are preserved: if a key already exists in the target CSV (including extra locale columns, `_character`, `_notes`), its values are carried over and only the default-locale text is refreshed.
- Keys that are no longer present in any dialogue are dropped.

It reuses the existing CSV settings (delimiter, default locale, extra locales, character/notes columns) and the same `.import` delimiter detection as the single-file export.

## Changes

- `utilities/translations.gd`: new `export_all_translations_to_csv(to_path)`.
- `views/main_view.gd`: new menu item, `TranslationSource.AllLines`, and `export_all_translations_to_csv(path)` wiring (adds the resulting `.translation` to project l10n settings like the existing export).
- `l10n/en.po` + `translations.pot`: new `save_all_to_csv` string.