### PR TITLE
Show error when indenting directly after a cue

### DIFF
--- a/addons/dialogue_manager/compiler/compilation.gd
+++ b/addons/dialogue_manager/compiler/compilation.gd
@@ -290,6 +290,11 @@ func parse_line_tree(root: DMTreeLine, parent: DMCompiledLine = null) -> Array[D
 func parse_cue_line(tree_line: DMTreeLine, line: DMCompiledLine, siblings: Array[DMTreeLine], sibling_index: int, parent: DMCompiledLine) -> int:
 	var result: int = OK
 
+	# Cues should never have child lines
+	if tree_line.children.size() > 0:
+		for invalid_child: DMTreeLine in tree_line.children:
+			add_error(invalid_child.line_number, invalid_child.indent, DMConstants.ERR_INVALID_INDENTATION)
+
 	line.text = tree_line.text.substr(tree_line.text.find("~ ") + 2).strip_edges()
 
 	# Labels can't have numbers as the first letter


### PR DESCRIPTION
This adds a compilation error when indenting directly after a cue.

Fixes #1225 