### PR TITLE
Fix translation keys when using static IDs

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -744,7 +744,7 @@ func translate(data: Dictionary) -> String:
 	if static_id == "" or static_id == data.text:
 		return tr(data.text, "dialogue")
 	else:
-		return tr(data.text, StringName(static_id))
+		return tr(static_id)
 
 
 # Create a line of dialogue

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -44,8 +44,10 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		known_keys.append(static_id)
 		translated_lines.append(line)
 
-		var message: String = line.text.replace('"', '\"')
-		var context: String = static_id.replace('"', '\"') if static_id != line.text else "dialogue"
+		var has_static_id: bool = static_id != "" and static_id != line.text
+
+		var message: String = static_id.replace('"', '\"') if has_static_id else line.text
+		var context: String = line.text.replace('"', '\"') if has_static_id else "dialogue"
 		var plural: String = ""
 		var extra_details: PackedStringArray = []
 		if line.has("character"):


### PR DESCRIPTION
This restores static IDs being the translation keys for dialogue when exporting localisation templates from Godot.