### PR TITLE
Add method for clearing input waiters

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -970,8 +970,9 @@ func _wait_for(actions: PackedStringArray) -> void:
 	add_child(waiter)
 
 	waiting_for_input.emit()
-	await waiter.waited
-	waited_for_input.emit()
+	var action: String = await waiter.waited
+	if is_instance_valid(action):
+		waited_for_input.emit()
 
 	waiter.queue_free()
 

--- a/addons/dialogue_manager/utilities/waiter.gd
+++ b/addons/dialogue_manager/utilities/waiter.gd
@@ -1,15 +1,29 @@
 class_name DMWaiter extends Node
 
 
-signal waited()
+signal waited(for_action: String)
 
+
+static var all_waiters: Array[DMWaiter]
 
 var _actions: PackedStringArray
 var _null: String = str(null)
 
 
+## Emit [code]waited[/code] on all waiting [DMWaiter]s.
+static func clear_all() -> void:
+	for waiter: DMWaiter in all_waiters:
+		all_waiters.erase(waiter)
+		waiter.waited.emit(null)
+
+
 func _init(target_actions: PackedStringArray) -> void:
+	all_waiters.append(self)
 	_actions = target_actions
+
+
+func _exit_tree() -> void:
+	all_waiters.erase(self)
 
 
 func _input(event: InputEvent) -> void:
@@ -17,4 +31,5 @@ func _input(event: InputEvent) -> void:
 		if event.is_pressed():
 			if action == _null or (InputMap.has_action(action) and event.is_action(action)):
 				get_viewport().set_input_as_handled()
-				waited.emit()
+				all_waiters.erase(self)
+				waited.emit(action)


### PR DESCRIPTION
This adds `DMWaiter.clear_all()` for clearing any input waiters.

Related to #1252 