### PR TITLE
Fix settings filter for dialogue balloon scene

### DIFF
--- a/addons/dialogue_manager/DialogueManager.cs
+++ b/addons/dialogue_manager/DialogueManager.cs
@@ -276,6 +276,18 @@ namespace DialogueManagerRuntime
         }
 
 
+
+        /// <summary>
+        /// Set the default balloon to use at runtime.
+        /// </summary>
+        /// <param name="balloonScene"></param>
+        /// <returns></returns>
+        public static Error SetDefaultBalloon(Variant balloonScene)
+        {
+            return (Error)(int)Instance.Call("set_default_balloon", balloonScene);
+        }
+
+
         /// <summary>
         /// Show the example balloon
         /// </summary>

--- a/addons/dialogue_manager/dialogue_manager.gd
+++ b/addons/dialogue_manager/dialogue_manager.gd
@@ -598,6 +598,23 @@ func create_resource_from_text(text: String) -> Resource:
 #region Balloon helpers
 
 
+## Set the default balloon to use at runtime.
+func set_default_balloon(balloon_scene: Variant) -> Error:
+	var balloon_scene_path: String = ""
+
+	if balloon_scene is String:
+		balloon_scene_path = balloon_scene
+	elif balloon_scene is PackedScene:
+		balloon_scene_path = balloon_scene.resource_path
+
+	if not ["tscn", "scn"].has(balloon_scene_path.get_extension()):
+		return ERR_INVALID_DATA
+
+	ProjectSettings.set_setting(DMSettings.BALLOON_PATH, balloon_scene_path)
+
+	return OK
+
+
 ## Show the example balloon
 func show_example_dialogue_balloon(resource: DialogueResource, cue: String = "", extra_game_states: Array = []) -> CanvasLayer:
 	var balloon: Node = load(_get_example_balloon_path()).instantiate()

--- a/addons/dialogue_manager/settings.gd
+++ b/addons/dialogue_manager/settings.gd
@@ -77,6 +77,7 @@ static var SETTINGS_CONFIGURATION: Dictionary = {
 		value = preload("./test_scene.tscn").resource_path,
 		type = TYPE_STRING,
 		hint = PROPERTY_HINT_FILE,
+		hint_string = "*.tscn,*.scn",
 		is_advanced = true
 	},
 	EXTRA_AUTO_COMPLETE_SCRIPT_SOURCES: {
@@ -91,6 +92,7 @@ static var SETTINGS_CONFIGURATION: Dictionary = {
 		value = "",
 		type = TYPE_STRING,
 		hint = PROPERTY_HINT_FILE,
+		hint_string = "*.tscn,*.scn",
 	},
 	STATE_AUTOLOAD_SHORTCUTS: {
 		value = [],

--- a/tests/test_balloons.gd
+++ b/tests/test_balloons.gd
@@ -1,0 +1,12 @@
+extends AbstractTest
+
+
+func test_set_default_balloon() -> void:
+	var result: Error = DialogueManager.set_default_balloon("not a scene")
+	assert(result == ERR_INVALID_DATA, "Should not work for bogus scenes.")
+
+	result = DialogueManager.set_default_balloon("res://addons/dialogue_manager/example_balloon/example_balloon.tscn")
+	assert(result == OK, "Should work for path.")
+
+	result = DialogueManager.set_default_balloon(load("res://addons/dialogue_manager/example_balloon/example_balloon.tscn"))
+	assert(result == OK, "Should work for scene.")

--- a/tests/test_balloons.gd.uid
+++ b/tests/test_balloons.gd.uid
@@ -1,0 +1,1 @@
+uid://bmy2byb2jw8p3


### PR DESCRIPTION
This adds a filter in Project Settings on the balloon scene setting so that only scene files can be selected.