### PR TITLE
Fix reading translation when using static IDs

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -744,7 +744,7 @@ func translate(data: Dictionary) -> String:
 	if static_id == "" or static_id == data.text:
 		return tr(data.text, "dialogue")
 	else:
-		return tr(static_id)
+		return tr(static_id, data.text)
 
 
 # Create a line of dialogue


### PR DESCRIPTION
Reading translation without providing the context does not work as rows are saved with the context.