### PR TITLE
Fix initial console errors when installing

### DIFF
--- a/addons/dialogue_manager/nodes/actionable/dialogue_actionable_2d.gd
+++ b/addons/dialogue_manager/nodes/actionable/dialogue_actionable_2d.gd
@@ -35,13 +35,13 @@ var dialogue_balloon: Node
 
 ## The method used to start dialogue action [code]action()[/code] is called. Override if you need different logic.
 static var start_dialogue: Callable = func(with_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node:
-	return DialogueManager.show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
+	return Engine.get_singleton("DialogueManager").show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
 
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		add_to_group("dialogue_actionables")
-		DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
+		Engine.get_singleton("DialogueManager").dialogue_ended.connect(_on_dialogue_ended)
 
 
 #region Public

--- a/addons/dialogue_manager/nodes/actionable/dialogue_actionable_3d.gd
+++ b/addons/dialogue_manager/nodes/actionable/dialogue_actionable_3d.gd
@@ -35,13 +35,13 @@ var dialogue_balloon: Node
 
 ## The method used to start dialogue action [code]action()[/code] is called. Override if you need different logic.
 static var start_dialogue: Callable = func(with_dialogue_resource: DialogueResource, from_cue: String, extra_game_states: Array) -> Node:
-	return DialogueManager.show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
+	return Engine.get_singleton("DialogueManager").show_dialogue_balloon(with_dialogue_resource, from_cue, extra_game_states)
 
 
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		add_to_group("dialogue_actionables")
-		DialogueManager.dialogue_ended.connect(_on_dialogue_ended)
+		Engine.get_singleton("DialogueManager").dialogue_ended.connect(_on_dialogue_ended)
 
 
 #region Public

--- a/addons/dialogue_manager/nodes/context/dialogue_state_context.gd
+++ b/addons/dialogue_manager/nodes/context/dialogue_state_context.gd
@@ -25,12 +25,12 @@ class_name DialogueStateContext extends Node
 
 func _enter_tree() -> void:
 	if not Engine.is_editor_hint():
-		DialogueManager.register_state_context(alias, target)
+		Engine.get_singleton("DialogueManager").register_state_context(alias, target)
 
 
 func _exit_tree() -> void:
 	if not Engine.is_editor_hint():
-		DialogueManager.unregister_state_context(alias)
+		Engine.get_singleton("DialogueManager").unregister_state_context(alias)
 
 
 func _get_configuration_warnings() -> PackedStringArray:


### PR DESCRIPTION
This fixes some errors that pop up when first installing the addon (caused by the `DialogueManager` global not being available before enabling it in project settings).