### PR TITLE
Fix ExportPlugin including C# related files when project isn't dotnet

### DIFF
--- a/addons/dialogue_manager/export_plugin.gd
+++ b/addons/dialogue_manager/export_plugin.gd
@@ -21,6 +21,18 @@ func _export_file(path: String, _type: String, _features: PackedStringArray) -> 
 		if path.begins_with(plugin_path + ignored_path):
 			skip()
 
-	# Ignore C# stuff it not using dotnet
-	if path.begins_with(plugin_path) and not DMSettings.check_for_dotnet_solution() and path.ends_with(".cs"):
-		skip()
+	# Ignore C# stuff if not using dotnet
+	if path.begins_with(plugin_path) and not DMSettings.check_for_dotnet_solution():
+		if path.ends_with(".cs"):
+			skip()
+		
+		# Scenes that reference C# scripts cause the export to crash without dotnet
+		elif path.ends_with(".tscn") and _has_dotnet_dependency(path):
+			skip()
+
+
+func _has_dotnet_dependency(path: String) -> bool:
+	for dependency: String in ResourceLoader.get_dependencies(path):
+		if dependency.ends_with(".cs"):
+			return true
+	return false


### PR DESCRIPTION
I believe this will fix the issue I raised in #1301
