### PR TITLE
Fix issue with complex context

### DIFF
--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -739,12 +739,7 @@ func translate(data: Dictionary) -> String:
 	if TranslationServer.get_loaded_locales().size() == 0:
 		return data.text
 
-	var static_id: String = data.get(&"static_id", data.text)
-
-	if static_id == "" or static_id == data.text:
-		return tr(data.text, "dialogue")
-	else:
-		return tr(static_id)
+	return tr(data.get(&"static_id", data.text), "diaogue")
 
 
 # Create a line of dialogue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -739,7 +739,7 @@ func translate(data: Dictionary) -> String:
 	if TranslationServer.get_loaded_locales().size() == 0:
 		return data.text
 
-	return tr(data.get(&"static_id", data.text), "diaogue")
+	return tr(data.get(&"static_id", data.text), "dialogue")
 
 
 # Create a line of dialogue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -739,7 +739,11 @@ func translate(data: Dictionary) -> String:
 	if TranslationServer.get_loaded_locales().size() == 0:
 		return data.text
 
-	return tr(data.get(&"static_id", data.text), "dialogue")
+	var static_id: String = tr(data.get(&"static_id", data.text))
+	if static_id.is_empty() or static_id == data.text:
+		return tr(data.text, "dialogue")
+	else:
+		return tr(static_id, "dialogue")
 
 
 # Create a line of dialogue

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -739,7 +739,7 @@ func translate(data: Dictionary) -> String:
 	if TranslationServer.get_loaded_locales().size() == 0:
 		return data.text
 
-	var static_id: String = tr(data.get(&"static_id", data.text))
+	var static_id: String = data.get(&"static_id", data.text)
 	if static_id.is_empty() or static_id == data.text:
 		return tr(data.text, "dialogue")
 	else:

--- a/addons/dialogue_manager/editor_translation_parser_plugin.gd
+++ b/addons/dialogue_manager/editor_translation_parser_plugin.gd
@@ -47,13 +47,15 @@ func _parse_file(path: String) -> Array[PackedStringArray]:
 		var has_static_id: bool = static_id != "" and static_id != line.text
 
 		var message: String = static_id.replace('"', '\"') if has_static_id else line.text
-		var context: String = line.text.replace('"', '\"') if has_static_id else "dialogue"
+		var context: String = "dialogue"
 		var plural: String = ""
 		var extra_details: PackedStringArray = []
 		if line.has("character"):
-			extra_details.append("Character name: %s" % line.get("character", ""))
+			extra_details.append("Character: %s" % line.get("character", ""))
+		if has_static_id and not line.text.is_empty():
+			extra_details.append("Line: %s" % line.text)
 		if line.has("notes"):
-			extra_details.append(line.get("notes", ""))
+			extra_details.append("Notes: %s" % line.get("notes", ""))
 		var notes: String = "\n".join(extra_details)
 		msgs.append(PackedStringArray([
 			message,

--- a/docs/Upgrading_Version.md
+++ b/docs/Upgrading_Version.md
@@ -13,6 +13,7 @@ Godot 4.6 is now the minimum Godot version supported.
 - "Titles" are now called "Cues" to better reflect how they are used.
 - Response Conditions are now self-closing (eg. `- Text [if some_condition]` is now `- Text [if some_condition /]`).
 - The `translation_key` property of `DialogueLine`s is now `static_id` to better reflect that it's not just for translations.
+- When exporting translation templates from Godot, the line's `static_id` will be used as the translation key if it has one (previously, they'd be used as context but context is now always just "dialogue").
 
 ### Possible gotchas
 


### PR DESCRIPTION
This fixes an issue where reading a translated line required the context to match the original line. This fixes that by simplifying the context to always be "dialogue" (and adds a note for translators containing the original line text).