### PR TITLE
Add current scene to debugger

### DIFF
--- a/addons/dialogue_manager/debugger_plugin.gd
+++ b/addons/dialogue_manager/debugger_plugin.gd
@@ -32,6 +32,10 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 		"dm:debug":
 			debug_info = data[0]
 			return true
+			
+		"dm:current_scene":
+			debugger_view.current_scene = data[0]
+			return true
 
 		"dm:state":
 			debugger_view.contexts = data[0]

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -115,6 +115,11 @@ func _ready() -> void:
 		# If this is a debug build we can preload autoloads (otherwise this is
 		# done on the first state request.
 		_load_autoloads()
+		# If this is a debug build then we need to know when the scene changes.
+		get_tree().scene_changed.connect(func() -> void:
+			_send_current_scene_to_debugger()
+		)
+		_send_current_scene_to_debugger()
 
 
 ## Set a random seed.
@@ -808,6 +813,23 @@ func unregister_state_context(alias: String) -> void:
 	_send_state_to_debugger()
 
 
+# Let the debugger know about the current scene
+func _send_current_scene_to_debugger(current_scene: Node = null) -> void:
+	if not EngineDebugger.is_active(): return
+	
+	if not is_instance_valid(current_scene):
+		current_scene = get_current_scene.call() if get_current_scene.is_valid() else null
+	
+	var serialized_current_scene: Dictionary = {}
+	if is_instance_valid(current_scene): 
+		serialized_current_scene[current_scene.name] = _get_serialised_state_node(
+			current_scene.name, 
+			current_scene
+		)
+		
+	EngineDebugger.send_message("dm:current_scene", [serialized_current_scene])
+	
+	
 # Let the debugger know about the latest state
 func _send_state_to_debugger() -> void:
 	if not EngineDebugger.is_active(): return
@@ -845,6 +867,8 @@ func _get_game_states(extra_game_states: Array) -> Array:
 	_load_autoloads()
 
 	var current_scene: Node = get_current_scene.call() if get_current_scene.is_valid() else null
+	_send_current_scene_to_debugger(current_scene)
+	
 	var possible_states: Array = extra_game_states
 	possible_states += [_registered_contexts]
 	if is_instance_valid(current_scene):

--- a/addons/dialogue_manager/views/debugger_view.gd
+++ b/addons/dialogue_manager/views/debugger_view.gd
@@ -8,6 +8,13 @@ const CONTEXT_ICON: Texture2D = preload("../nodes/context/dialogue_state_context
 
 var session: EditorDebuggerSession
 
+var current_scene: Dictionary = {}:
+	set(value):
+		current_scene = value
+		_update_state_tree()
+	get:
+		return current_scene
+
 var contexts: Dictionary = {}:
 	set(value):
 		contexts = value
@@ -99,12 +106,21 @@ func _update_state_tree() -> void:
 
 	state_tree.columns = 2
 
+	# Current scene
 	var item: TreeItem = state_tree.create_item(root)
+	item.set_selectable(0, false)
+	item.set_icon(0, get_theme_icon("PackedScene", "EditorIcons"))
+	item.set_text(0, DMConstants.translate("Current scene"))
+	create_state_items(item, current_scene)
+	
+	# Context
+	item = state_tree.create_item(root)
 	item.set_selectable(0, false)
 	item.set_icon(0, CONTEXT_ICON)
 	item.set_text(0, DMConstants.translate("Context Nodes"))
 	create_state_items(item, contexts)
 
+	# Globals
 	item = state_tree.create_item(root)
 	item.set_selectable(0, false)
 	item.set_icon(0, get_theme_icon("Object", "EditorIcons"))
@@ -125,7 +141,8 @@ func create_state_items(parent_item: TreeItem, state_data_list: Dictionary) -> v
 				item.set_icon(0, get_theme_icon(data.base_type, "EditorIcons"))
 			item.set_text(0, data.alias)
 			item.set_text(1, data.path)
-			item.add_button(1, get_theme_icon("Script", "EditorIcons"), 0)
+			if not data.script.is_empty():
+				item.add_button(1, get_theme_icon("Script", "EditorIcons"), 0)
 
 
 func _open_script(path: String) -> void:


### PR DESCRIPTION
This adds a new section in the debugger for showing what resolves as the current scene for state fetching.